### PR TITLE
fix: use natural number sorting for public codes if numbers

### DIFF
--- a/src/service/impl/stops/utils/grouping.ts
+++ b/src/service/impl/stops/utils/grouping.ts
@@ -171,9 +171,18 @@ export default function mapQueryToGroups(
     return {
       stopPlace: stopPlaceInfo,
       quays: sortBy(quayGroups, [
-        group => group.quay.publicCode,
+        group => sortByNumberIfPossible(group.quay.publicCode),
         group => group.quay.id
       ])
     };
   });
+}
+
+function sortByNumberIfPossible(val?: string) {
+  if (!val) return val;
+  const parsed = parseInt(val, 10);
+  if (Number.isNaN(parsed)) {
+    return val;
+  }
+  return parsed;
 }


### PR DESCRIPTION
Currently, when treating Public Code as a string we don't get a natural sort for numbers. Which causes 11 to be sorted before 2 etc. But also we can't guarantee that all public codes are numbers. So this checks if it is a number and if it is we sort by the parsed number.