### PR TITLE
fixes: strips unknown properties for favorites in stop scheme

### DIFF
--- a/src/api/stops/schema.ts
+++ b/src/api/stops/schema.ts
@@ -87,7 +87,7 @@ export const getDeparturesCursoredRequest = {
         stopId: Joi.string().required(),
         lineName: Joi.string().required(),
         lineId: Joi.string().required()
-      })
+      }).options({ stripUnknown: true })
     )
   }),
   query: Joi.object<DepartureGroupsQuery>({

--- a/src/service/impl/stops/utils/grouping.ts
+++ b/src/service/impl/stops/utils/grouping.ts
@@ -94,10 +94,13 @@ export default function mapQueryToGroups(
     return [];
   }
 
-  const isFavorite = (item: DepartureLineInfo) =>
+  const isFavorite = (item: DepartureLineInfo, stopId: string) =>
     !favorites ||
     favorites.some(
-      f => item.lineName === f.lineName && item.lineId === f.lineId
+      f =>
+        item.lineName === f.lineName &&
+        item.lineId === f.lineId &&
+        stopId === f.stopId
     );
 
   return stopPlaces.filter(Boolean).map(function (stopPlace) {
@@ -137,7 +140,7 @@ export default function mapQueryToGroups(
             lineId: lineInfoEntry.serviceJourney?.line.id ?? ''
           };
 
-          if (!isFavorite(lineInfo)) {
+          if (!isFavorite(lineInfo, stopPlaceInfo.id)) {
             continue;
           }
 


### PR DESCRIPTION
Just to make it easier to use with favorites there is no need to give bad request just because there are some surplus data.

(Also I added another change to piggyback on this, which is a bad thing to do, but I did it anyway. The change is to fix issue with lines not getting filtered out from stops that are not favorites)