### PR TITLE
Adds small script for generating swagger.yaml file automatically

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,6 +16,22 @@ Build and run the docker image:
 
 `docker run --rm --env PORT=8080 -p 8080:8080 -it $(docker build -q .)`
 
+## Deploying
+
+Staging is deployed automatically using Cloud Build triggered on main branch.
+Production code is deployed from `prod` branch currently (subject to change).
+
+DNS gateway uses Swagger documentation to open specific endpoints. This means if
+you change the public API in any case you will have to update the
+[`swagger.yaml` file](./swagger.yaml) in root:
+
+```sh
+npm run swagger-gen
+```
+
+and comitting the code generated. Remember to check the git diff to see if
+everything looks ok.
+
 ## Architecture
 
 The runtime is written in TypeScript and runs on Node.js

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start:dev": "ts-node --files ./src/index.ts",
     "start:watch": "nodemon",
     "test": "jest",
-    "gql-gen": "graphql-codegen --config codegen.yml"
+    "gql-gen": "graphql-codegen --config codegen.yml",
+    "swagger-gen": "node tools/generate-swagger.js"
   },
   "keywords": [],
   "author": "",
@@ -35,7 +36,8 @@
     "prettier": "^2.0.5",
     "ts-jest": "^26.1.3",
     "ts-node": "^8.10.2",
