### PR TITLE
fix: make node the docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ COPY --from=proddeps /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 
 ENV NODE_ENV=production
-CMD npm start
+CMD ["node", "/app/dist/index.js"]


### PR DESCRIPTION
Closes #87 

Graceful shutdown is handled by the `hapi-pulse` plugin, so we don't need our own handler.