### PR TITLE
Support usage of dev and staging versions of Entur APIs

### DIFF
--- a/src/service/impl/entur.ts
+++ b/src/service/impl/entur.ts
@@ -88,6 +88,15 @@ const service = (config: Config) => {
 
   return createService({
     clientName: process.env.CLIENT_NAME || 'atb-mittatb',
+
+    /* Use environment variable ENTUR_ENV to override usage of production version of Entur
+       APIs. Set variable to dev or staging to use development or staging enviroment. */
+    hosts: process.env.ENTUR_ENV ? {
+      journeyPlanner:  `https://api.${process.env.ENTUR_ENV}.entur.io/journey-planner/v2`,
+      geocoder: `https://api.${process.env.ENTUR_ENV}.entur.io/geocoder/v1`,
+      nsr: `https://api.${process.env.ENTUR_ENV}.entur.io/stop-places/v1`,
+    }: undefined,
+    
     fetch: (url, init) => {
       let endpoint = 'UNKNOWN';
       const match = url.match(ENDPOINT_RE);


### PR DESCRIPTION
If the environment variable `ENTUR_ENV` is not set production version of APIs should be used. Otherwise, the value of `ENTUR_ENV` is used as a prefix in the hostname `entur.io`. Thus, if ENTUR_ENV is `dev` `api.dev.entur.io` should be used.