-    "typescript": "^3.9.7"
+    "typescript": "^3.9.7",
+    "yaml": "^1.10.0"
   },
   "dependencies": {
     "@badrap/result": "^0.2.6",

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,9 +39,8 @@ process.on('unhandledRejection', err => {
     });
     const projectId = await auth.getProjectId();
 
-    const server = createServer({
-      port: process.env['PORT'] || '8080'
-    });
+    const port = process.env['PORT'] || '8080';
+    const server = createServer({ port });
     const enturService = enturClient({});
     await initializePlugins(server);
     server.route({
@@ -57,13 +56,13 @@ process.on('unhandledRejection', err => {
     stopsRoutes(server)(stopsService(enturService));
     geocoderRoutes(server)(geocoderService(enturService, pubSubClient));
     journeyRoutes(server)(js);
-    agentRoutes(server)(
-      agentService(stopsService(enturService), js)
-    );
+    agentRoutes(server)(agentService(stopsService(enturService), js));
 
     registerMetricsExporter(projectId);
     await server.initialize();
     await server.start();
+
+    console.log(`[STARTED] Running on port ${port}`);
   } catch (error) {
     console.error(
       `failed to initialize server: ${error?.message}, terminating process.`

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,4 +1,4 @@
-swagger: '2.0'
+swagger: "2.0"
 info:
   title: atb-bff
   description: ATB BFF
@@ -12,7 +12,7 @@ x-google-backend:
   address: https://atb-bff-staging-jlmnrncfba-ew.a.run.app
   path_translation: APPEND_PATH_TO_ADDRESS
 paths:
-  '/bff/v1/departures':
+  /bff/v1/departures:
     get:
       summary: Find departures between stop places
       operationId: getBffV1Departures
@@ -32,13 +32,13 @@ paths:
           schema:
             type: string
           description: Successful
-  '/bff/v1/departures-realtime':
+  /bff/v1/departures-realtime:
     get:
-      summary:
-        Get updated realtime information of all lines and quays passed as data
+      summary: Get updated realtime information of all lines and quays passed as data
       operationId: getBffV1Departuresrealtime
       parameters:
         - type: array
+          default: []
           items:
             type: string
           collectionFormat: multi
@@ -59,7 +59,7 @@ paths:
           schema:
             type: string
           description: Successful
-  '/bff/v1/stops':
+  /bff/v1/stops:
     get:
       summary: Find stops matching query
       operationId: getBffV1Stops
@@ -81,7 +81,7 @@ paths:
           schema:
             type: string
           description: Successful
-  '/bff/v1/agent/next-departure-between':
+  /bff/v1/agent/next-departure-between:
     get:
       summary: Get next departures between stops
       operationId: getBffV1AgentNextdeparturebetween
@@ -101,7 +101,7 @@ paths:
           schema:
             type: string
           description: Successful
-  '/bff/v1/agent/next-departure-between-nearest':
+  /bff/v1/agent/next-departure-between-nearest:
     get:
       operationId: getBffV1AgentNextdeparturebetweennearest
       parameters:
@@ -124,11 +124,10 @@ paths:
           schema:
             type: string
           description: Successful
-  '/bff/v1/departures/nearest':
+  /bff/v1/departures/nearest:
     get:
-      summary:
-        'Get departures from stops near coordinates. Deprecated: Use POST
-        /v1/departures-from-location instead'
+      summary: "Get departures from stops near coordinates. Deprecated: Use POST
+        /v1/departures-from-location instead"
       operationId: getBffV1DeparturesNearest
       parameters:
         - type: number
@@ -159,7 +158,7 @@ paths:
             type: string
           description: Successful
       deprecated: true
-  '/bff/v1/geocoder/features':
+  /bff/v1/geocoder/features:
     get:
       summary: Find features matching query
       operationId: getBffV1GeocoderFeatures
@@ -205,7 +204,7 @@ paths:
           schema:
             type: string
           description: Successful
-  '/bff/v1/geocoder/reverse':
+  /bff/v1/geocoder/reverse:
     get:
       summary: Find addresses, POIs and stop places near the given coordinates
       operationId: getBffV1GeocoderReverse
@@ -234,7 +233,7 @@ paths:
           schema:
             type: string
           description: Successful
-  '/bff/v1/journey/single-trip':
+  /bff/v1/journey/single-trip:
     get:
       summary: Get one specific trip pattern from generated ID
       operationId: getBffV1JourneySingletrip
@@ -250,7 +249,7 @@ paths:
           schema:
             type: string
           description: Successful
-  '/bff/v1/journey/trip':
+  /bff/v1/journey/trip:
     get:
       summary: Find trip patterns with a simple query
       operationId: getBffV1JourneyTrip
@@ -281,7 +280,7 @@ paths:
         - in: body
           name: body
           schema:
-            '$ref': '#/definitions/Model2'
+            $ref: "#/definitions/Model2"
       tags:
         - bff
       responses:
@@ -289,7 +288,7 @@ paths:
           schema:
             type: string
           description: Successful
-  '/bff/v1/stop/{id}':
+  "/bff/v1/stop/{id}":
     get:
       summary: Get details for a StopPlace
       operationId: getBffV1StopId
@@ -305,7 +304,7 @@ paths:
           schema:
             type: string
           description: Successful
-  '/bff/v1/stops/nearest':
+  /bff/v1/stops/nearest:
     get:
       summary: Find stops near coordinates
       operationId: getBffV1StopsNearest
@@ -328,7 +327,7 @@ paths:
           schema:
             type: string
           description: Successful
-  '/bff/v1/quay/{id}/departures':
+  "/bff/v1/quay/{id}/departures":
     get:
       summary: Get departures from Quay
       operationId: getBffV1QuayIdDepartures
@@ -357,7 +356,7 @@ paths:
           schema:
             type: string
           description: Successful
-  '/bff/v1/servicejourney/{id}/departures':
+  "/bff/v1/servicejourney/{id}/departures":
     get:
       summary: Get departures for Service Journey
       operationId: getBffV1ServicejourneyIdDepartures
@@ -377,11 +376,10 @@ paths:
           schema:
             type: string
           description: Successful
-  '/bff/v1/stop/{id}/departures':
+  "/bff/v1/stop/{id}/departures":
     get:
-      summary:
-        'Get departures from StopPlace. Deprecated: Use POST
-        /v1/departures-from-location instead'
+      summary: "Get departures from StopPlace. Deprecated: Use POST
+        /v1/departures-from-location instead"
       operationId: getBffV1StopIdDepartures
       parameters:
         - type: string
@@ -409,7 +407,7 @@ paths:
             type: string
           description: Successful
       deprecated: true
-  '/bff/v1/stop/{id}/quays':
+  "/bff/v1/stop/{id}/quays":
     get:
       summary: Get all quays that belongs to a StopPlace
       operationId: getBffV1StopIdQuays
@@ -429,7 +427,7 @@ paths:
           schema:
             type: string
           description: Successful
-  '/bff/v1/departures-from-location':
+  /bff/v1/departures-from-location:
     post:
       summary: Get departures from feature location
       operationId: postBffV1Departuresfromlocation
@@ -453,7 +451,7 @@ paths:
         - in: body
           name: body
           schema:
-            '$ref': '#/definitions/Model1'
+            $ref: "#/definitions/Model1"
       tags:
         - bff
       responses:
@@ -461,7 +459,7 @@ paths:
           schema:
             type: string
           description: Successful
-  '/bff/v1/departures-from-location-paging':
+  /bff/v1/departures-from-location-paging:
     post:
       summary: Get departures from feature location
       operationId: postBffV1Departuresfromlocationpaging
@@ -495,7 +493,7 @@ paths:
         - in: body
           name: body
           schema:
-            '$ref': '#/definitions/Model1'
+            $ref: "#/definitions/Model1"
       tags:
         - bff
       responses:
@@ -519,7 +517,7 @@ definitions:
       id:
         type: string
       coordinates:
-        '$ref': '#/definitions/coordinates'
+        $ref: "#/definitions/coordinates"
   from:
     type: object
     properties:
@@ -529,7 +527,7 @@ definitions:
         type: string
         default: UNKNOWN
       coordinates:
-        '$ref': '#/definitions/coordinates'
+        $ref: "#/definitions/coordinates"
   modes:
     type: array
     default:
@@ -546,9 +544,9 @@ definitions:
     type: object
     properties:
       from:
-        '$ref': '#/definitions/from'
+        $ref: "#/definitions/from"
       to:
-        '$ref': '#/definitions/from'
+        $ref: "#/definitions/from"
       searchDate:
         type: string
         format: date
@@ -559,7 +557,7 @@ definitions:
         type: number
         default: 30
       modes:
-        '$ref': '#/definitions/modes'
+        $ref: "#/definitions/modes"
       limit:
         type: number
         default: 10

--- a/tools/generate-swagger.js
+++ b/tools/generate-swagger.js
@@ -1,0 +1,89 @@
+const yaml = require('yaml');
+const fetch = require('node-fetch');
+const { spawn } = require('child_process');
+const fs = require('fs');
+const { join } = require('path');
+
+const { readFile, writeFile } = fs.promises;
+
+const PORT = '1337';
+const URL = `http://localhost:${PORT}/swagger.json`;
+
+const TIMEOUT = 10 * 1000;
+
+const swaggerFile = join(process.cwd(), 'swagger.yaml');
+
+if (!fs.existsSync(swaggerFile)) {
+  console.error(`Could not find existing swagger file at ${swaggerFile}`);
+  process.exit(-1);
+}
+
+function startServer() {
+  return new Promise(function (res, rej) {
+    const server = spawn(`npm`, ['run', 'start:dev'], {
+      env: { ...process.env, PORT }
+    });
+
+    server.stdout.on('data', data => {
+      if (data.includes('[STARTED]')) {
+        res(() => server.kill());
+      }
+    });
+
+    const timeoutId = setTimeout(function () {
+      console.error('Timed out. Stopping subprocess');
+      server.kill();
+      rej(new Error('TIMEOUT'));
+    }, TIMEOUT);
+
+    server.on('close', code => {
+      clearTimeout(timeoutId);
+      if (code !== 0) {
+        rej(new Error('STATUS ' + code));
+      }
+    });
+  });
+}
+
+async function getNewSwaggerYamlFromLocalhost() {
+  const result = await fetch(URL);
+  const data = await result.json();
+  const { paths, definitions } = data;
+  return yaml.stringify({ paths, definitions });
+}
+
+async function getExistingSwaggerHeader() {
+  const existingSource = (await readFile(swaggerFile)).toString('utf-8');
+  const { paths: _1, definitions: _2, ...rest } = yaml.parse(existingSource);
+  return yaml.stringify(rest);
+}
+
+async function getSwaggerAsYaml() {
+  let status = 0;
+  let stopServer;
+  try {
+    const yamlYeader = getExistingSwaggerHeader();
+    stopServer = await startServer();
+    const newPathsAndDefinitions = await getNewSwaggerYamlFromLocalhost();
+
+    const newYaml = (await yamlYeader) + newPathsAndDefinitions;
+
+    await writeFile(swaggerFile, newYaml);
+
+    console.log('---------------------------');
+    console.log(
+      'Wrote new swagger.json, stage and commit for CI to detect new end points'
+    );
+    console.log('Remember to check the git diff as quality assurance.');
+    console.log('---------------------------');
+  } catch (e) {
+    status = -1;
+    console.error('Unable to generate swagger data');
+    console.error(e);
+  } finally {
+    stopServer?.();
+    process.exit(status);
+  }
+}
+
+getSwaggerAsYaml();


### PR DESCRIPTION
Rudimentary script for simplifying rolling out changes to the public API. This flow optimizes for running locally, but can at some point be a part of a CI-step. But for now, I would prefer to be able to verify the git diff when rolling out changes.

Tried to see if there was a simple way of generating the swagger.json file from hapi-swagger programmatically, but there's too much bootstrapping, so the simplest way is just to spawn a subprocess on a "unique" port. Spawning a subprocess to let the script have more autonomy. 