### PR TITLE
fix: add + before phone number while creating user as well

### DIFF
--- a/src/api/vipps-login/index.ts
+++ b/src/api/vipps-login/index.ts
@@ -65,7 +65,7 @@ export default (server: Hapi.Server) => () => {
                         return await auth.createCustomToken(user.uid);
                     } catch (error: any) {
                         if (error && error.code && error.code === 'auth/user-not-found') {
-                            const user = await auth.createUser({phoneNumber});
+                            const user = await auth.createUser({phoneNumber: `+${phoneNumber}`});
                             return await auth.createCustomToken(user.uid);
                         }
                         throw error;


### PR DESCRIPTION
Was missing `+`  before phone number while creating a new user.