### PR TITLE
adds stack trace to logging

### DIFF
--- a/src/plugins/logfmt.ts
+++ b/src/plugins/logfmt.ts
@@ -62,11 +62,14 @@ const plugin: Hapi.Plugin<LogFmtOptions> = {
     server.ext('onPreResponse', (request, h, err) => {
       if (request.response instanceof Boom) {
         request.logfmt.with({ err: request.response.message });
+        request.logfmt.with({ stackTrace: request.response.stack });
       }
       return h.continue;
     });
     server.events.on('response', request => {
-      request.logfmt.with({ code: request.raw.res.statusCode.toString() });
+      if (request.raw.res && request.raw.res.statusCode) {
+        request.logfmt.with({ code: request.raw.res.statusCode.toString() });
+      }
       request.logfmt.log();
     });
   },


### PR DESCRIPTION
There are some errors in the staging, but I can't find any way to actually trace the errors, but in Error reporter in GCP and log tracing.

I don't know if this will help, as it seems as the logfmt output is just JSON in any case? I'm having a hard time tracking the logic/flow of logging here.