### PR TITLE
refactor: add publicCode field to favorite departures query

### DIFF
--- a/src/service/impl/departures/gql/jp3/favourite-departure.graphql
+++ b/src/service/impl/departures/gql/jp3/favourite-departure.graphql
@@ -2,6 +2,7 @@ query favouriteDeparture($quayIds: [String], $lines: [ID]) {
   quays(ids: $quayIds) {
     id
     name
+    publicCode
     stopPlace {
       id
       description
@@ -36,4 +37,3 @@ query favouriteDeparture($quayIds: [String], $lines: [ID]) {
     }
   }
 }
-

--- a/src/service/impl/departures/gql/jp3/favourite-departure.graphql-gen.ts
+++ b/src/service/impl/departures/gql/jp3/favourite-departure.graphql-gen.ts
@@ -3,102 +3,60 @@ import * as Types from '../../../../../graphql/journeyplanner-types_v3';
 import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
 export type FavouriteDepartureQueryVariables = Types.Exact<{
-  quayIds?: Types.InputMaybe<
-    | Array<Types.InputMaybe<Types.Scalars['String']>>
-    | Types.InputMaybe<Types.Scalars['String']>
-  >;
-  lines?: Types.InputMaybe<
-    | Array<Types.InputMaybe<Types.Scalars['ID']>>
-    | Types.InputMaybe<Types.Scalars['ID']>
-  >;
+  quayIds?: Types.InputMaybe<Array<Types.InputMaybe<Types.Scalars['String']>> | Types.InputMaybe<Types.Scalars['String']>>;
+  lines?: Types.InputMaybe<Array<Types.InputMaybe<Types.Scalars['ID']>> | Types.InputMaybe<Types.Scalars['ID']>>;
 }>;
 
-export type FavouriteDepartureQuery = {
-  quays: Array<{
-    id: string;
-    name: string;
-    stopPlace?: {
-      id: string;
-      description?: string;
-      name: string;
-      longitude?: number;
-      latitude?: number;
-    };
-    estimatedCalls: Array<{
-      date?: any;
-      expectedDepartureTime: any;
-      aimedDepartureTime: any;
-      quay?: { id: string };
-      destinationDisplay?: { frontText?: string };
-      serviceJourney?: {
-        id: string;
-        line: {
-          id: string;
-          publicCode?: string;
-          transportMode?: Types.TransportMode;
-          transportSubmode?: Types.TransportSubmode;
-          name?: string;
-        };
-      };
-    }>;
-  }>;
-};
+
+export type FavouriteDepartureQuery = { quays: Array<{ id: string, name: string, publicCode?: string, stopPlace?: { id: string, description?: string, name: string, longitude?: number, latitude?: number }, estimatedCalls: Array<{ date?: any, expectedDepartureTime: any, aimedDepartureTime: any, quay?: { id: string }, destinationDisplay?: { frontText?: string }, serviceJourney?: { id: string, line: { id: string, publicCode?: string, transportMode?: Types.TransportMode, transportSubmode?: Types.TransportSubmode, name?: string } } }> }> };
+
 
 export const FavouriteDepartureDocument = gql`
-  query favouriteDeparture($quayIds: [String], $lines: [ID]) {
-    quays(ids: $quayIds) {
+    query favouriteDeparture($quayIds: [String], $lines: [ID]) {
+  quays(ids: $quayIds) {
+    id
+    name
+    publicCode
+    stopPlace {
       id
+      description
       name
-      stopPlace {
+      longitude
+      latitude
+    }
+    estimatedCalls(
+      whiteListed: {lines: $lines}
+      numberOfDepartures: 30
+      numberOfDeparturesPerLineAndDestinationDisplay: 7
+    ) {
+      date
+      expectedDepartureTime
+      aimedDepartureTime
+      quay {
         id
-        description
-        name
-        longitude
-        latitude
       }
-      estimatedCalls(
-        whiteListed: { lines: $lines }
-        numberOfDepartures: 30
-        numberOfDeparturesPerLineAndDestinationDisplay: 7
-      ) {
-        date
-        expectedDepartureTime
-        aimedDepartureTime
-        quay {
+      destinationDisplay {
+        frontText
+      }
+      serviceJourney {
+        id
+        line {
           id
-        }
-        destinationDisplay {
-          frontText
-        }
-        serviceJourney {
-          id
-          line {
-            id
-            publicCode
-            transportMode
-            transportSubmode
-            name
-          }
+          publicCode
+          transportMode
+          transportSubmode
+          name
         }
       }
     }
   }
-`;
-export type Requester<C = {}> = <R, V>(
-  doc: DocumentNode,
-  vars?: V,
-  options?: C
-) => Promise<R>;
+}
+    `;
+export type Requester<C= {}> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R>
 export function getSdk<C>(requester: Requester<C>) {
   return {
-    favouriteDeparture(
-      variables?: FavouriteDepartureQueryVariables,
-      options?: C
-    ): Promise<FavouriteDepartureQuery> {
-      return requester<
-        FavouriteDepartureQuery,
-        FavouriteDepartureQueryVariables
-      >(FavouriteDepartureDocument, variables, options);
+    favouriteDeparture(variables?: FavouriteDepartureQueryVariables, options?: C): Promise<FavouriteDepartureQuery> {
+      return requester<FavouriteDepartureQuery, FavouriteDepartureQueryVariables>(FavouriteDepartureDocument, variables, options);
     }
   };
 }

--- a/src/service/impl/departures/utils/favorites.ts
+++ b/src/service/impl/departures/utils/favorites.ts
@@ -138,6 +138,7 @@ export function extractQuays(queryResults: FavouriteDepartureQuery[]) {
         id: quay!.id, // !bang because stoopid TSC
         name: quay!.name,
         stopPlaceId: quay!.stopPlace?.id,
+        publicCode: quay?.publicCode,
         latitude: quay?.stopPlace?.latitude,
         longitude: quay?.stopPlace?.longitude,
         situations: []


### PR DESCRIPTION
Adds publicCode field to favourite-departure graphql query

Also applies formatting to favourite-departure.graphql-gen.ts, which shouldn't change any functionality.