### PR TITLE
feat: Add departure endpoints

### DIFF
--- a/src/api/departures/index.ts
+++ b/src/api/departures/index.ts
@@ -4,12 +4,27 @@ import { IDeparturesService } from '../../service/interface';
 import {
   getStopDeparturesRequest,
   getDepartureRealtime,
-  getQuayDeparturesRequest
+  getQuayDeparturesRequest,
+  getStopsNearestRequest
 } from './schema';
 import { DepartureRealtimeQuery } from '../../service/types';
 import { QuayDeparturesQueryVariables } from '../../service/impl/departures/gql/jp3/quay-departures.graphql-gen';
+import { NearestStopPlacesQueryVariables } from '../../service/impl/departures/gql/jp3/stops-nearest.graphql-gen';
 
 export default (server: Hapi.Server) => (service: IDeparturesService) => {
+  server.route({
+    method: 'GET',
+    path: '/bff/v2/departures/stops-nearest',
+    options: {
+      tags: ['api', 'departures', 'stop'],
+      validate: getStopsNearestRequest,
+      description: 'Find stops near coordinates'
+    },
+    handler: async (request, h) => {
+      const query = (request.query as unknown) as NearestStopPlacesQueryVariables;
+      return (await service.getStopPlacesByPosition(query)).unwrap();
+    }
+  });
   server.route({
     method: 'GET',
     path: '/bff/v2/departures/stop-departures',

--- a/src/api/departures/index.ts
+++ b/src/api/departures/index.ts
@@ -20,7 +20,7 @@ export default (server: Hapi.Server) => (service: IDeparturesService) => {
     },
     handler: async (request, h) => {
       const query = (request.query as unknown) as StopPlaceQuayDeparturesQueryVariables;
-      return (await service.getStopPlaceQuayDepartures(query)).unwrap();
+      return (await service.getStopQuayDepartures(query)).unwrap();
     }
   });
   server.route({

--- a/src/api/departures/index.ts
+++ b/src/api/departures/index.ts
@@ -1,21 +1,39 @@
 import Hapi from '@hapi/hapi';
 import { StopPlaceQuayDeparturesQueryVariables } from '../../service/impl/departures/gql/jp3/stop-departures.graphql-gen';
 import { IDeparturesService } from '../../service/interface';
-import { getStopDeparturesRequest, getDepartureRealtime } from './schema';
+import {
+  getStopDeparturesRequest,
+  getDepartureRealtime,
+  getQuayDeparturesRequest
+} from './schema';
 import { DepartureRealtimeQuery } from '../../service/types';
+import { QuayDeparturesQueryVariables } from '../../service/impl/departures/gql/jp3/quay-departures.graphql-gen';
 
 export default (server: Hapi.Server) => (service: IDeparturesService) => {
   server.route({
     method: 'GET',
     path: '/bff/v2/departures/stop-departures',
     options: {
-      tags: ['api', 'departures', 'quay', 'estimatedCalls'],
+      tags: ['api', 'departures', 'stopPlace', 'estimatedCalls'],
       validate: getStopDeparturesRequest,
       description: 'Get stop with departures for every quay'
     },
     handler: async (request, h) => {
       const query = (request.query as unknown) as StopPlaceQuayDeparturesQueryVariables;
       return (await service.getStopPlaceQuayDepartures(query)).unwrap();
+    }
+  });
+  server.route({
+    method: 'GET',
+    path: '/bff/v2/departures/quay-departures',
+    options: {
+      tags: ['api', 'departures', 'quay', 'estimatedCalls'],
+      validate: getQuayDeparturesRequest,
+      description: 'Get departures from a quay'
+    },
+    handler: async (request, h) => {
+      const query = (request.query as unknown) as QuayDeparturesQueryVariables;
+      return (await service.getQuayDepartures(query)).unwrap();
     }
   });
   server.route({

--- a/src/api/departures/schema.ts
+++ b/src/api/departures/schema.ts
@@ -8,6 +8,14 @@ export const getStopDeparturesRequest = {
   })
 };
 
+export const getQuayDeparturesRequest = {
+  query: Joi.object({
+    id: Joi.string().required(),
+    numberOfDepartures: Joi.number(),
+    startTime: Joi.string()
+  })
+};
+
 export const getDepartureRealtime = {
   query: Joi.object({
     quayIds: Joi.array().items(Joi.string()).default([]).single(),

--- a/src/api/departures/schema.ts
+++ b/src/api/departures/schema.ts
@@ -1,5 +1,15 @@
 import Joi from 'joi';
 
+export const getStopsNearestRequest = {
+  query: Joi.object({
+    latitude: Joi.number().required(),
+    longitude: Joi.number().required(),
+    distance: Joi.number(),
+    count: Joi.number(),
+    after: Joi.string()
+  })
+};
+
 export const getStopDeparturesRequest = {
   query: Joi.object({
     id: Joi.string().required(),

--- a/src/api/departures/schema.ts
+++ b/src/api/departures/schema.ts
@@ -4,8 +4,8 @@ export const getStopsNearestRequest = {
   query: Joi.object({
     latitude: Joi.number().required(),
     longitude: Joi.number().required(),
-    distance: Joi.number(),
-    count: Joi.number(),
+    distance: Joi.number().default(1000),
+    count: Joi.number().default(10),
     after: Joi.string()
   })
 };
@@ -13,7 +13,7 @@ export const getStopsNearestRequest = {
 export const getStopDeparturesRequest = {
   query: Joi.object({
     id: Joi.string().required(),
-    numberOfDepartures: Joi.number(),
+    numberOfDepartures: Joi.number().default(5),
     startTime: Joi.string()
   })
 };
@@ -21,9 +21,9 @@ export const getStopDeparturesRequest = {
 export const getQuayDeparturesRequest = {
   query: Joi.object({
     id: Joi.string().required(),
-    numberOfDepartures: Joi.number(),
+    numberOfDepartures: Joi.number().default(10),
     startTime: Joi.string(),
-    timeRange: Joi.number()
+    timeRange: Joi.number().default(86400)
   })
 };
 

--- a/src/api/departures/schema.ts
+++ b/src/api/departures/schema.ts
@@ -12,7 +12,8 @@ export const getQuayDeparturesRequest = {
   query: Joi.object({
     id: Joi.string().required(),
     numberOfDepartures: Joi.number(),
-    startTime: Joi.string()
+    startTime: Joi.string(),
+    timeRange: Joi.number()
   })
 };
 

--- a/src/service/impl/departures/gql/jp3/quay-departures.graphql
+++ b/src/service/impl/departures/gql/jp3/quay-departures.graphql
@@ -1,0 +1,33 @@
+query quayDepartures($id: String!, $numberOfDepartures: Int, $startTime: DateTime) {
+  quay(id: $id) {
+    id
+    description
+    publicCode
+    name
+    estimatedCalls(numberOfDepartures: $numberOfDepartures, startTime: $startTime) {
+      expectedDepartureTime
+      realtime
+      quay {
+        id
+        stopPlace {
+          id
+        }
+      }
+      destinationDisplay {
+        frontText
+      }
+      serviceJourney {
+        id
+        privateCode
+        line {
+          name
+          id
+          description
+          publicCode
+          transportMode
+          transportSubmode
+        }
+      }
+    }
+  }
+}

--- a/src/service/impl/departures/gql/jp3/quay-departures.graphql
+++ b/src/service/impl/departures/gql/jp3/quay-departures.graphql
@@ -1,10 +1,14 @@
-query quayDepartures($id: String!, $numberOfDepartures: Int, $startTime: DateTime) {
+query quayDepartures($id: String!, $numberOfDepartures: Int, $startTime: DateTime, $timeRange: Int) {
   quay(id: $id) {
     id
     description
     publicCode
     name
-    estimatedCalls(numberOfDepartures: $numberOfDepartures, startTime: $startTime) {
+    estimatedCalls(
+      numberOfDepartures: $numberOfDepartures
+      startTime: $startTime
+      timeRange: $timeRange
+    ) {
       expectedDepartureTime
       realtime
       quay {

--- a/src/service/impl/departures/gql/jp3/quay-departures.graphql-gen.ts
+++ b/src/service/impl/departures/gql/jp3/quay-departures.graphql-gen.ts
@@ -1,0 +1,58 @@
+import * as Types from '../../../../../graphql/journeyplanner-types_v3';
+
+import { DocumentNode } from 'graphql';
+import gql from 'graphql-tag';
+export type QuayDeparturesQueryVariables = Types.Exact<{
+  id: Types.Scalars['String'];
+  numberOfDepartures?: Types.Maybe<Types.Scalars['Int']>;
+  startTime?: Types.Maybe<Types.Scalars['DateTime']>;
+}>;
+
+
+export type QuayDeparturesQuery = { quay?: Types.Maybe<{ id: string, description?: Types.Maybe<string>, publicCode?: Types.Maybe<string>, name: string, estimatedCalls: Array<Types.Maybe<{ expectedDepartureTime?: Types.Maybe<any>, realtime?: Types.Maybe<boolean>, quay?: Types.Maybe<{ id: string, stopPlace?: Types.Maybe<{ id: string }> }>, destinationDisplay?: Types.Maybe<{ frontText?: Types.Maybe<string> }>, serviceJourney?: Types.Maybe<{ id: string, privateCode?: Types.Maybe<string>, line: { name?: Types.Maybe<string>, id: string, description?: Types.Maybe<string>, publicCode?: Types.Maybe<string>, transportMode?: Types.Maybe<Types.TransportMode>, transportSubmode?: Types.Maybe<Types.TransportSubmode> } }> }>> }> };
+
+
+export const QuayDeparturesDocument = gql`
+    query quayDepartures($id: String!, $numberOfDepartures: Int, $startTime: DateTime) {
+  quay(id: $id) {
+    id
+    description
+    publicCode
+    name
+    estimatedCalls(numberOfDepartures: $numberOfDepartures, startTime: $startTime) {
+      expectedDepartureTime
+      realtime
+      quay {
+        id
+        stopPlace {
+          id
+        }
+      }
+      destinationDisplay {
+        frontText
+      }
+      serviceJourney {
+        id
+        privateCode
+        line {
+          name
+          id
+          description
+          publicCode
+          transportMode
+          transportSubmode
+        }
+      }
+    }
+  }
+}
+    `;
+export type Requester<C= {}> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R>
+export function getSdk<C>(requester: Requester<C>) {
+  return {
+    quayDepartures(variables: QuayDeparturesQueryVariables, options?: C): Promise<QuayDeparturesQuery> {
+      return requester<QuayDeparturesQuery, QuayDeparturesQueryVariables>(QuayDeparturesDocument, variables, options);
+    }
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/src/service/impl/departures/gql/jp3/quay-departures.graphql-gen.ts
+++ b/src/service/impl/departures/gql/jp3/quay-departures.graphql-gen.ts
@@ -6,6 +6,7 @@ export type QuayDeparturesQueryVariables = Types.Exact<{
   id: Types.Scalars['String'];
   numberOfDepartures?: Types.Maybe<Types.Scalars['Int']>;
   startTime?: Types.Maybe<Types.Scalars['DateTime']>;
+  timeRange?: Types.Maybe<Types.Scalars['Int']>;
 }>;
 
 
@@ -13,13 +14,17 @@ export type QuayDeparturesQuery = { quay?: Types.Maybe<{ id: string, description
 
 
 export const QuayDeparturesDocument = gql`
-    query quayDepartures($id: String!, $numberOfDepartures: Int, $startTime: DateTime) {
+    query quayDepartures($id: String!, $numberOfDepartures: Int, $startTime: DateTime, $timeRange: Int) {
   quay(id: $id) {
     id
     description
     publicCode
     name
-    estimatedCalls(numberOfDepartures: $numberOfDepartures, startTime: $startTime) {
+    estimatedCalls(
+      numberOfDepartures: $numberOfDepartures
+      startTime: $startTime
+      timeRange: $timeRange
+    ) {
       expectedDepartureTime
       realtime
       quay {

--- a/src/service/impl/departures/gql/jp3/stops-nearest.graphql
+++ b/src/service/impl/departures/gql/jp3/stops-nearest.graphql
@@ -1,0 +1,39 @@
+query nearestStopPlaces($count: Int = 10, $distance: Float!, $longitude: Float!, $latitude: Float!, $after: String) {
+  nearest(
+    latitude: $latitude
+    longitude: $longitude
+    maximumDistance: $distance
+    first: $count
+    after: $after
+    filterByInUse: true
+    filterByPlaceTypes: stopPlace
+    multiModalMode: parent
+  ) {
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+    edges {
+      node {
+        distance
+        place {
+          ... on StopPlace {
+            name
+            quays(filterByInUse: true) {
+              id
+              description
+              name
+              publicCode
+              stopPlace {
+                id
+              }
+            }
+            transportMode
+            description
+            id
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/service/impl/departures/gql/jp3/stops-nearest.graphql-gen.ts
+++ b/src/service/impl/departures/gql/jp3/stops-nearest.graphql-gen.ts
@@ -1,0 +1,66 @@
+import * as Types from '../../../../../graphql/journeyplanner-types_v3';
+
+import { DocumentNode } from 'graphql';
+import gql from 'graphql-tag';
+export type NearestStopPlacesQueryVariables = Types.Exact<{
+  count?: Types.Maybe<Types.Scalars['Int']>;
+  distance: Types.Scalars['Float'];
+  longitude: Types.Scalars['Float'];
+  latitude: Types.Scalars['Float'];
+  after?: Types.Maybe<Types.Scalars['String']>;
+}>;
+
+
+export type NearestStopPlacesQuery = { nearest?: Types.Maybe<{ pageInfo: { endCursor?: Types.Maybe<string>, hasNextPage: boolean }, edges?: Types.Maybe<Array<Types.Maybe<{ node?: Types.Maybe<{ distance?: Types.Maybe<number>, place?: Types.Maybe<{ name: string, transportMode?: Types.Maybe<Array<Types.Maybe<Types.TransportMode>>>, description?: Types.Maybe<string>, id: string, quays?: Types.Maybe<Array<Types.Maybe<{ id: string, description?: Types.Maybe<string>, name: string, publicCode?: Types.Maybe<string>, stopPlace?: Types.Maybe<{ id: string }> }>>> }> }> }>>> }> };
+
+
+export const NearestStopPlacesDocument = gql`
+    query nearestStopPlaces($count: Int = 10, $distance: Float!, $longitude: Float!, $latitude: Float!, $after: String) {
+  nearest(
+    latitude: $latitude
+    longitude: $longitude
+    maximumDistance: $distance
+    first: $count
+    after: $after
+    filterByInUse: true
+    filterByPlaceTypes: stopPlace
+    multiModalMode: parent
+  ) {
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+    edges {
+      node {
+        distance
+        place {
+          ... on StopPlace {
+            name
+            quays(filterByInUse: true) {
+              id
+              description
+              name
+              publicCode
+              stopPlace {
+                id
+              }
+            }
+            transportMode
+            description
+            id
+          }
+        }
+      }
+    }
+  }
+}
+    `;
+export type Requester<C= {}> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R>
+export function getSdk<C>(requester: Requester<C>) {
+  return {
+    nearestStopPlaces(variables: NearestStopPlacesQueryVariables, options?: C): Promise<NearestStopPlacesQuery> {
+      return requester<NearestStopPlacesQuery, NearestStopPlacesQueryVariables>(NearestStopPlacesDocument, variables, options);
+    }
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/src/service/impl/departures/index.ts
+++ b/src/service/impl/departures/index.ts
@@ -11,6 +11,11 @@ import {
   StopPlaceQuayDeparturesQueryVariables
 } from './gql/jp3/stop-departures.graphql-gen';
 import { getRealtimeDepartureTime } from '../stops/departure-time';
+import {
+  QuayDeparturesDocument,
+  QuayDeparturesQuery,
+  QuayDeparturesQueryVariables
+} from './gql/jp3/quay-departures.graphql-gen';
 
 const ENV = getEnv();
 const topicName = `analytics_departures_search`;
@@ -50,6 +55,29 @@ export default (
           StopPlaceQuayDeparturesQueryVariables
         >({
           query: StopPlaceQuayDeparturesDocument,
+          variables: {
+            id,
+            numberOfDepartures,
+            startTime
+          }
+        });
+
+        if (result.errors) {
+          return Result.err(new APIError(result.errors));
+        }
+
+        return Result.ok(result.data);
+      } catch (error) {
+        return Result.err(new APIError(error));
+      }
+    },
+    async getQuayDepartures({ id, numberOfDepartures = 10, startTime }) {
+      try {
+        const result = await journeyPlannerClient_v3.query<
+          QuayDeparturesQuery,
+          QuayDeparturesQueryVariables
+        >({
+          query: QuayDeparturesDocument,
           variables: {
             id,
             numberOfDepartures,

--- a/src/service/impl/departures/index.ts
+++ b/src/service/impl/departures/index.ts
@@ -44,11 +44,7 @@ export default (
   );
 
   const api: IDeparturesService = {
-    async getStopPlaceQuayDepartures({
-      id,
-      numberOfDepartures = 10,
-      startTime
-    }) {
+    async getStopQuayDepartures({ id, numberOfDepartures = 10, startTime }) {
       try {
         const result = await journeyPlannerClient_v3.query<
           StopPlaceQuayDeparturesQuery,

--- a/src/service/impl/departures/index.ts
+++ b/src/service/impl/departures/index.ts
@@ -67,7 +67,12 @@ export default (
         return Result.err(new APIError(error));
       }
     },
-    async getQuayDepartures({ id, numberOfDepartures = 10, startTime }) {
+    async getQuayDepartures({
+      id,
+      numberOfDepartures = 10,
+      startTime,
+      timeRange = 86400
+    }) {
       try {
         const result = await journeyPlannerClient_v3.query<
           QuayDeparturesQuery,
@@ -77,7 +82,8 @@ export default (
           variables: {
             id,
             numberOfDepartures,
-            startTime
+            startTime,
+            timeRange
           }
         });
 

--- a/src/service/impl/departures/index.ts
+++ b/src/service/impl/departures/index.ts
@@ -57,7 +57,6 @@ export default (
       after
     }) {
       try {
-        console.log('getstopplace');
         const result = await journeyPlannerClient_v3.query<
           NearestStopPlacesQuery,
           NearestStopPlacesQueryVariables

--- a/src/service/impl/departures/index.ts
+++ b/src/service/impl/departures/index.ts
@@ -16,6 +16,11 @@ import {
   QuayDeparturesQuery,
   QuayDeparturesQueryVariables
 } from './gql/jp3/quay-departures.graphql-gen';
+import {
+  NearestStopPlacesDocument,
+  NearestStopPlacesQuery,
+  NearestStopPlacesQueryVariables
+} from './gql/jp3/stops-nearest.graphql-gen';
 
 const ENV = getEnv();
 const topicName = `analytics_departures_search`;
@@ -44,6 +49,39 @@ export default (
   );
 
   const api: IDeparturesService = {
+    async getStopPlacesByPosition({
+      latitude,
+      longitude,
+      distance = 1000,
+      count = 10,
+      after
+    }) {
+      try {
+        console.log('getstopplace');
+        const result = await journeyPlannerClient_v3.query<
+          NearestStopPlacesQuery,
+          NearestStopPlacesQueryVariables
+        >({
+          query: NearestStopPlacesDocument,
+          variables: {
+            latitude,
+            longitude,
+            distance,
+            after,
+            count
+          }
+        });
+
+        if (result.errors) {
+          return Result.err(new APIError(result.errors));
+        }
+
+        return Result.ok(result.data);
+      } catch (error) {
+        return Result.err(new APIError(error));
+      }
+    },
+
     async getStopQuayDepartures({ id, numberOfDepartures = 10, startTime }) {
       try {
         const result = await journeyPlannerClient_v3.query<

--- a/src/service/impl/departures/index.ts
+++ b/src/service/impl/departures/index.ts
@@ -108,7 +108,7 @@ export default (
       id,
       numberOfDepartures = 10,
       startTime,
-      timeRange = 86400
+      timeRange = 86400 // 24 hours
     }) {
       try {
         const result = await journeyPlannerClient_v3.query<

--- a/src/service/interface.ts
+++ b/src/service/interface.ts
@@ -137,7 +137,7 @@ export interface IStopsService {
 }
 
 export interface IDeparturesService {
-  getStopPlaceQuayDepartures(
+  getStopQuayDepartures(
     query: StopPlaceQuayDeparturesQueryVariables
   ): Promise<Result<StopPlaceQuayDeparturesQuery, APIError>>;
   getQuayDepartures(

--- a/src/service/interface.ts
+++ b/src/service/interface.ts
@@ -43,6 +43,10 @@ import {
   StopPlaceQuayDeparturesQueryVariables
 } from './impl/departures/gql/jp3/stop-departures.graphql-gen';
 import * as Trips from '../types/trips';
+import {
+  QuayDeparturesQuery,
+  QuayDeparturesQueryVariables
+} from './impl/departures/gql/jp3/quay-departures.graphql-gen';
 
 export interface IGeocoderService {
   getFeatures(query: FeaturesQuery): Promise<Result<Feature[], APIError>>;
@@ -136,6 +140,9 @@ export interface IDeparturesService {
   getStopPlaceQuayDepartures(
     query: StopPlaceQuayDeparturesQueryVariables
   ): Promise<Result<StopPlaceQuayDeparturesQuery, APIError>>;
+  getQuayDepartures(
+    query: QuayDeparturesQueryVariables
+  ): Promise<Result<QuayDeparturesQuery, APIError>>;
   getDepartureRealtime(
     query: DepartureRealtimeQuery
   ): Promise<Result<DeparturesRealtimeData, APIError>>;

--- a/src/service/interface.ts
+++ b/src/service/interface.ts
@@ -47,6 +47,10 @@ import {
   QuayDeparturesQuery,
   QuayDeparturesQueryVariables
 } from './impl/departures/gql/jp3/quay-departures.graphql-gen';
+import {
+  NearestStopPlacesQuery,
+  NearestStopPlacesQueryVariables
+} from './impl/departures/gql/jp3/stops-nearest.graphql-gen';
 
 export interface IGeocoderService {
   getFeatures(query: FeaturesQuery): Promise<Result<Feature[], APIError>>;
@@ -137,6 +141,9 @@ export interface IStopsService {
 }
 
 export interface IDeparturesService {
+  getStopPlacesByPosition(
+    query: NearestStopPlacesQueryVariables
+  ): Promise<Result<NearestStopPlacesQuery, APIError>>;
   getStopQuayDepartures(
     query: StopPlaceQuayDeparturesQueryVariables
   ): Promise<Result<StopPlaceQuayDeparturesQuery, APIError>>;

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -539,6 +539,37 @@ paths:
           schema:
             type: string
           description: Successful
+  /bff/v2/departures/stops-nearest:
+    get:
+      summary: Get stops geographically nearest to a set of coordinates
+      operationId: getBffV2StopsNearest
+      parameters:
+        - type: number
+          name: latitude
+          in: query
+          required: true
+        - type: number
+          name: longitude
+          in: query
+          required: true
+        - type: number
+          name: distance
+          default: 1000
+          in: query
+        - type: number
+          name: count
+          default: 10
+          in: query
+        - type: string
+          name: after
+          in: query
+      tags:
+        - bff
+      responses:
+        default:
+          schema:
+            type: string
+          description: Successful
   /bff/v2/departures/stop-departures:
     get:
       summary: Get stop with departures for every quay
@@ -556,6 +587,35 @@ paths:
           format: date
           default: '2021-01-27T09:48:19.354Z'
           name: startTime
+          in: query
+      tags:
+        - bff
+      responses:
+        default:
+          schema:
+            type: string
+          description: Successful
+  /bff/v2/departures/quay-departures:
+    get:
+      summary: Get departures from a quay
+      operationId: getBffV2QuayDepartures
+      parameters:
+        - type: string
+          name: id
+          in: query
+          required: true
+        - type: number
+          name: numberOfDepartures
+          default: 5
+          in: query
+        - type: string
+          format: date
+          default: '2021-01-27T09:48:19.330Z'
+          name: startTime
+          in: query
+        - type: number
+          name: timeRange
+          default: 86400
           in: query
       tags:
         - bff


### PR DESCRIPTION
Legger til to endepunkt, som gir data til ny avganger-visning i appen.

- `/bff/v2/departures/quay-departures` 
- `/bff/v2/departures/stops-nearest`

Henger sammen med https://github.com/AtB-AS/mittatb-app/issues/1884 / https://github.com/AtB-AS/mittatb-app/pull/1885 