### PR TITLE
Adds endpoint for fetching one specific journey trip pattern

### DIFF
--- a/src/api/__test__/errors.test.ts
+++ b/src/api/__test__/errors.test.ts
@@ -30,6 +30,7 @@ errorCodesToTest.forEach(e =>
 );
 const svc: jest.Mocked<IJourneyService> = {
   getTripPatterns: jest.fn((args: any): any => Result.ok(Promise.resolve([]))),
+  getTripPattern: jest.fn((args: any): any => Result.ok(Promise.resolve([]))),
   getTrips: failingServiceCall
 };
 

--- a/src/api/__test__/journey.test.ts
+++ b/src/api/__test__/journey.test.ts
@@ -4,10 +4,14 @@ import { IJourneyService } from '../../service/interface';
 import { Result } from '@badrap/result';
 import { createServer, initializePlugins } from '../../server';
 import { randomPort } from './common';
+import { generateId } from '../../utils/journey-utils';
+import { TripPattern } from '@entur/sdk';
+import { TripPatternQuery, TripPatternsQuery } from '../../service/types';
 
 let server: Hapi.Server;
 const svc: jest.Mocked<IJourneyService> = {
   getTripPatterns: jest.fn((args: any): any => Result.ok(Promise.resolve([]))),
+  getTripPattern: jest.fn((args: any): any => Result.ok(Promise.resolve([]))),
   getTrips: jest.fn((args: any): any => Result.ok(Promise.resolve([])))
 };
 
