### PR TITLE
Disable caching in graphql-client

### DIFF
--- a/src/graphql/graphql-client.ts
+++ b/src/graphql/graphql-client.ts
@@ -12,11 +12,11 @@ import { ENTUR_BASEURL, ET_CLIENT_NAME } from '../config/env';
 
 const defaultOptions: DefaultOptions = {
   watchQuery: {
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'no-cache',
     errorPolicy: 'ignore'
   },
   query: {
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'no-cache',
     errorPolicy: 'all'
   }
 };


### PR DESCRIPTION
We discovered numerous issues around caching when deploying the bff to our own cluster.

We didn't specify any resource limits for the pods initially, but started observing unbounded memory growth. 

![Screenshot 2022-09-28 at 13 24 45](https://user-images.githubusercontent.com/13596984/192767057-71725fbc-a42d-4589-a03f-42bd75210bd8.png)
![Screenshot 2022-09-28 at 13 26 31](https://user-images.githubusercontent.com/13596984/192767431-1ba380cd-1426-4179-b8d2-0fdfcc5ef791.png)

We applied some limits on both cpu and memory and observed that the node process was not able to respond to liveness probes from the cluster in a timely manner when CPU was throttled. This resulted in repeated restarts. CPU usage seemed to increase with memory growth.

After changing the deployment to use an image with the changes proposed in this PR, memory and cpu usage plummeted.