### PR TITLE
feat: more trip results, penalty for walking, max walking distance

### DIFF
--- a/src/api/__test__/journey.test.ts
+++ b/src/api/__test__/journey.test.ts
@@ -97,7 +97,10 @@ describe('GET /bff/v1/journey/single-trip', () => {
       limit: 1,
       modes: [],
       searchDate: new Date(),
-      wheelchairAccessible: true
+      wheelchairAccessible: true,
+      maxPreTransitWalkDistance: 2000,
+      maxTransferWalkDistance: 2000,
+      walkReluctance: 4
     };
     const pastTrip = {
       expectedStartTime: '2020-05-14T20:02:00+0200',

--- a/src/api/journey/schema.ts
+++ b/src/api/journey/schema.ts
@@ -39,7 +39,12 @@ export const postJourneyRequest = {
     modes: Joi.array()
       .single()
       .default(['foot', 'bus', 'tram', 'rail', 'metro', 'water', 'air']),
-    limit: Joi.number().default(10),
+    limit: Joi.number().default(15),
+    // Default in meters. 2000m = 2km. Should be somewhat high
+    // for more rural areas.
+    maxPreTransitWalkDistance: Joi.number().default(2000),
+    // Higher number = lower rating for walking. Default by entur is 4
+    walkReluctance: Joi.number().default(5),
     wheelchairAccessible: Joi.bool().default(false)
   }).options({ abortEarly: false })
 };

--- a/src/api/journey/schema.ts
+++ b/src/api/journey/schema.ts
@@ -43,6 +43,8 @@ export const postJourneyRequest = {
     // Default in meters. 2000m = 2km. Should be somewhat high
     // for more rural areas.
     maxPreTransitWalkDistance: Joi.number().default(2000),
+    // Max meters walking on transfers. Defaults to 2000 by Entur.
+    maxTransferWalkDistance: Joi.number().default(2000),
     // Higher number = lower rating for walking. Default by entur is 4
     walkReluctance: Joi.number().default(5),
     wheelchairAccessible: Joi.bool().default(false)

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -149,6 +149,9 @@ export interface TripPatternsQuery {
   searchDate?: Date;
   arriveBy: boolean;
   limit: number;
+  maxTransferWalkDistance: number; // Meters. Defaults to 2000 in Entur
+  maxPreTransitWalkDistance: number; // Meters. Defaults to alot in Entur
+  walkReluctance: number; // Factor. Defaults to 4 in Entur
   modes: QueryMode[];
   wheelchairAccessible: boolean;
 }


### PR DESCRIPTION
- Øker antall trips til max 15
- Setter "straff" på gange til 5 (opp fra 4)
- Setter maks gange før reisemetode til 2km (fra uendelig)
- Setter eksplisitt maks gange mellom overføringer til 2km.

Enda ikke testet i reell kjøring men oppretter PR for kontekst