### PR TITLE
docs: update git repo url in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@ API documentation is generated at runtime and lives in `/documentation`
 
 Clone this project:
 
-`git clone https://github.com/atb-as/bff-oneclick-planner.git`
+`git clone https://github.com/atb-as/atb-bff.git`
 
 Build and run the docker image:
 


### PR DESCRIPTION
Ser at man blir bedt om å klone "atb-as/bff-oneclick-planner" istedet for "atb-as/atb-bff" i readme. Forslag om å forandre til ny URL.