### PR TITLE
feat: adds support for focus point

### DIFF
--- a/src/service/impl/geocoder.ts
+++ b/src/service/impl/geocoder.ts
@@ -8,10 +8,14 @@ import { getEnv } from '../../utils/getenv';
 const ENV = getEnv();
 const topicName = `analytics_geocoder_features`;
 
-export default (service: EnturService, pubSubClient: PubSub): IGeocoderService => {
+const FOCUS_WEIGHT = parseInt(process.env.GEOCODER_FOCUS_WEIGHT || '18');
+
+export default (
+  service: EnturService,
+  pubSubClient: PubSub
+): IGeocoderService => {
   // createTopic might fail if the topic already exists; ignore.
-  pubSubClient.createTopic(topicName).catch(() => {
-  });
+  pubSubClient.createTopic(topicName).catch(() => {});
 
   const batchedPublisher = pubSubClient.topic(topicName, {
     batching: {
@@ -22,12 +26,20 @@ export default (service: EnturService, pubSubClient: PubSub): IGeocoderService =
   return {
     async getFeatures({ query, lat, lon, ...params }) {
       try {
-        batchedPublisher
-          .publish(Buffer.from(JSON.stringify(query)), { environment: ENV });
+        batchedPublisher.publish(Buffer.from(JSON.stringify(query)), {
+          environment: ENV
+        });
         const features = await service.getFeatures(
           query,
           { latitude: lat, longitude: lon },
-          { ...params }
+          {
+            // Set default focus point settings for better results
+            // for local searches.
+            'focus.weight': FOCUS_WEIGHT,
+            'focus.scale': '200km',
+            'focus.function': 'exp',
+            ...params
+          }
         );
 
         return Result.ok(features);
@@ -48,4 +60,4 @@ export default (service: EnturService, pubSubClient: PubSub): IGeocoderService =
       }
     }
   };
-}
+};

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -39,6 +39,10 @@ export type FeaturesQuery = {
   layers?: string[];
   tariff_zone_authorities?: string;
   limit?: number;
+
+  'focus.weight'?: number;
+  'focus.function'?: 'linear' | 'exp';
+  'focus.scale'?: 'string';
 };
 
 export interface QuaysForStopPlaceQuery {

--- a/src/types/entur.d.ts
+++ b/src/types/entur.d.ts
@@ -1,0 +1,26 @@
+import { GetFeaturesParams } from '@entur/sdk';
+
+declare module '@entur/sdk' {
+  export interface GetFeaturesParams {
+    /** @deprecated Use boundary object instead */
+    'boundary.rect.min_lon'?: number;
+    /** @deprecated Use boundary object instead */
+    'boundary.rect.max_lon'?: number;
+    /** @deprecated Use boundary object instead */
+    'boundary.rect.min_lat'?: number;
+    /** @deprecated Use boundary object instead */
+    'boundary.rect.max_lat'?: number;
+    /** @deprecated Use boundary object instead */
+    'boundary.country'?: string;
+    /** @deprecated Use boundary object instead */
+    'boundary.county_ids'?: string;
+    /** @deprecated Use boundary object instead */
+    'boundary.locality_ids'?: string;
+    multiModal?: 'parent' | 'child' | 'all';
+    limit?: number;
+
+    'focus.weight'?: number;
+    'focus.function'?: 'linear' | 'exp';
+    'focus.scale'?: string;
+  }
+}


### PR DESCRIPTION
Adding this initial code to get the feature. I'm planning on sending a PR to Entur SDK with the additional properties so we don't have to override here, but to be able to test in staging and fine-tune the focus weighting I'm adding this code now.

I've added ENV `GEOCODER_FOCUS_WEIGHT` to be able to override the weighting without deploying new code.