@@ -66,6 +70,48 @@ describe('POST /journey/trip', () => {
           }
         }
       }
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
+});
+
+describe('GET /journey/single-trip', () => {
+  it('responds with 200', async () => {
+    const pastQuery: TripPatternsQuery = {
+      from: {
+        name: 'Trondheim',
+        coordinates: {
+          latitude: 63.43,
+          longitude: 10.34
+        }
+      },
+      to: {
+        name: 'Oslo',
+        coordinates: {
+          latitude: 59.9139,
+          longitude: 10.7522
+        }
+      },
+      arriveBy: true,
+      limit: 1,
+      modes: [],
+      searchDate: new Date(),
+      wheelchairAccessible: true
+    };
+    const pastTrip = {
+      startTime: '2020-05-14T20:02:00+0200',
+      endTime: '2020-05-14T20:07:05+0200',
+      directDuration: 305,
+      duration: 305,
+      distance: 814.0718743106913,
+      walkDistance: 81.07607692557397,
+      legs: []
+    };
+    const id = generateId(pastTrip, pastQuery);
+    const res = await server.inject({
+      method: 'get',
+      url: `/journey/single-trip?id=${id}`
     });
 
     expect(res.statusCode).toBe(200);

--- a/src/api/journey/schema.ts
+++ b/src/api/journey/schema.ts
@@ -8,6 +8,12 @@ export const getJourneyRequest = {
   })
 };
 
+export const getSingleTripPattern = {
+  query: Joi.object({
+    id: Joi.string().required()
+  })
+};
+
 export const postJourneyRequest = {
   payload: Joi.object({
     from: Joi.object({

--- a/src/service/impl/journey.ts
+++ b/src/service/impl/journey.ts
@@ -40,7 +40,6 @@ export default (
         });
         console.log(query);
         const trips = await service.getTripPatterns(query);
-        console.log(trips);
         return Result.ok(addIdsToTrips(trips, query));
       } catch (error) {
         return Result.err(new APIError(error));

--- a/src/service/impl/journey.ts
+++ b/src/service/impl/journey.ts
@@ -38,7 +38,6 @@ export default (
         batchedPublisher.publish(Buffer.from(JSON.stringify(query)), {
           environment: ENV
         });
-        console.log(query);
         const trips = await service.getTripPatterns(query);
         return Result.ok(addIdsToTrips(trips, query));
       } catch (error) {

--- a/src/service/impl/journey.ts
+++ b/src/service/impl/journey.ts
@@ -1,10 +1,11 @@
-import { EnturService } from '@entur/sdk';
+import { EnturService, TripPattern } from '@entur/sdk';
 import { IJourneyService } from '../interface';
 import { Result } from '@badrap/result';
-import { APIError } from '../types';
+import { APIError, TripPatternsQuery } from '../types';
 
 import { PubSub } from '@google-cloud/pubsub';
 import { getEnv } from '../../utils/getenv';
+import { generateId, getServiceIds } from '../../utils/journey-utils';
 
 const ENV = getEnv();
 const topicName = `analytics_trip_search`;
@@ -13,10 +14,8 @@ export default (
   service: EnturService,
   pubSubClient: PubSub
 ): IJourneyService => {
-
   // createTopic might fail if the topic already exists; ignore.
-  pubSubClient.createTopic(topicName).catch(() => {
-  });
+  pubSubClient.createTopic(topicName).catch(() => {});
 
   const batchedPublisher = pubSubClient.topic(topicName, {
     batching: {
@@ -24,7 +23,8 @@ export default (
       maxMilliseconds: 5 * 1000
     }
   });
-  return {
+
+  const api: IJourneyService = {
     async getTrips({ from, to, when }) {
       try {
         const trips = await service.findTrips(from, to, when);
@@ -35,13 +35,56 @@ export default (
     },
     async getTripPatterns(query) {
       try {
-        batchedPublisher
-          .publish(Buffer.from(JSON.stringify(query)), { environment: ENV });
+        batchedPublisher.publish(Buffer.from(JSON.stringify(query)), {
+          environment: ENV
+        });
+        console.log(query);
         const trips = await service.getTripPatterns(query);
-        return Result.ok(trips);
+        console.log(trips);
+        return Result.ok(addIdsToTrips(trips, query));
       } catch (error) {
         return Result.err(new APIError(error));
       }
+    },
+    async getTripPattern({ query, serviceIds }) {
+      // There are no ways to get actual specific trip pattern after having retrieved it,
+      // So we try to do the search with the same query and hope the first result is the same.
+      // The first query can have different legs as part of the pattern, and is therefore not
+      // the same trip. So we match on all service journey id's and see if they match. If not, 404
+      // and we should show an error to the user.
+      //
+      // Fetching 20 results as in some cases, when there are many busses passing, you wont
+      // get the right result (non deterministic search).
+      //
+      // @TODO At some point we maybe can compensate for this by using cache layer and
+      // manually updating all clocks.
+      return (
+        await api.getTripPatterns({
+          ...query,
+          limit: 20
+        })
+      ).map(trips => findTripsMatchingServiceIds(trips, serviceIds) ?? null);
     }
   };
+
+  return api;
 };
+
+function addIdsToTrips(trips: TripPattern[], query: TripPatternsQuery) {
+  return trips.map(oneTrip => ({
+    ...oneTrip,
+    id: generateId(oneTrip, query)
+  }));
+}
+
+function findTripsMatchingServiceIds(
+  trips: TripPattern[],
+  serviceIds: string[]
+) {
+  const sIdsAsString = (sIds: string[]) => sIds.join(',');
+  const originalServiceIds = sIdsAsString(serviceIds);
+  return trips.find(trip => {
+    console.log(sIdsAsString(getServiceIds(trip)), originalServiceIds);
+    return sIdsAsString(getServiceIds(trip)) === originalServiceIds;
+  });
+}

--- a/src/service/impl/journey.ts
+++ b/src/service/impl/journey.ts
@@ -82,7 +82,6 @@ function findTripsMatchingServiceIds(
   const sIdsAsString = (sIds: string[]) => sIds.join(',');
   const originalServiceIds = sIdsAsString(serviceIds);
   return trips.find(trip => {
-    console.log(sIdsAsString(getServiceIds(trip)), originalServiceIds);
     return sIdsAsString(getServiceIds(trip)) === originalServiceIds;
   });
 }

--- a/src/service/interface.ts
+++ b/src/service/interface.ts
@@ -27,7 +27,9 @@ import {
   TripQuery,
   StopPlaceByNameQuery,
   NearestDeparturesQuery,
-  DeparturesByIdWithStopName
+  DeparturesByIdWithStopName,
+  SingleTripPatternQuery,
+  TripPatternQuery
 } from './types';
 import { AgentError } from './impl/agent';
 
@@ -93,6 +95,9 @@ export interface IStopsService {
 export interface IJourneyService {
   getTrips(query: TripQuery): Promise<Result<TripPattern[], APIError>>;
 
+  getTripPattern(
+    query: TripPatternQuery
+  ): Promise<Result<TripPattern | null, APIError>>;
   getTripPatterns(
     query: TripPatternsQuery
   ): Promise<Result<TripPattern[], APIError>>;

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -84,6 +84,15 @@ export interface TripPatternsQuery {
   wheelchairAccessible: boolean;
 }
 
+export interface SingleTripPatternQuery {
+  id: string;
+}
+
+export interface TripPatternQuery {
+  query: TripPatternsQuery;
+  serviceIds: string[];
+}
+
 export interface NearestPlacesQuery {
   lat: number;
   lon: number;

--- a/src/utils/journey-utils.ts
+++ b/src/utils/journey-utils.ts
@@ -1,0 +1,44 @@
+import Joi from '@hapi/joi';
+import { TripPattern } from '@entur/sdk';
+import { TripPatternsQuery, TripPatternQuery } from '../service/types';
+
+export function generateId(trip: TripPattern, query: TripPatternsQuery) {
+  const fields: TripPatternsQuery = {
+    searchDate: new Date(trip.startTime),
+    ...query
+  };
+  const serviceIds = getServiceIds(trip);
+  return Buffer.from(JSON.stringify({ query: fields, serviceIds })).toString(
+    'base64'
+  );
+}
+
+export function getServiceIds(trip: TripPattern) {
+  return trip.legs.map(leg => leg.serviceJourney?.id ?? 'null');
+}
+
+export function parseTripPatternId(
+  id: string,
+  queryValidator: Joi.ObjectSchema<any>
+): TripPatternQuery {
+  try {
+    const fields = JSON.parse(Buffer.from(id, 'base64').toString());
+    fields.query = queryValidator.validate(fields.query).value;
+
+    if (isTripPatternsQuery(fields.query) && Array.isArray(fields.serviceIds)) {
+      return fields as TripPatternQuery;
+    }
+  } catch (_) {}
+
+  throw new Error('Could not parse input trip id');
+}
+
+function isTripPatternsQuery(
+  potentialTripPatternsQuery: any
+): potentialTripPatternsQuery is TripPatternsQuery {
+  return (
+    'from' in potentialTripPatternsQuery &&
+    'searchDate' in potentialTripPatternsQuery &&
+    'modes' in potentialTripPatternsQuery
+  );
+}


### PR DESCRIPTION
This is kind of odd, but as it is now, Entur doesn't provide a way to get one particular trip pattern suggestion ofter having searched for it. This makes navigating, real-time polling, and many other things difficult.

This adds a very rudimentary workaround for this issue by storing the original query, the time of the query, and the service journeys from the trip pattern as a base64-encoded ID passed to the client. We can use that client to do another search and find the same trip suggestion. The thing is: Sometimes you don't get the same result (high traffic stops for instance), so now it looks like searching for 20 suggestions does the trick. Not an ideal solution, but OK for now to avoid spending way to much time on this.

A possible extension at some point can be to add an outer cache layer to refetch the original trip pattern and manually construct updated time by retrieving all service journeys manually.