### PR TITLE
feat: Support tariff zone authorities

### DIFF
--- a/src/api/geocoder/schema.ts
+++ b/src/api/geocoder/schema.ts
@@ -10,6 +10,7 @@ export const getFeaturesRequest = Joi.object({
     }
     return val;
   }),
+  tariff_zone_authorities: Joi.string(),
   'boundary.rect.min_lat': Joi.number(),
   'boundary.rect.max_lat': Joi.number(),
   'boundary.rect.min_lon': Joi.number(),

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -30,6 +30,7 @@ export type FeaturesQuery = {
   'boundary.country'?: string;
   sources?: string[];
   layers?: string[];
+  tariff_zone_authorities?: string;
   limit?: number;
 };
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -177,6 +177,9 @@ paths:
         - type: string
           name: layers
           in: query
+        - type: string
+          name: tariff_zone_authorities
+          in: query
         - type: number
           name: boundary.rect.min_lat
           in: query


### PR DESCRIPTION
Necessary for tariff zone selection in app where only venues within ATB
tariff zones should be selectable.