### PR TITLE
feat(departure): Adds endpint POST /v1/departures 

### DIFF
--- a/src/api/stops/index.ts
+++ b/src/api/stops/index.ts
@@ -11,7 +11,8 @@ import {
   getDeparturesForServiceJourneyRequest,
   getDeparturesBetweenStopPlacesRequest,
   getStopPlacesByNameRequest,
-  getNearestDeparturesRequest
+  getNearestDeparturesRequest,
+  getDeparturesRequest
 } from './schema';
 import {
   StopPlaceQuery,
@@ -21,7 +22,9 @@ import {
   DeparturesFromQuayQuery,
   DeparturesBetweenStopPlacesQuery,
   StopPlaceByNameQuery,
-  NearestDeparturesQuery
+  NearestDeparturesQuery,
+  FeatureLocation,
+  DeparturesFromLocationQuery
 } from '../../service/types';
 
 export default (server: Hapi.Server) => (service: IStopsService) => {
@@ -125,6 +128,21 @@ export default (server: Hapi.Server) => (service: IStopsService) => {
       const query = (request.query as unknown) as DeparturesFromStopPlaceQuery;
 
       return (await service.getDeparturesFromStopPlace(id, query)).unwrap();
+    }
+  });
+  server.route({
+    method: 'POST',
+    path: '/v1/departures',
+    options: {
+      tags: ['api', 'stops'],
+      validate: getDeparturesRequest,
+      description: 'Get departures from feature location'
+    },
+    handler: async (request, h) => {
+      const locaton = (request.payload as unknown) as FeatureLocation;
+      const query = (request.query as unknown) as DeparturesFromLocationQuery;
+
+      return (await service.getDepartures(locaton, query)).unwrap();
     }
   });
   server.route({

--- a/src/api/stops/index.ts
+++ b/src/api/stops/index.ts
@@ -107,7 +107,13 @@ export default (server: Hapi.Server) => (service: IStopsService) => {
     options: {
       tags: ['api', 'stops'],
       validate: getNearestDeparturesRequest,
-      description: 'Get departures from stops near coordinates'
+      description:
+        'Get departures from stops near coordinates. Deprecated: Use /v1/departures instead',
+      plugins: {
+        'hapi-swagger': {
+          deprecated: true
+        }
+      }
     },
     handler: async (request, h) => {
       const query = (request.query as unknown) as NearestDeparturesQuery;
@@ -121,28 +127,19 @@ export default (server: Hapi.Server) => (service: IStopsService) => {
     options: {
       tags: ['api', 'stops'],
       validate: getStopPlaceDeparturesRequest,
-      description: 'Get departures from StopPlace'
+      description:
+        'Get departures from StopPlace. Deprecated: Use /v1/departures instead',
+      plugins: {
+        'hapi-swagger': {
+          deprecated: true
+        }
+      }
     },
     handler: async (request, h) => {
       const { id } = request.params;
       const query = (request.query as unknown) as DeparturesFromStopPlaceQuery;
 
       return (await service.getDeparturesFromStopPlace(id, query)).unwrap();
-    }
-  });
-  server.route({
-    method: 'POST',
-    path: '/v1/departures',
-    options: {
-      tags: ['api', 'stops'],
-      validate: getDeparturesRequest,
-      description: 'Get departures from feature location'
-    },
-    handler: async (request, h) => {
-      const locaton = (request.payload as unknown) as FeatureLocation;
-      const query = (request.query as unknown) as DeparturesFromLocationQuery;
-
-      return (await service.getDepartures(locaton, query)).unwrap();
     }
   });
   server.route({
@@ -182,6 +179,21 @@ export default (server: Hapi.Server) => (service: IStopsService) => {
     handler: async (request, h) => {
       const query = (request.query as unknown) as DeparturesBetweenStopPlacesQuery;
       return (await service.getDeparturesBetweenStopPlaces(query)).unwrap();
+    }
+  });
+  server.route({
+    method: 'POST',
+    path: '/v1/departures',
+    options: {
+      tags: ['api', 'stops', 'departures'],
+      validate: getDeparturesRequest,
+      description: 'Get departures from feature location'
+    },
+    handler: async (request, h) => {
+      const locaton = (request.payload as unknown) as FeatureLocation;
+      const query = (request.query as unknown) as DeparturesFromLocationQuery;
+
+      return (await service.getDepartures(locaton, query)).unwrap();
     }
   });
 };

--- a/src/api/stops/schema.ts
+++ b/src/api/stops/schema.ts
@@ -26,6 +26,21 @@ export const getStopPlaceDeparturesRequest = {
     includeNonBoarding: Joi.bool()
   })
 };
+export const getDeparturesRequest = {
+  payload: Joi.object({
+    layer: Joi.string(),
+    id: Joi.string(),
+    coordinates: Joi.object({ longitude: Joi.number(), latitude: Joi.number() })
+  }).options({ allowUnknown: true }),
+
+  query: Joi.object({
+    limit: Joi.number().default(5),
+    includeNonBoarding: Joi.bool().default(false),
+    offset: Joi.number().default(ONE_MINUTE),
+    walkSpeed: Joi.number().default(1.3),
+    includeIrrelevant: Joi.bool().default(false)
+  })
+};
 export const getDeparturesFromQuayRequest = getStopPlaceDeparturesRequest;
 
 export const getNearestDeparturesRequest = {

--- a/src/service/impl/stops.ts
+++ b/src/service/impl/stops.ts
@@ -1,200 +1,316 @@
 import { Result } from '@badrap/result';
-import { EnturService, StopPlaceDetails, EstimatedCall } from '@entur/sdk';
+import {
+  EnturService,
+  StopPlaceDetails,
+  EstimatedCall,
+  Quay
+} from '@entur/sdk';
 import haversineDistance from 'haversine-distance';
 import { IStopsService } from '../interface';
-import { APIError } from '../types';
+import {
+  APIError,
+  DeparturesWithStop,
+  DeparturesFromLocationQuery,
+  FeatureLocation
+} from '../types';
 
 type EstimatedCallWithStop = EstimatedCall & { stop: StopPlaceDetails };
 
-export default (service: EnturService): IStopsService => ({
-  async getDeparturesBetweenStopPlaces({ from, to }, params) {
-    try {
-      const departures = await service.getDeparturesBetweenStopPlaces(
-        from,
-        to,
-        params
-      );
-      return Result.ok(departures);
-    } catch (error) {
-      return Result.err(new APIError(error));
-    }
-  },
-  async getStopPlacesByName({ query, lat, lon }) {
-    try {
-      const coordinates =
-        lat && lon ? { latitude: lat, longitude: lon } : undefined;
-      const features = await service.getFeatures(query, coordinates, {
-        layers: ['venue']
-      });
-      const isStop = /^NSR:StopPlace:\d+$/;
-
-      const stopIDs = features
-        .filter(f => f.properties.id.match(isStop))
-        .map(s => s.properties.id);
-
-      const stops = (await service.getStopPlaces(stopIDs)).filter(
-        s => s !== undefined
-      ) as StopPlaceDetails[];
-
-      return Result.ok(stops);
-    } catch (error) {
-      return Result.err(new APIError(error));
-    }
-  },
-  async getStopPlace(id) {
-    try {
-      const stop = await service.getStopPlace(id);
-      return Result.ok(stop);
-    } catch (error) {
-      if (error instanceof Error) {
-        const re = /Entur SDK: No data available/;
-        if (error.message.match(re)) return Result.ok(null);
+export default (service: EnturService): IStopsService => {
+  const api: IStopsService = {
+    async getDeparturesBetweenStopPlaces({ from, to }, params) {
+      try {
+        const departures = await service.getDeparturesBetweenStopPlaces(
+          from,
+          to,
+          params
+        );
+        return Result.ok(departures);
+      } catch (error) {
+        return Result.err(new APIError(error));
       }
-      return Result.err(new APIError(error));
-    }
-  },
-  async getDeparturesFromStopPlace(id, query) {
-    try {
-      const departures = await service.getDeparturesFromStopPlace(id, query);
+    },
+    async getStopPlacesByName({ query, lat, lon }) {
+      try {
+        const coordinates =
+          lat && lon ? { latitude: lat, longitude: lon } : undefined;
+        const features = await service.getFeatures(query, coordinates, {
+          layers: ['venue']
+        });
+        const isStop = /^NSR:StopPlace:\d+$/;
 
-      return Result.ok(departures);
-    } catch (error) {
-      return Result.err(new APIError(error));
-    }
-  },
-  async getDeparturesFromQuay(id, query) {
-    const q: any = {
-      omitNonBoarding: false
-    };
-    try {
-      const departures = await service.getDeparturesFromQuays([id], q);
-      if (departures.length > 0 && departures[0]?.departures) {
-        return Result.ok(departures[0]?.departures);
+        const stopIDs = features
+          .filter(f => f.properties.id.match(isStop))
+          .map(s => s.properties.id);
+
+        const stops = (await service.getStopPlaces(stopIDs)).filter(
+          s => s !== undefined
+        ) as StopPlaceDetails[];
+
+        return Result.ok(stops);
+      } catch (error) {
+        return Result.err(new APIError(error));
       }
-      return Result.ok([]);
-    } catch (error) {
-      return Result.err(new APIError(error));
-    }
-  },
-  async getStopPlacesByPosition({ lat: latitude, lon: longitude, distance }) {
-    try {
-      const stops = await service.getStopPlacesByPosition(
-        {
-          latitude,
-          longitude
-        },
-        distance
-      );
+    },
+    async getStopPlace(id) {
+      try {
+        const stop = await service.getStopPlace(id);
+        return Result.ok(stop);
+      } catch (error) {
+        if (error instanceof Error) {
+          const re = /Entur SDK: No data available/;
+          if (error.message.match(re)) return Result.ok(null);
+        }
+        return Result.err(new APIError(error));
+      }
+    },
+    async getDeparturesFromStopPlace(id, query) {
+      try {
+        const departures = await service.getDeparturesFromStopPlace(id, query);
 
-      return Result.ok(stops);
-    } catch (error) {
-      return Result.err(new APIError(error));
-    }
-  },
-  async getNearestPlaces({ lat, lon, ...query }) {
-    try {
-      const places = await service.getNearestPlaces({
-        latitude: lat,
-        longitude: lon
-      });
-      return Result.ok(places);
-    } catch (error) {
-      return Result.err(new APIError(error));
-    }
-  },
-  async getNearestDepartures({ lat, lon, ...query }) {
-    const start = new Date(Date.now() + query.offset);
-    const now = Date.now();
-    const irrelevant = (d: EstimatedCallWithStop) => {
-      if (query.includeIrrelevant) return true;
+        return Result.ok(departures);
+      } catch (error) {
+        return Result.err(new APIError(error));
+      }
+    },
+    async getDepartures(location, query) {
+      const groupByQuays = (
+        calls: EstimatedCall[],
+        stop: StopPlaceDetails,
+        limit: number
+      ) => {
+        return calls.reduce(
+          function(obj, call) {
+            const quayId = call.quay?.id ?? 'unknown';
+            if (!obj.quays[quayId]) {
+              obj.quays[quayId] = {
+                quay: call.quay!,
+                departures: []
+              };
+            }
+            if (obj.quays[quayId].departures.length >= limit) return obj;
 
-      const walkTimeMS =
-        query.walkSpeed *
+            obj.quays[quayId].departures.push(call);
+            return obj;
+          },
+          {
+            stop,
+            quays: {}
+          } as DeparturesWithStop
+        );
+      };
+      const getDeparturesFromLocation = async (
+        { latitude: lat, longitude: lon }: FeatureLocation['coordinates'],
+        query: DeparturesFromLocationQuery
+      ) => {
+        const start = new Date(Date.now() + query.offset);
+        const now = Date.now();
+        const hasLatLon = (quay?: Quay) =>
+          quay && quay?.stopPlace.latitude && quay?.stopPlace.longitude;
+        let distanceTo = (latTarget: number, lonTarget: number) =>
+          haversineDistance(
+            { lat, lon },
+            {
+              lat: latTarget,
+              lon: lonTarget
+            }
+          );
+        const irrelevant = (d: EstimatedCall) => {
+          if (query.includeIrrelevant) return true;
+          const walkTimeMS = !hasLatLon(d.quay)
+            ? 0
+            : query.walkSpeed *
+              distanceTo(
+                d.quay?.stopPlace.latitude!,
+                d.quay?.stopPlace.longitude!
+              ) *
+              1000;
+
+          const arrival = now + walkTimeMS;
+          const departure = new Date(d.expectedDepartureTime).getTime();
+          return arrival < departure;
+        };
+        const byDistance = (
+          a: DeparturesWithStop,
+          b: DeparturesWithStop
+        ): number =>
+          distanceTo(a.stop.latitude ?? 0, a.stop.longitude ?? 0) -
+          distanceTo(b.stop.latitude ?? 0, b.stop.longitude ?? 0);
+        const toDepartures = async (
+          stop: StopPlaceDetails
+        ): Promise<DeparturesWithStop> =>
+          groupByQuays(
+            (
+              await service.getDeparturesFromStopPlace(stop.id, {
+                start,
+                limit: query.limit ?? 5 * 3
+              })
+            ).filter(irrelevant),
+            stop,
+            query.limit
+          );
+
+        const stops = await service.getStopPlacesByPosition({
+          latitude: lat,
+          longitude: lon
+        });
+        const departures = await Promise.all(stops.map(toDepartures));
+        return departures.sort(byDistance);
+      };
+      try {
+        if (location.layer === 'venue') {
+          const stop = await service.getStopPlace(location.id);
+          const data = await service.getDeparturesFromStopPlace(location.id, {
+            limit: query.limit * 3,
+            includeNonBoarding: query.includeNonBoarding
+          });
+          return Result.ok([groupByQuays(data, stop, query.limit)]);
+        }
+
+        const data = await getDeparturesFromLocation(location.coordinates, {
+          ...query
+        });
+        return Result.ok(data);
+      } catch (error) {
+        return Result.err(new APIError(error));
+      }
+    },
+    async getDeparturesFromQuay(id, query) {
+      const q: any = {
+        omitNonBoarding: false
+      };
+      try {
+        const departures = await service.getDeparturesFromQuays([id], q);
+        if (departures.length > 0 && departures[0]?.departures) {
+          return Result.ok(departures[0]?.departures);
+        }
+        return Result.ok([]);
+      } catch (error) {
+        return Result.err(new APIError(error));
+      }
+    },
+    async getStopPlacesByPosition({ lat: latitude, lon: longitude, distance }) {
+      try {
+        const stops = await service.getStopPlacesByPosition(
+          {
+            latitude,
+            longitude
+          },
+          distance
+        );
+
+        return Result.ok(stops);
+      } catch (error) {
+        return Result.err(new APIError(error));
+      }
+    },
+    async getNearestPlaces({ lat, lon, ...query }) {
+      try {
+        const places = await service.getNearestPlaces({
+          latitude: lat,
+          longitude: lon
+        });
+        return Result.ok(places);
+      } catch (error) {
+        return Result.err(new APIError(error));
+      }
+    },
+    async getNearestDepartures({ lat, lon, ...query }) {
+      const start = new Date(Date.now() + query.offset);
+      const now = Date.now();
+      const irrelevant = (d: EstimatedCallWithStop) => {
+        if (query.includeIrrelevant) return true;
+
+        const walkTimeMS =
+          query.walkSpeed *
+          haversineDistance(
+            { lat, lon },
+            { lat: d.stop.latitude, lon: d.stop.longitude }
+          ) *
+          1000;
+
+        const arrival = now + walkTimeMS;
+        const departure = new Date(d.expectedDepartureTime).getTime();
+
+        return arrival < departure;
+      };
+      const byDepartureTime = (a: EstimatedCall, b: EstimatedCall): number =>
+        new Date(a.expectedDepartureTime).getTime() -
+        new Date(b.expectedDepartureTime).getTime();
+      const byDistance = (
+        a: EstimatedCallWithStop,
+        b: EstimatedCallWithStop
+      ): number =>
         haversineDistance(
-          { lat, lon },
-          { lat: d.stop.latitude, lon: d.stop.longitude }
-        ) *
-        1000;
+          { latitude: a.stop.latitude, longitude: a.stop.longitude },
+          { latitude: lat, longitude: lon }
+        ) -
+        haversineDistance(
+          { latitude: b.stop.latitude, longitude: b.stop.longitude },
+          { latitude: lat, longitude: lon }
+        );
+      const byFlattening = <T>(a: T[], b: T[]) => a.concat(b);
+      const overServiceJourneyId = (
+        a: { [key: string]: EstimatedCall },
+        b: EstimatedCall
+      ) => ({ ...a, [b.serviceJourney.id]: b });
+      const toDepartures = async (
+        stop: StopPlaceDetails
+      ): Promise<EstimatedCallWithStop[]> =>
+        (
+          await service.getDeparturesFromStopPlace(stop.id, {
+            start,
+            limit: 10
+          })
+        ).map(d => ({ ...d, stop }));
+      try {
+        const stops = await service.getStopPlacesByPosition({
+          latitude: lat,
+          longitude: lon
+        });
+        const departures = await Promise.all(stops.map(toDepartures));
+        const departuresByDistanceAndTime = Object.values(
+          departures
+            .reduce(byFlattening, [])
+            .filter(irrelevant)
+            .sort(byDistance)
+            .reduceRight(overServiceJourneyId, {})
+        ).sort(byDepartureTime);
 
-      const arrival = now + walkTimeMS;
-      const departure = new Date(d.expectedDepartureTime).getTime();
+        return Result.ok(departuresByDistanceAndTime);
+      } catch (error) {
+        return Result.err(new APIError(error));
+      }
+    },
+    async getQuaysForStopPlace(id, query) {
+      try {
+        const quays = await service.getQuaysForStopPlace(id, query);
 
-      return arrival < departure;
-    };
-    const byDepartureTime = (a: EstimatedCall, b: EstimatedCall): number =>
-      new Date(a.expectedDepartureTime).getTime() -
-      new Date(b.expectedDepartureTime).getTime();
-    const byDistance = (
-      a: EstimatedCallWithStop,
-      b: EstimatedCallWithStop
-    ): number =>
-      haversineDistance(
-        { latitude: a.stop.latitude, longitude: a.stop.longitude },
-        { latitude: lat, longitude: lon }
-      ) -
-      haversineDistance(
-        { latitude: b.stop.latitude, longitude: b.stop.longitude },
-        { latitude: lat, longitude: lon }
-      );
-    const byFlattening = <T>(a: T[], b: T[]) => a.concat(b);
-    const overServiceJourneyId = (
-      a: { [key: string]: EstimatedCall },
-      b: EstimatedCall
-    ) => ({ ...a, [b.serviceJourney.id]: b });
-    const toDepartures = async (
-      stop: StopPlaceDetails
-    ): Promise<EstimatedCallWithStop[]> =>
-      (
-        await service.getDeparturesFromStopPlace(stop.id, {
-          start,
-          limit: 10
-        })
-      ).map(d => ({ ...d, stop }));
-    try {
-      const stops = await service.getStopPlacesByPosition({
-        latitude: lat,
-        longitude: lon
-      });
-      const departures = await Promise.all(stops.map(toDepartures));
-      const departuresByDistanceAndTime = Object.values(
-        departures
-          .reduce(byFlattening, [])
-          .filter(irrelevant)
-          .sort(byDistance)
-          .reduceRight(overServiceJourneyId, {})
-      ).sort(byDepartureTime);
+        return Result.ok(quays);
+      } catch (error) {
+        if (error instanceof Error) {
+          const re = /Entur SDK: No data available/;
+          if (error.message.match(re)) return Result.ok(null);
+        }
+        return Result.err(new APIError(error));
+      }
+    },
+    async getDeparturesForServiceJourney(id, { date }) {
+      try {
+        const departures = await service.getDeparturesForServiceJourney(
+          id,
+          date?.toISOString()
+        );
 
-      return Result.ok(departuresByDistanceAndTime);
-    } catch (error) {
-      return Result.err(new APIError(error));
-    }
-  },
-  async getQuaysForStopPlace(id, query) {
-    try {
-      const quays = await service.getQuaysForStopPlace(id, query);
-
-      return Result.ok(quays);
-    } catch (error) {
-      if (error instanceof Error) {
+        return Result.ok(departures);
+      } catch (error) {
         const re = /Entur SDK: No data available/;
         if (error.message.match(re)) return Result.ok(null);
+
+        return Result.err(new APIError(error));
       }
-      return Result.err(new APIError(error));
     }
-  },
-  async getDeparturesForServiceJourney(id, { date }) {
-    try {
-      const departures = await service.getDeparturesForServiceJourney(
-        id,
-        date?.toISOString()
-      );
+  };
 
-      return Result.ok(departures);
-    } catch (error) {
-      const re = /Entur SDK: No data available/;
-      if (error.message.match(re)) return Result.ok(null);
-
-      return Result.err(new APIError(error));
-    }
-  }
-});
+  return api;
+};

--- a/src/service/interface.ts
+++ b/src/service/interface.ts
@@ -6,8 +6,7 @@ import {
   Quay,
   StopPlace,
   StopPlaceDetails,
-  TripPattern,
-  DeparturesById
+  TripPattern
 } from '@entur/sdk';
 import {
   APIError,
@@ -27,9 +26,10 @@ import {
   TripQuery,
   StopPlaceByNameQuery,
   NearestDeparturesQuery,
-  DeparturesByIdWithStopName,
-  SingleTripPatternQuery,
-  TripPatternQuery
+  TripPatternQuery,
+  FeatureLocation,
+  DeparturesWithStop,
+  DeparturesFromLocationQuery
 } from './types';
 import { AgentError } from './impl/agent';
 
@@ -76,6 +76,11 @@ export interface IStopsService {
     id: string,
     query: DeparturesFromStopPlaceQuery
   ): Promise<Result<EstimatedCall[], APIError>>;
+
+  getDepartures(
+    location: FeatureLocation,
+    query: DeparturesFromLocationQuery
+  ): Promise<Result<DeparturesWithStop[], APIError>>;
 
   getDeparturesFromQuay(
     id: string,

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -1,4 +1,12 @@
-import { Location, QueryMode, DeparturesById } from '@entur/sdk';
+import {
+  Location,
+  QueryMode,
+  DeparturesById,
+  Feature,
+  StopPlaceDetails,
+  Quay,
+  Departure
+} from '@entur/sdk';
 import { FetchError } from 'node-fetch';
 import { boomify } from '@hapi/boom';
 
@@ -6,6 +14,10 @@ export interface Coordinates {
   latitude: number;
   longitude: number;
 }
+
+export type FeatureLocation = Feature['properties'] & {
+  coordinates: { longitude: number; latitude: number };
+};
 
 export type FeaturesQuery = {
   query: string;
@@ -58,6 +70,14 @@ export interface DeparturesFromStopPlaceQuery {
   timeRange?: number;
   limit?: number;
   includeNonBoarding?: boolean;
+}
+
+export interface DeparturesFromLocationQuery {
+  offset: number;
+  walkSpeed: number;
+  includeIrrelevant: boolean;
+  limit: number;
+  includeNonBoarding: boolean;
 }
 
 export interface DeparturesFromQuayQuery {
@@ -129,6 +149,13 @@ export type NextDepartureFromCoordinateQuery = {
 
 export type DeparturesByIdWithStopName = DeparturesById & {
   name: string;
+};
+
+export type DeparturesWithStop = {
+  stop: StopPlaceDetails;
+  quays: {
+    [quayId: string]: { quay: Quay; departures: Array<Departure> };
+  };
 };
 
 export class APIError extends Error {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "target": "es5",
     "module": "commonjs",
     "outDir": "dist",
-    "sourceMap": true
+    "sourceMap": true,
+    "lib": ["es2019"]
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
Adds own endpoint for generated departures by stop place and quay. This will replace the previously used nearest and stops endpoints and instead work on "Location" type. From the app, it is oblivious if the passed location is a venue or not. This also allows us to have consistent behavior across clients at some point.

There are several improvements that could be made at some point. Most notably for fetching additional results, but thinking this can be fixed as a part of https://github.com/AtB-AS/mittatb-app/issues/255. 

Another point we can think about at some point is caching.