### PR TITLE
feat: add aimedDepartureTime to departures queries

### DIFF
--- a/src/graphql/journeyplanner-types_v3.ts
+++ b/src/graphql/journeyplanner-types_v3.ts
@@ -128,6 +128,20 @@ export enum BookingMethod {
   Text = 'text'
 }
 
+export type Branding = {
+  /** Description of branding. */
+  description?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['ID']>;
+  /** URL to an image be used for branding */
+  image?: Maybe<Scalars['String']>;
+  /** Full name to be used for branding. */
+  name?: Maybe<Scalars['String']>;
+  /** Short name to be used for branding. */
+  shortName?: Maybe<Scalars['String']>;
+  /** URL to be used for branding */
+  url?: Maybe<Scalars['String']>;
+};
+
 export type Contact = {
   /** Name of person to contact */
   contactPerson?: Maybe<Scalars['String']>;
@@ -401,6 +415,7 @@ export type Line = {
    * @deprecated BookingArrangements are defined per stop, and can be found under `passingTimes` or `estimatedCalls`
    */
   bookingArrangements?: Maybe<BookingArrangement>;
+  branding?: Maybe<Branding>;
   description?: Maybe<Scalars['String']>;
   /** Type of flexible line, or null if line is not flexible. */
   flexibleLineType?: Maybe<Scalars['String']>;
@@ -1446,10 +1461,7 @@ export type Trip = {
    * @deprecated Use routingErrors instead
    */
   messageStrings: Array<Maybe<Scalars['String']>>;
-  /**
-   * The trip request metadata.
-   * @deprecated Use pageCursor instead
-   */
+  /** The trip request metadata. */
   metadata?: Maybe<TripSearchData>;
   /**
    * Use the cursor to get the next page of results. Use this cursor for the pageCursor parameter in the trip query in order to get the next page.

--- a/src/service/impl/departures/gql/jp3/quay-departures.graphql
+++ b/src/service/impl/departures/gql/jp3/quay-departures.graphql
@@ -10,6 +10,7 @@ query quayDepartures($id: String!, $numberOfDepartures: Int, $startTime: DateTim
       timeRange: $timeRange
     ) {
       expectedDepartureTime
+      aimedDepartureTime
       realtime
       quay {
         id

--- a/src/service/impl/departures/gql/jp3/quay-departures.graphql-gen.ts
+++ b/src/service/impl/departures/gql/jp3/quay-departures.graphql-gen.ts
@@ -10,7 +10,7 @@ export type QuayDeparturesQueryVariables = Types.Exact<{
 }>;
 
 
-export type QuayDeparturesQuery = { quay?: { id: string, description?: string, publicCode?: string, name: string, estimatedCalls: Array<{ expectedDepartureTime?: any, realtime?: boolean, quay?: { id: string }, destinationDisplay?: { frontText?: string }, serviceJourney?: { id: string, line: { id: string, description?: string, publicCode?: string, transportMode?: Types.TransportMode, transportSubmode?: Types.TransportSubmode } } }> } };
+export type QuayDeparturesQuery = { quay?: { id: string, description?: string, publicCode?: string, name: string, estimatedCalls: Array<{ expectedDepartureTime?: any, aimedDepartureTime?: any, realtime?: boolean, quay?: { id: string }, destinationDisplay?: { frontText?: string }, serviceJourney?: { id: string, line: { id: string, description?: string, publicCode?: string, transportMode?: Types.TransportMode, transportSubmode?: Types.TransportSubmode } } }> } };
 
 
 export const QuayDeparturesDocument = gql`
@@ -26,6 +26,7 @@ export const QuayDeparturesDocument = gql`
       timeRange: $timeRange
     ) {
       expectedDepartureTime
+      aimedDepartureTime
       realtime
       quay {
         id

--- a/src/service/impl/departures/gql/jp3/stop-departures.graphql
+++ b/src/service/impl/departures/gql/jp3/stop-departures.graphql
@@ -5,6 +5,7 @@ query stopPlaceQuayDepartures($id: String!, $numberOfDepartures: Int, $startTime
       id
       estimatedCalls(numberOfDepartures: $numberOfDepartures, startTime: $startTime, timeRange: $timeRange) {
         expectedDepartureTime
+        aimedDepartureTime
         realtime
         quay {
           id

--- a/src/service/impl/departures/gql/jp3/stop-departures.graphql-gen.ts
+++ b/src/service/impl/departures/gql/jp3/stop-departures.graphql-gen.ts
@@ -10,7 +10,7 @@ export type StopPlaceQuayDeparturesQueryVariables = Types.Exact<{
 }>;
 
 
-export type StopPlaceQuayDeparturesQuery = { stopPlace?: { id: string, quays?: Array<{ id: string, estimatedCalls: Array<{ expectedDepartureTime?: any, realtime?: boolean, quay?: { id: string }, destinationDisplay?: { frontText?: string }, serviceJourney?: { id: string, line: { id: string, description?: string, publicCode?: string, transportMode?: Types.TransportMode, transportSubmode?: Types.TransportSubmode } } }> }> } };
+export type StopPlaceQuayDeparturesQuery = { stopPlace?: { id: string, quays?: Array<{ id: string, estimatedCalls: Array<{ expectedDepartureTime?: any, aimedDepartureTime?: any, realtime?: boolean, quay?: { id: string }, destinationDisplay?: { frontText?: string }, serviceJourney?: { id: string, line: { id: string, description?: string, publicCode?: string, transportMode?: Types.TransportMode, transportSubmode?: Types.TransportSubmode } } }> }> } };
 
 
 export const StopPlaceQuayDeparturesDocument = gql`
@@ -25,6 +25,7 @@ export const StopPlaceQuayDeparturesDocument = gql`
         timeRange: $timeRange
       ) {
         expectedDepartureTime
+        aimedDepartureTime
         realtime
         quay {
           id


### PR DESCRIPTION
I sammenheng med sak https://github.com/AtB-AS/mittatb-app/issues/2090 trenger man å hente `aimedDepartureTime` som del av query StopPlaceDepartures og QuayDepartures. 

Oppdaterer også genererte JP3 typer i samme slengen. 
