### PR TITLE
chore: Substitution values and env vars

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -15,7 +15,12 @@ steps:
       - gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA
       - --region
       - europe-west1
+      - '--set-env-vars=ENTUR_BASEURL=$_ENTUR_BASEURL,PERIOD_TICKET_INVITE_KEY=$_PERIOD_TICKET_INVITE_KEY,TICKET_INVITE_KEY=$_TICKET_INVITE_KEY'
       - --platform
       - managed
       - --allow-unauthenticated
+substitutions:
+  _ENTUR_BASEURL: 'https://api.staging.entur.io'
+  _PERIOD_TICKET_INVITE_KEY: 'period-ticket-staging'
+  _TICKET_INVITE_KEY: 'ticket-invite-staging'
 timeout: 1500s


### PR DESCRIPTION
Prøver å løse det slik at environment vars blir ikke overskrevet for hver deploy for BFF.

Dette fordrer at substitution variables settes på triggers i Cloud Build CC @mikaelbr 

![image](https://user-images.githubusercontent.com/4932625/152118969-b124ffdb-984a-4d41-b99b-8810936bb956.png)
