### PR TITLE
better error responses for upstream errors

### DIFF
--- a/src/api/__test__/errors.test.ts
+++ b/src/api/__test__/errors.test.ts
@@ -1,0 +1,60 @@
+import Hapi from '@hapi/hapi';
+import journeyRoutes from '../journey';
+import { IJourneyService } from '../../service/interface';
+import { Result } from '@badrap/result';
+import { createServer, initializePlugins } from '../../server';
+import { randomPort } from './common';
+import { FetchError } from 'node-fetch';
+import { APIError } from '../../service/types';
+
+let server: Hapi.Server;
+
+const errorCodesToTest = [
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'EPIPE'
+];
+
+const failingServiceCall = jest.fn();
+errorCodesToTest.forEach(e =>
+  failingServiceCall.mockReturnValue(
+    Promise.resolve(
+      Result.err(
+        //@ts-ignore
+        new APIError(new FetchError('request failed', 'system', { code: e }))
+      )
+    )
+  )
+);
+const svc: jest.Mocked<IJourneyService> = {
+  getTripPatterns: jest.fn((args: any): any => Result.ok(Promise.resolve([]))),
+  getTrips: failingServiceCall
+};
+
+beforeAll(async () => {
+  server = createServer({
+    port: randomPort()
+  });
+
+  await initializePlugins(server);
+  journeyRoutes(server)(svc);
+  await server.initialize();
+  await server.start();
+});
+afterAll(async () => {
+  await server.stop();
+});
+
+describe('GET /journey/trip', () => {
+  errorCodesToTest.forEach(err => {
+    it(`responds with 503 for upstream error ${err}`, async () => {
+      const res = await server.inject({
+        method: 'get',
+        url: '/journey/trip?from=Trondheim&to=Oslo'
+      });
+      expect(res.statusCode).toBe(503);
+    });
+  });
+});

--- a/src/service/impl/geocoder.ts
+++ b/src/service/impl/geocoder.ts
@@ -14,7 +14,7 @@ export default (service: EnturService): IGeocoderService => ({
 
       return Result.ok(features);
     } catch (error) {
-      return Result.err(new APIError(error?.message));
+      return Result.err(new APIError(error));
     }
   },
   async getFeaturesReverse({ lat, lon, ...params }) {
@@ -26,7 +26,7 @@ export default (service: EnturService): IGeocoderService => ({
 
       return Result.ok(features);
     } catch (error) {
-      return Result.err(new APIError(error?.message));
+      return Result.err(new APIError(error));
     }
   }
 });

--- a/src/service/impl/journey.ts
+++ b/src/service/impl/journey.ts
@@ -9,7 +9,7 @@ export default (service: EnturService): IJourneyService => ({
       const trips = await service.findTrips(from, to, when);
       return Result.ok(trips);
     } catch (error) {
-      return Result.err(new APIError(error?.message));
+      return Result.err(new APIError(error));
     }
   },
   async getTripPatterns(query) {
@@ -17,7 +17,7 @@ export default (service: EnturService): IJourneyService => ({
       const trips = await service.getTripPatterns(query);
       return Result.ok(trips);
     } catch (error) {
-      return Result.err(new APIError(error?.message));
+      return Result.err(new APIError(error));
     }
   }
 });

--- a/src/service/impl/stops.ts
+++ b/src/service/impl/stops.ts
@@ -13,7 +13,7 @@ export default (service: EnturService): IStopsService => ({
       );
       return Result.ok(departures);
     } catch (error) {
-      return Result.err(new APIError(error?.message));
+      return Result.err(new APIError(error));
     }
   },
   async getStopPlace(id) {
@@ -25,7 +25,7 @@ export default (service: EnturService): IStopsService => ({
         const re = /Entur SDK: No data available/;
         if (error.message.match(re)) return Result.ok(null);
       }
-      return Result.err(new APIError(error?.message));
+      return Result.err(new APIError(error));
     }
   },
   async getDeparturesFromStopPlace(id, query) {
@@ -34,7 +34,7 @@ export default (service: EnturService): IStopsService => ({
 
       return Result.ok(departures);
     } catch (error) {
-      return Result.err(new APIError(error?.message));
+      return Result.err(new APIError(error));
     }
   },
   async getDeparturesFromQuay(id, query) {
@@ -48,7 +48,7 @@ export default (service: EnturService): IStopsService => ({
       }
       return Result.ok([]);
     } catch (error) {
-      return Result.err(new APIError(error?.message));
+      return Result.err(new APIError(error));
     }
   },
   async getStopPlacesByPosition({ lat: latitude, lon: longitude, distance }) {
@@ -63,7 +63,7 @@ export default (service: EnturService): IStopsService => ({
 
       return Result.ok(stops);
     } catch (error) {
-      return Result.err(new APIError(error?.message));
+      return Result.err(new APIError(error));
     }
   },
   async getNearestPlaces({ lat, lon, ...query }) {
@@ -74,7 +74,7 @@ export default (service: EnturService): IStopsService => ({
       });
       return Result.ok(places);
     } catch (error) {
-      return Result.err(new APIError(error?.message));
+      return Result.err(new APIError(error));
     }
   },
   async getQuaysForStopPlace(id, query) {
@@ -87,7 +87,7 @@ export default (service: EnturService): IStopsService => ({
         const re = /Entur SDK: No data available/;
         if (error.message.match(re)) return Result.ok(null);
       }
-      return Result.err(new APIError(error?.message));
+      return Result.err(new APIError(error));
     }
   },
   async getDeparturesForServiceJourney(id, { date }) {
@@ -102,7 +102,7 @@ export default (service: EnturService): IStopsService => ({
       const re = /Entur SDK: No data available/;
       if (error.message.match(re)) return Result.ok(null);
 
-      return Result.err(new APIError(error?.message));
+      return Result.err(new APIError(error));
     }
   }
 });

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -1,4 +1,6 @@
 import { Location, QueryMode } from '@entur/sdk';
+import { FetchError } from 'node-fetch';
+import { boomify } from '@hapi/boom';
 
 export interface Coordinates {
   latitude: number;
@@ -103,8 +105,21 @@ export type NextDepartureFromCoordinateQuery = {
 };
 
 export class APIError extends Error {
-  constructor(public message: string) {
+  public statusCode?: number = 500;
+
+  constructor(error: any) {
     super();
-    this.name = 'APIError';
+    if (error instanceof FetchError) {
+      switch (error.code) {
+        case 'ETIMEDOUT':
+        case 'EPIPE':
+        case 'ECONNRESET':
+        case 'ECONNREFUSED':
+        case 'ENOTFOUND':
+          this.message = 'Upstream service temporarily unavailable';
+          this.statusCode = 503;
+      }
+    }
+    return boomify(this, { statusCode: this.statusCode });
   }
 }


### PR DESCRIPTION
Maps the following system errors from requests upstream to 503:
- ECONNRESET
- ECONNREFUSED
- ENOTFOUND
- EPIPE
- ETIMEDOUT

Adds test cases for errors

Closes #2 