### PR TITLE
refactor: clean up pubsub

### DIFF
--- a/src/analytics/publisher.ts
+++ b/src/analytics/publisher.ts
@@ -1,0 +1,92 @@
+import {
+  DepartureGroupsPayload,
+  DepartureGroupsQuery,
+  DepartureRealtimeQuery,
+  DeparturesFromLocationPagingQuery,
+  FeatureLocation,
+  TripPatternsQuery
+} from '../service/types';
+import { PubSub, Topic } from '@google-cloud/pubsub';
+
+type Topics = {
+  departuresSearchGroupsTopic: string;
+  departuresSearchRealtimeTopic: string;
+  departuresSearchTopic: string;
+  getFeaturesTopic: string;
+  getTripPatternsTopic: string;
+};
+
+type Meta = {
+  environment: string;
+};
+
+export default (pubSub: PubSub, topics: Topics, meta: Meta) => {
+  const departuresSearchGroupsTopic = batchedTopic(
+    pubSub,
+    topics.departuresSearchGroupsTopic
+  );
+  const departuresSearchRealtimeTopic = batchedTopic(
+    pubSub,
+    topics.departuresSearchRealtimeTopic
+  );
+  const departuresSearchTopic = batchedTopic(
+    pubSub,
+    topics.departuresSearchTopic
+  );
+  const getFeaturesTopic = batchedTopic(pubSub, topics.getFeaturesTopic);
+  const getTripPatternsTopic = batchedTopic(
+    pubSub,
+    topics.getTripPatternsTopic
+  );
+
+  return {
+    async departuresSearchGroups(
+      payload: DepartureGroupsPayload,
+      query: DepartureGroupsQuery
+    ) {
+      await departuresSearchGroupsTopic.publish(serialize({ payload, query }), {
+        environment: meta.environment
+      });
+    },
+
+    async departuresSearchRealtime(query: DepartureRealtimeQuery) {
+      await departuresSearchRealtimeTopic.publish(serialize({ query }), {
+        environment: meta.environment
+      });
+    },
+
+    async departuresSearch(
+      location: FeatureLocation,
+      query: DeparturesFromLocationPagingQuery
+    ) {
+      await departuresSearchTopic.publish(serialize({ location, query }), {
+        environment: meta.environment
+      });
+    },
+
+    async getFeatures(query: string) {
+      await getFeaturesTopic.publish(Buffer.from(query), {
+        environment: meta.environment
+      });
+    },
+
+    async getTripPatterns(query: TripPatternsQuery) {
+      await getTripPatternsTopic.publish(serialize(query), {
+        environment: meta.environment
+      });
+    }
+  };
+};
+
+function serialize(data: object): Buffer {
+  return Buffer.from(JSON.stringify(data));
+}
+
+function batchedTopic(client: PubSub, topicName: string): Topic {
+  return client.topic(topicName, {
+    batching: {
+      maxMessages: 100,
+      maxMilliseconds: 5 * 1000
+    }
+  });
+}

--- a/src/service/impl/geocoder.ts
+++ b/src/service/impl/geocoder.ts
@@ -1,34 +1,22 @@
 import { Result } from '@badrap/result';
 import { IGeocoderService } from '../interface';
 import { APIError } from '../types';
-import { PubSub } from '@google-cloud/pubsub';
-import { getEnv } from '../../utils/getenv';
 import { EnturServiceAPI } from './entur';
-
-const ENV = getEnv();
-const topicName = `analytics_geocoder_features`;
 
 const FOCUS_WEIGHT = parseInt(process.env.GEOCODER_FOCUS_WEIGHT || '18');
 
+interface geocoderAnalyticsPublisher {
+  getFeatures(query: string): Promise<void>
+}
+
 export default (
   service: EnturServiceAPI,
-  pubSubClient: PubSub
+  publisher: geocoderAnalyticsPublisher
 ): IGeocoderService => {
-  // createTopic might fail if the topic already exists; ignore.
-  pubSubClient.createTopic(topicName).catch(() => {});
-
-  const batchedPublisher = pubSubClient.topic(topicName, {
-    batching: {
-      maxMessages: 100,
-      maxMilliseconds: 5 * 1000
-    }
-  });
   return {
     async getFeatures({ query, lat, lon, ...params }) {
       try {
-        batchedPublisher.publish(Buffer.from(JSON.stringify(query)), {
-          environment: ENV
-        });
+        await publisher.getFeatures(query);
         const features = await service.getFeatures(
           query,
           { latitude: lat, longitude: lon },


### PR DESCRIPTION
Decouples the service from the PubSub implementation and moves
initialization of topics to the main entry point to better clarify
dependencies on the environment.

This is needed for an upcoming infrastructure rollout by Terraform for
Nordland.

Closes #81.