### PR TITLE
fix: updates hapi version to support node 16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@google-cloud/pubsub": "^2.10.0",
         "@google-cloud/trace-agent": "^5.1.3",
         "@hapi/boom": "^9.1.1",
-        "@hapi/hapi": "^20.1.0",
+        "@hapi/hapi": "^20.2.1",
         "@hapi/inert": "^6.0.3",
         "@hapi/vision": "^6.0.1",
         "@mapbox/polyline": "^1.1.1",
@@ -2236,28 +2236,28 @@
       "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
     },
     "node_modules/@hapi/hapi": {
-      "version": "20.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.1.0.tgz",
-      "integrity": "sha512-DocLxRpPlHV0jEZw7FHfF/Y+tiRLNOXMcqEDGWdqfbQkDKo8ca3TLHRO4w91BKq1TDcM27w+MHZ1sINTDZyGRw==",
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.2.1.tgz",
+      "integrity": "sha512-OXAU+yWLwkMfPFic+KITo+XPp6Oxpgc9WUH+pxXWcTIuvWbgco5TC/jS8UDvz+NFF5IzRgF2CL6UV/KLdQYUSQ==",
       "dependencies": {
         "@hapi/accept": "^5.0.1",
         "@hapi/ammo": "^5.0.1",
-        "@hapi/boom": "9.x.x",
-        "@hapi/bounce": "2.x.x",
-        "@hapi/call": "8.x.x",
+        "@hapi/boom": "^9.1.0",
+        "@hapi/bounce": "^2.0.0",
+        "@hapi/call": "^8.0.0",
         "@hapi/catbox": "^11.1.1",
-        "@hapi/catbox-memory": "5.x.x",
+        "@hapi/catbox-memory": "^5.0.0",
         "@hapi/heavy": "^7.0.1",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/mimos": "5.x.x",
+        "@hapi/hoek": "^9.0.4",
+        "@hapi/mimos": "^6.0.0",
         "@hapi/podium": "^4.1.1",
-        "@hapi/shot": "^5.0.1",
-        "@hapi/somever": "3.x.x",
+        "@hapi/shot": "^5.0.5",
+        "@hapi/somever": "^3.0.0",
         "@hapi/statehood": "^7.0.3",
         "@hapi/subtext": "^7.0.3",
-        "@hapi/teamwork": "5.x.x",
-        "@hapi/topo": "5.x.x",
-        "@hapi/validate": "^1.1.0"
+        "@hapi/teamwork": "^5.1.0",
+        "@hapi/topo": "^5.0.0",
+        "@hapi/validate": "^1.1.1"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -2274,9 +2274,9 @@
       }
     },
     "node_modules/@hapi/hoek": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.3.tgz",
-      "integrity": "sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg=="
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+      "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw=="
     },
     "node_modules/@hapi/inert": {
       "version": "6.0.3",
@@ -2304,9 +2304,9 @@
       }
     },
     "node_modules/@hapi/mimos": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-5.0.0.tgz",
-      "integrity": "sha512-EVS6wJYeE73InTlPWt+2e3Izn319iIvffDreci3qDNT+t3lA5ylJ0/SoTaID8e0TPNUkHUSsgJZXEmLHvoYzrA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-6.0.0.tgz",
+      "integrity": "sha512-Op/67tr1I+JafN3R3XN5DucVSxKRT/Tc+tUszDwENoNpolxeXkhrJ2Czt6B6AAqrespHoivhgZBWYSuANN9QXg==",
       "dependencies": {
         "@hapi/hoek": "9.x.x",
         "mime-db": "1.x.x"
@@ -2323,11 +2323,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/@hapi/nigel/node_modules/@hapi/hoek": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
-      "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
     },
     "node_modules/@hapi/pez": {
       "version": "5.0.3",
@@ -16243,28 +16238,28 @@
       "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
     },
     "@hapi/hapi": {
-      "version": "20.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.1.0.tgz",
-      "integrity": "sha512-DocLxRpPlHV0jEZw7FHfF/Y+tiRLNOXMcqEDGWdqfbQkDKo8ca3TLHRO4w91BKq1TDcM27w+MHZ1sINTDZyGRw==",
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.2.1.tgz",
+      "integrity": "sha512-OXAU+yWLwkMfPFic+KITo+XPp6Oxpgc9WUH+pxXWcTIuvWbgco5TC/jS8UDvz+NFF5IzRgF2CL6UV/KLdQYUSQ==",
       "requires": {
         "@hapi/accept": "^5.0.1",
         "@hapi/ammo": "^5.0.1",
-        "@hapi/boom": "9.x.x",
-        "@hapi/bounce": "2.x.x",
-        "@hapi/call": "8.x.x",
+        "@hapi/boom": "^9.1.0",
+        "@hapi/bounce": "^2.0.0",
+        "@hapi/call": "^8.0.0",
         "@hapi/catbox": "^11.1.1",
-        "@hapi/catbox-memory": "5.x.x",
+        "@hapi/catbox-memory": "^5.0.0",
         "@hapi/heavy": "^7.0.1",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/mimos": "5.x.x",
+        "@hapi/hoek": "^9.0.4",
+        "@hapi/mimos": "^6.0.0",
         "@hapi/podium": "^4.1.1",
-        "@hapi/shot": "^5.0.1",
-        "@hapi/somever": "3.x.x",
+        "@hapi/shot": "^5.0.5",
+        "@hapi/somever": "^3.0.0",
         "@hapi/statehood": "^7.0.3",
         "@hapi/subtext": "^7.0.3",
-        "@hapi/teamwork": "5.x.x",
-        "@hapi/topo": "5.x.x",
-        "@hapi/validate": "^1.1.0"
+        "@hapi/teamwork": "^5.1.0",
+        "@hapi/topo": "^5.0.0",
+        "@hapi/validate": "^1.1.1"
       }
     },
     "@hapi/heavy": {
@@ -16278,9 +16273,9 @@
       }
     },
     "@hapi/hoek": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.3.tgz",
-      "integrity": "sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg=="
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+      "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw=="
     },
     "@hapi/inert": {
       "version": "6.0.3",
@@ -16308,9 +16303,9 @@
       }
     },
     "@hapi/mimos": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-5.0.0.tgz",
-      "integrity": "sha512-EVS6wJYeE73InTlPWt+2e3Izn319iIvffDreci3qDNT+t3lA5ylJ0/SoTaID8e0TPNUkHUSsgJZXEmLHvoYzrA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-6.0.0.tgz",
+      "integrity": "sha512-Op/67tr1I+JafN3R3XN5DucVSxKRT/Tc+tUszDwENoNpolxeXkhrJ2Czt6B6AAqrespHoivhgZBWYSuANN9QXg==",
       "requires": {
         "@hapi/hoek": "9.x.x",
         "mime-db": "1.x.x"
@@ -16323,13 +16318,6 @@
       "requires": {
         "@hapi/hoek": "^9.0.4",
         "@hapi/vise": "^4.0.0"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
-          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
-        }
       }
     },
     "@hapi/pez": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@google-cloud/pubsub": "^2.10.0",
     "@google-cloud/trace-agent": "^5.1.3",
     "@hapi/boom": "^9.1.1",
-    "@hapi/hapi": "^20.1.0",
+    "@hapi/hapi": "^20.2.1",
     "@hapi/inert": "^6.0.3",
     "@hapi/vision": "^6.0.1",
     "@mapbox/polyline": "^1.1.1",


### PR DESCRIPTION
Oppdaterer til en Hapi-versjon som støtter nyeste LTS av Node (16).


---

Dette unngå feil med null statusCode i versjon av Node over 14.