### PR TITLE
refactor: add realtime field to favorite departure query

### DIFF
--- a/src/service/impl/departures/gql/jp3/favourite-departure.graphql
+++ b/src/service/impl/departures/gql/jp3/favourite-departure.graphql
@@ -18,6 +18,7 @@ query favouriteDeparture($quayIds: [String], $lines: [ID]) {
       date
       expectedDepartureTime
       aimedDepartureTime
+      realtime
       quay {
         id
       }

--- a/src/service/impl/departures/gql/jp3/favourite-departure.graphql-gen.ts
+++ b/src/service/impl/departures/gql/jp3/favourite-departure.graphql-gen.ts
@@ -8,7 +8,7 @@ export type FavouriteDepartureQueryVariables = Types.Exact<{
 }>;
 
 
-export type FavouriteDepartureQuery = { quays: Array<{ id: string, name: string, publicCode?: string, stopPlace?: { id: string, description?: string, name: string, longitude?: number, latitude?: number }, estimatedCalls: Array<{ date?: any, expectedDepartureTime: any, aimedDepartureTime: any, quay?: { id: string }, destinationDisplay?: { frontText?: string }, serviceJourney?: { id: string, line: { id: string, publicCode?: string, transportMode?: Types.TransportMode, transportSubmode?: Types.TransportSubmode, name?: string } } }> }> };
+export type FavouriteDepartureQuery = { quays: Array<{ id: string, name: string, publicCode?: string, stopPlace?: { id: string, description?: string, name: string, longitude?: number, latitude?: number }, estimatedCalls: Array<{ date?: any, expectedDepartureTime: any, aimedDepartureTime: any, realtime: boolean, quay?: { id: string }, destinationDisplay?: { frontText?: string }, serviceJourney?: { id: string, line: { id: string, publicCode?: string, transportMode?: Types.TransportMode, transportSubmode?: Types.TransportSubmode, name?: string } } }> }> };
 
 
 export const FavouriteDepartureDocument = gql`
@@ -32,6 +32,7 @@ export const FavouriteDepartureDocument = gql`
       date
       expectedDepartureTime
       aimedDepartureTime
+      realtime
       quay {
         id
       }

--- a/src/service/impl/departures/index.ts
+++ b/src/service/impl/departures/index.ts
@@ -135,6 +135,7 @@ export default (
                   serviceDate: call.date,
                   time: call.expectedDepartureTime,
                   situations: [],
+                  realtime: call.realtime,
                   serviceJourneyId: call.serviceJourney?.id
                 });
             });


### PR DESCRIPTION
Adds realtime field to the favorite deparure query, in order to show "ca." on the correct departures

Fixes comment from QA https://github.com/AtB-AS/kundevendt/issues/1877#issuecomment-1240321388 (@HanneLH)