### PR TITLE
feat: add `includeUnusedQuays` on `getStopPlacesByPosition`

### DIFF
--- a/src/api/stops/schema.ts
+++ b/src/api/stops/schema.ts
@@ -13,7 +13,8 @@ export const getStopPlaceByPositionRequest = {
   query: Joi.object({
     lat: Joi.number().required(),
     lon: Joi.number().required(),
-    distance: Joi.number()
+    distance: Joi.number(),
+    includeUnusedQuays: Joi.boolean()
   })
 };
 export const getStopPlaceDeparturesRequest = {

--- a/src/service/impl/stops/index.ts
+++ b/src/service/impl/stops/index.ts
@@ -152,14 +152,20 @@ export default (
         return Result.err(new APIError(error));
       }
     },
-    async getStopPlacesByPosition({ lat: latitude, lon: longitude, distance }) {
+    async getStopPlacesByPosition({
+      lat: latitude,
+      lon: longitude,
+      distance,
+      includeUnusedQuays
+    }) {
       try {
         const stops = await service.getStopPlacesByPosition(
           {
             latitude,
             longitude
           },
-          distance
+          distance,
+          { includeUnusedQuays }
         );
 
         return Result.ok(stops);

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -75,6 +75,7 @@ export interface StopPlaceQuery {
   lat: number;
   lon: number;
   distance?: number;
+  includeUnusedQuays?: boolean;
 }
 
 export interface StopPlaceByNameQuery {


### PR DESCRIPTION
Ny avganger visning i appen er avhengig av å hente ut stopPlaces i nærheten, og da vil jeg ikke ha med ubrukte quays. Parameteren `includeUnusedQuays` er derfor fin å kunne sette.

