### PR TITLE
feat: add timeRange parameter to stopPlaceQuayDepartures

### DIFF
--- a/src/api/departures/schema.ts
+++ b/src/api/departures/schema.ts
@@ -14,7 +14,8 @@ export const getStopDeparturesRequest = {
   query: Joi.object({
     id: Joi.string().required(),
     numberOfDepartures: Joi.number().default(5),
-    startTime: Joi.string()
+    startTime: Joi.string(),
+    timeRange: Joi.number()
   })
 };
 

--- a/src/service/impl/departures/gql/jp3/stop-departures.graphql
+++ b/src/service/impl/departures/gql/jp3/stop-departures.graphql
@@ -1,9 +1,9 @@
-query stopPlaceQuayDepartures($id: String!, $numberOfDepartures: Int, $startTime: DateTime) {
+query stopPlaceQuayDepartures($id: String!, $numberOfDepartures: Int, $startTime: DateTime, $timeRange: Int) {
   stopPlace(id: $id) {
     id
     quays(filterByInUse: true) {
       id
-      estimatedCalls(numberOfDepartures: $numberOfDepartures, startTime: $startTime) {
+      estimatedCalls(numberOfDepartures: $numberOfDepartures, startTime: $startTime, timeRange: $timeRange) {
         expectedDepartureTime
         realtime
         quay {

--- a/src/service/impl/departures/gql/jp3/stop-departures.graphql-gen.ts
+++ b/src/service/impl/departures/gql/jp3/stop-departures.graphql-gen.ts
@@ -6,6 +6,7 @@ export type StopPlaceQuayDeparturesQueryVariables = Types.Exact<{
   id: Types.Scalars['String'];
   numberOfDepartures?: Types.Maybe<Types.Scalars['Int']>;
   startTime?: Types.Maybe<Types.Scalars['DateTime']>;
+  timeRange?: Types.Maybe<Types.Scalars['Int']>;
 }>;
 
 
@@ -13,12 +14,16 @@ export type StopPlaceQuayDeparturesQuery = { stopPlace?: Types.Maybe<{ id: strin
 
 
 export const StopPlaceQuayDeparturesDocument = gql`
-    query stopPlaceQuayDepartures($id: String!, $numberOfDepartures: Int, $startTime: DateTime) {
+    query stopPlaceQuayDepartures($id: String!, $numberOfDepartures: Int, $startTime: DateTime, $timeRange: Int) {
   stopPlace(id: $id) {
     id
     quays(filterByInUse: true) {
       id
-      estimatedCalls(numberOfDepartures: $numberOfDepartures, startTime: $startTime) {
+      estimatedCalls(
+        numberOfDepartures: $numberOfDepartures
+        startTime: $startTime
+        timeRange: $timeRange
+      ) {
         expectedDepartureTime
         realtime
         quay {

--- a/src/service/impl/departures/index.ts
+++ b/src/service/impl/departures/index.ts
@@ -81,7 +81,12 @@ export default (
       }
     },
 
-    async getStopQuayDepartures({ id, numberOfDepartures = 10, startTime }) {
+    async getStopQuayDepartures({
+      id,
+      numberOfDepartures = 10,
+      startTime,
+      timeRange
+    }) {
       try {
         const result = await journeyPlannerClient_v3.query<
           StopPlaceQuayDeparturesQuery,
@@ -91,7 +96,8 @@ export default (
           variables: {
             id,
             numberOfDepartures,
-            startTime
+            startTime,
+            timeRange
           }
         });
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -588,6 +588,9 @@ paths:
           default: '2021-01-27T09:48:19.354Z'
           name: startTime
           in: query
+        - type: number
+          name: timeRange
+          in: query
       tags:
         - bff
       responses:


### PR DESCRIPTION
For å gjøre oppførselen mellom `stopPlaceQuayDepartures` og [`quayDepartures`](https://github.com/AtB-AS/atb-bff/blob/master/src/service/impl/departures/gql/jp3/quay-departures.graphql#L1) likere, legger jeg til et `timeRange` parameter. Hvis jeg forstår det riktig, så er det ikke breaking, siden den er optional? 
