### PR TITLE
Improve stops

### DIFF
--- a/src/api/__test__/stops.test.ts
+++ b/src/api/__test__/stops.test.ts
@@ -7,6 +7,9 @@ import { randomPort } from './common';
 
 let server: Hapi.Server;
 const svc: jest.Mocked<IStopsService> = {
+  getStopPlacesByName: jest.fn((...args: any): any =>
+    Result.ok(Promise.resolve([]))
+  ),
   getDeparturesBetweenStopPlaces: jest.fn((...args: any): any =>
     Result.ok(Promise.resolve([]))
   ),
@@ -73,11 +76,11 @@ describe('GET /stops/{id}/departures', () => {
     expect(res.statusCode).toBe(200);
   });
 });
-describe('GET /stops', () => {
+describe('GET /stops/nearest', () => {
   it('responds with 200', async () => {
     const res = await server.inject({
       method: 'get',
-      url: '/stops?lat=63.3818027&lon=10.3677379'
+      url: '/stops/nearest?lat=63.3818027&lon=10.3677379'
     });
 
     expect(res.statusCode).toBe(200);
@@ -86,9 +89,25 @@ describe('GET /stops', () => {
   it('responds with 400 for missing required parameters', async () => {
     const res = await server.inject({
       method: 'get',
-      url: '/stops?invalid=wut'
+      url: '/stops/nearest?invalid=wut'
     });
 
+    expect(res.statusCode).toBe(400);
+  });
+});
+describe('GET /stops', () => {
+  it('responds with 200', async () => {
+    const res = await server.inject({
+      method: 'get',
+      url: '/stops?query=Prinsens gate&lat=63.433&lon=10.399'
+    });
+    expect(res.statusCode).toBe(200);
+  });
+  it('responds with 400 for invalid parameters', async () => {
+    const res = await server.inject({
+      method: 'get',
+      url: '/stops?query=Konges gate&lon=10.399'
+    });
     expect(res.statusCode).toBe(400);
   });
 });

--- a/src/api/stops/index.ts
+++ b/src/api/stops/index.ts
@@ -111,7 +111,7 @@ export default (server: Hapi.Server) => (service: IStopsService) => {
   });
   server.route({
     method: 'GET',
-    path: '/v1/stops',
+    path: '/v1/nearest',
     options: {
       tags: ['api', 'stops'],
       validate: getStopPlaceByPositionRequest,

--- a/src/api/stops/index.ts
+++ b/src/api/stops/index.ts
@@ -9,7 +9,8 @@ import {
   getStopPlaceQuaysRequest,
   getDeparturesFromQuayRequest,
   getDeparturesForServiceJourneyRequest,
-  getDeparturesBetweenStopPlacesRequest
+  getDeparturesBetweenStopPlacesRequest,
+  getStopPlacesByNameRequest
 } from './schema';
 import {
   StopPlaceQuery,
@@ -17,7 +18,8 @@ import {
   DeparturesForServiceJourneyQuery,
   QuaysForStopPlaceQuery,
   DeparturesFromQuayQuery,
-  DeparturesBetweenStopPlacesQuery
+  DeparturesBetweenStopPlacesQuery,
+  StopPlaceByNameQuery
 } from '../../service/types';
 
 export default (server: Hapi.Server) => (service: IStopsService) => {
@@ -111,7 +113,7 @@ export default (server: Hapi.Server) => (service: IStopsService) => {
   });
   server.route({
     method: 'GET',
-    path: '/v1/nearest',
+    path: '/v1/stops/nearest',
     options: {
       tags: ['api', 'stops'],
       validate: getStopPlaceByPositionRequest,
@@ -120,6 +122,19 @@ export default (server: Hapi.Server) => (service: IStopsService) => {
     handler: async (request, h) => {
       const query = (request.query as unknown) as StopPlaceQuery;
       return (await service.getStopPlacesByPosition(query)).unwrap();
+    }
+  });
+  server.route({
+    method: 'GET',
+    path: '/v1/stops',
+    options: {
+      tags: ['api', 'stops'],
+      validate: getStopPlacesByNameRequest,
+      description: 'Find stops matching query'
+    },
+    handler: async (request, h) => {
+      const query = (request.query as unknown) as StopPlaceByNameQuery;
+      return (await service.getStopPlacesByName(query)).unwrap();
     }
   });
   server.route({

--- a/src/api/stops/schema.ts
+++ b/src/api/stops/schema.ts
@@ -35,6 +35,14 @@ export const getStopPlaceQuaysRequest = {
   })
 };
 
+export const getStopPlacesByNameRequest = {
+  query: Joi.object({
+    query: Joi.string().required(),
+    lat: Joi.number(),
+    lon: Joi.number()
+  }).and('lat', 'lon')
+};
+
 export const getDeparturesForServiceJourneyRequest = {
   params: Joi.object({
     id: Joi.string().required()

--- a/src/service/interface.ts
+++ b/src/service/interface.ts
@@ -23,7 +23,8 @@ import {
   ReverseFeaturesQuery,
   StopPlaceQuery,
   TripPatternsQuery,
-  TripQuery
+  TripQuery,
+  StopPlaceByNameQuery
 } from './types';
 import { AgentError } from './impl/agent';
 
@@ -46,7 +47,9 @@ export interface IGeocoderService {
 
 export interface IStopsService {
   getStopPlace(id: string): Promise<Result<StopPlaceDetails | null, APIError>>;
-
+  getStopPlacesByName(
+    query: StopPlaceByNameQuery
+  ): Promise<Result<StopPlaceDetails[], APIError>>;
   getDeparturesBetweenStopPlaces(
     query: DeparturesBetweenStopPlacesQuery,
     params?: DeparturesBetweenStopPlacesParams

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -39,6 +39,12 @@ export interface StopPlaceQuery {
   distance?: number;
 }
 
+export interface StopPlaceByNameQuery {
+  query: string;
+  lat?: number;
+  lon?: number;
+}
+
 export interface DeparturesFromStopPlaceQuery {
   start?: Date;
   timeRange?: number;


### PR DESCRIPTION
In preparation of new functionality in route planner:

- GET /stops/nearest?lat=NUMBER&lon=NUMBER:
Queries NSR for the nearest stop places
- GET /stops?query=Kongens gate&lat=63.433&lon=10.322
Convenience for first querying geocoder with query, and sources = 'venue'. Filters the results for stops with a valid NSR id and queries NSR for the resulting IDs. `lat` and `lon` are optional

