### PR TITLE
feat: remove unused data from departure queries

### DIFF
--- a/src/service/impl/departures/gql/jp3/quay-departures.graphql
+++ b/src/service/impl/departures/gql/jp3/quay-departures.graphql
@@ -13,18 +13,13 @@ query quayDepartures($id: String!, $numberOfDepartures: Int, $startTime: DateTim
       realtime
       quay {
         id
-        stopPlace {
-          id
-        }
       }
       destinationDisplay {
         frontText
       }
       serviceJourney {
         id
-        privateCode
         line {
-          name
           id
           description
           publicCode

--- a/src/service/impl/departures/gql/jp3/quay-departures.graphql-gen.ts
+++ b/src/service/impl/departures/gql/jp3/quay-departures.graphql-gen.ts
@@ -10,7 +10,7 @@ export type QuayDeparturesQueryVariables = Types.Exact<{
 }>;
 
 
-export type QuayDeparturesQuery = { quay?: Types.Maybe<{ id: string, description?: Types.Maybe<string>, publicCode?: Types.Maybe<string>, name: string, estimatedCalls: Array<Types.Maybe<{ expectedDepartureTime?: Types.Maybe<any>, realtime?: Types.Maybe<boolean>, quay?: Types.Maybe<{ id: string, stopPlace?: Types.Maybe<{ id: string }> }>, destinationDisplay?: Types.Maybe<{ frontText?: Types.Maybe<string> }>, serviceJourney?: Types.Maybe<{ id: string, privateCode?: Types.Maybe<string>, line: { name?: Types.Maybe<string>, id: string, description?: Types.Maybe<string>, publicCode?: Types.Maybe<string>, transportMode?: Types.Maybe<Types.TransportMode>, transportSubmode?: Types.Maybe<Types.TransportSubmode> } }> }>> }> };
+export type QuayDeparturesQuery = { quay?: Types.Maybe<{ id: string, description?: Types.Maybe<string>, publicCode?: Types.Maybe<string>, name: string, estimatedCalls: Array<Types.Maybe<{ expectedDepartureTime?: Types.Maybe<any>, realtime?: Types.Maybe<boolean>, quay?: Types.Maybe<{ id: string }>, destinationDisplay?: Types.Maybe<{ frontText?: Types.Maybe<string> }>, serviceJourney?: Types.Maybe<{ id: string, line: { id: string, description?: Types.Maybe<string>, publicCode?: Types.Maybe<string>, transportMode?: Types.Maybe<Types.TransportMode>, transportSubmode?: Types.Maybe<Types.TransportSubmode> } }> }>> }> };
 
 
 export const QuayDeparturesDocument = gql`
@@ -29,18 +29,13 @@ export const QuayDeparturesDocument = gql`
       realtime
       quay {
         id
-        stopPlace {
-          id
-        }
       }
       destinationDisplay {
         frontText
       }
       serviceJourney {
         id
-        privateCode
         line {
-          name
           id
           description
           publicCode

--- a/src/service/impl/departures/gql/jp3/stop-departures.graphql
+++ b/src/service/impl/departures/gql/jp3/stop-departures.graphql
@@ -8,18 +8,13 @@ query stopPlaceQuayDepartures($id: String!, $numberOfDepartures: Int, $startTime
         realtime
         quay {
           id
-          stopPlace {
-            id
-          }
         }
         destinationDisplay {
           frontText
         }
         serviceJourney {
           id
-          privateCode
           line {
-            name
             id
             description
             publicCode

--- a/src/service/impl/departures/gql/jp3/stop-departures.graphql-gen.ts
+++ b/src/service/impl/departures/gql/jp3/stop-departures.graphql-gen.ts
@@ -9,7 +9,7 @@ export type StopPlaceQuayDeparturesQueryVariables = Types.Exact<{
 }>;
 
 
-export type StopPlaceQuayDeparturesQuery = { stopPlace?: Types.Maybe<{ id: string, quays?: Types.Maybe<Array<Types.Maybe<{ id: string, estimatedCalls: Array<Types.Maybe<{ expectedDepartureTime?: Types.Maybe<any>, realtime?: Types.Maybe<boolean>, quay?: Types.Maybe<{ id: string, stopPlace?: Types.Maybe<{ id: string }> }>, destinationDisplay?: Types.Maybe<{ frontText?: Types.Maybe<string> }>, serviceJourney?: Types.Maybe<{ id: string, privateCode?: Types.Maybe<string>, line: { name?: Types.Maybe<string>, id: string, description?: Types.Maybe<string>, publicCode?: Types.Maybe<string>, transportMode?: Types.Maybe<Types.TransportMode>, transportSubmode?: Types.Maybe<Types.TransportSubmode> } }> }>> }>>> }> };
+export type StopPlaceQuayDeparturesQuery = { stopPlace?: Types.Maybe<{ id: string, quays?: Types.Maybe<Array<Types.Maybe<{ id: string, estimatedCalls: Array<Types.Maybe<{ expectedDepartureTime?: Types.Maybe<any>, realtime?: Types.Maybe<boolean>, quay?: Types.Maybe<{ id: string }>, destinationDisplay?: Types.Maybe<{ frontText?: Types.Maybe<string> }>, serviceJourney?: Types.Maybe<{ id: string, line: { id: string, description?: Types.Maybe<string>, publicCode?: Types.Maybe<string>, transportMode?: Types.Maybe<Types.TransportMode>, transportSubmode?: Types.Maybe<Types.TransportSubmode> } }> }>> }>>> }> };
 
 
 export const StopPlaceQuayDeparturesDocument = gql`
@@ -23,18 +23,13 @@ export const StopPlaceQuayDeparturesDocument = gql`
         realtime
         quay {
           id
-          stopPlace {
-            id
-          }
         }
         destinationDisplay {
           frontText
         }
         serviceJourney {
           id
-          privateCode
           line {
-            name
             id
             description
             publicCode


### PR DESCRIPTION
Det er ikke alle delene av graphQL spørringene som er i bruk i ny avganger visning, så de fjernes her for å spare (litt) på mobildata og minne når det er mange avganger som lastes. 