### PR TITLE
test: api-tests for bff

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -1,0 +1,47 @@
+name: API-tests
+
+on:
+  #push:
+  #  branches:
+  #    - tor/api-tests
+  workflow_dispatch:
+
+jobs:
+  api-test:
+    name: API-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: tor/api-tests
+
+      - name: Install k6
+        run: |
+          curl https://github.com/grafana/k6/releases/download/v0.40.0/k6-v0.40.0-linux-amd64.tar.gz -L | tar xvz --strip-components 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+          cache: 'pip'
+
+      - name: Run API tests
+        working-directory: test
+        run: |
+          ./k6 run k6.js --config=config/functional.json --env environment=staging --log-output=stdout --logformat=raw | tee results/junitLog.txt
+
+      - name: Create JUnit from checks
+        run: python python-tools/apiCheckToJUnit/apiCheckToJUnit.py --file junitLog.txt --folder results
+        working-directory: test
+
+      - name: Create JUnit from checks
+        run: python python-tools/combineJUnit/combineJUnit.py --files junit_bff.xml,junitFromChecks.xml --folder results
+        working-directory: test
+
+      - name: Upload test report json
+        uses: actions/upload-artifact@v3
+        with:
+          name: junit-results
+          path: ./test/results/*.xml
+          retention-days: 5

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,4 @@
+.idea
+*.iml
+config/auth.json
+logg.txt

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,50 @@
+# API tests
+
+API-tests of the BFF. The tests are scripted in JavaScript and run by the k6 test tool (https://k6.io/docs/), 
+which mainly is used for performance testing - i.e. enables the API-tests also to be used for performance. 
+
+### Run modes
+- Functional test: 1 user and 1 iteration
+- Performance test: X users over Y seconds (see _config/performance.json_)
+  - _CURRENTLY NOT FULLY SUPPORTED_
+  
+### API-tests
+Each BFF endpoint is run with a list of assertions. These are structured in folders `v1` and `v2`.
+
+The configuration of the tests are located in `config/functional.json`, and environments in `config/env.json`.
+
+### Commands
+Run functional tests - default: 1 user, 1 iteration, "bff" usecase
+```bash
+$  k6 run k6.js --config=config/functional.json --env environment=[staging, prod]
+```
+
+Run performance test (NOT FULLY SUPPORTED) - default: 5 user, 300s duration + ramp-up/-down, "bffPerformanceTest" usecase
+```bash
+$  k6 run k6.js --config=config/performance.json --env environment=[staging, prod] --env performanceTest=true
+```
+
+Github Actions run with a console log print to file for JUnit creation of the assertion results. Resulting JUnit file
+will be stored in `results/combinedJUnit.xml` (see also `.github/workflows/api-tests.yml`).
+```bash
+$  k6 run k6.js --config=config/functional.json --env environment=[staging, prod]
+$  python3 python-tools/apiCheckToJUnit/apiCheckToJUnit.py --file junitLog.txt --folder results
+$  python3 python-tools/combineJUnit/combineJUnit.py --files junit_bff.xml,junitFromChecks.xml --folder results
+```
+
+### Detailed output
+For detailed output, use (also see _k6.json#handleSummary()_)
+```bash
+$  k6 run k6.js --config=config/functional.json  --env environment=[staging, prod] --out csv=results/output.csv
+or
+$  k6 run k6.js --config=config/functional.json  --env environment=[staging, prod] --out json=results/output.json
+```
+For debugging
+```bash
+$  k6 run k6.js --config=config/functional.json --env environment=[staging, prod] [--http-debug || --http-debug="full"]
+```
+
+### Performance test metrics
+All request names are defined in _config/configuration.js#reqNameList_, and gives:
+- response time trends per request
+- successful rate per request

--- a/test/aClass.js
+++ b/test/aClass.js
@@ -1,0 +1,34 @@
+/*
+Ticket information to use in other scenarios
+ */
+
+let AClass = null
+
+export const ticketData = {
+    creatTicket: (orderId, paymentId, transactionId, netsTransactionId) => AClass = new Ticket(orderId, paymentId, transactionId, netsTransactionId),
+    orderId: () => AClass.getOrderId(),
+    paymentId: () => AClass.getPaymentId(),
+    transactionId: () => AClass.getTransactionId(),
+    netsTransactionId: () => AClass.getNetsTransactionId()
+}
+
+class Ticket {
+    constructor(orderId, paymentId, transactionId, netsTransactionId) {
+        this.orderId = orderId
+        this.paymentId = paymentId
+        this.transactionId = transactionId
+        this.netTransactionId = netsTransactionId
+    }
+    getOrderId(){
+        return this.orderId
+    }
+    getPaymentId(){
+        return this.paymentId
+    }
+    getTransactionId(){
+        return this.transactionId
+    }
+    getNetsTransactionId(){
+        return this.netTransactionId
+    }
+}

--- a/test/config/configuration.js
+++ b/test/config/configuration.js
@@ -1,0 +1,200 @@
+/*
+Configuration that makes parameters from config file available
+ */
+
+import { Rate, Counter, Trend } from "k6/metrics";
+import {check as loadTestingCheck} from "k6";
+import {logResults} from "../utils/log.js";
+
+
+let env = __ENV.environment || "staging"
+let envHosts = JSON.parse(open('env.json'))
+let performanceTest = __ENV.performanceTest === "true" || false
+//Default options are different for perfTest or not - vu/duration/iteration can be overrun by cli options
+let options = performanceTest ? JSON.parse(open('performance.json')) : JSON.parse(open('functional.json'));
+
+// *** Individual Trend metrics per request name ***
+// There may come changes that allows sub-metrics in the summary without specifying these in 'thresholds'.
+// This can simplify the need of creating Trends per reqName by adding to a common Trend with reqName tags (https://github.com/k6io/k6/issues/1321)
+//let reqNameList = ["realtime"]
+let reqNameList = []
+let reqNameTrend = {}
+// Initializes each reqName's corresponding Trend
+export function setupReqNameTrends(){
+    reqNameList.forEach(item => {
+        reqNameTrend[item] = new Trend("trend_req_" + item)
+    })
+}
+// ***
+
+// *** Functional: Add failed counter ***
+let failureCount = new Counter("reqs_failed")
+
+// *** Performance: Add success rates per group ***
+// See comments under 'Individual Trend metrics per request name'
+let successRates = {}
+// Initializes each group's corresponding success Rate
+export function setupSuccessRates(){
+    reqNameList.forEach(item => {
+        successRates[item] = new Rate("rate_req_success_" + item)
+    })
+}
+// ***
+
+//Configuration parameters for others to use
+export const conf = {
+    env: () => env,
+    host: () => envHosts.environments[env].host,
+    usecase: () => __ENV.usecase || options.usecase,
+    isPerformanceTest: () => performanceTest,
+    includeJunit: () => __ENV.junitCheckOutput || options.junitCheckOutput,
+}
+
+//Make metrics available
+export const metrics = {
+    // Performance: Add delay to request name Trend metric
+    log: (requestName, delay) => {
+        if (reqNameList.includes(requestName)){
+            reqNameTrend[requestName].add(delay)
+        }
+        else {
+            reqNameTrend["unknown"].add(delay)
+        }
+    },
+    //Manually add to failure rates
+    addFailure: (requestName) => {
+        if (conf.isPerformanceTest()) {
+            if (requestName in successRates) {
+                successRates[requestName].add(false)
+            } else {
+                successRates["unknown"].add(false)
+            }
+            successRates["all"].add(false)
+        }
+        else {
+            failureCount.add(true)
+        }
+    },
+    //Add to failure rate if check is false
+    addFailureIf: (requestName, check, expect = false) => {
+        if (conf.isPerformanceTest()) {
+            if (requestName in successRates) {
+                successRates[requestName].add(expect)
+            } else {
+                successRates["unknown"].add(expect)
+            }
+            successRates["all"].add(expect)
+        }
+        else {
+            failureCount.add(!expect)
+        }
+        return expect
+    },
+    //Add to failure rate if one of multiple checks is false
+    //Format: [{'check': '<description>', 'expect': '<check>'}, {...}, ...]
+    addFailureIfMultipleChecks: (obj, requestName, expectsArray) => {
+        let failureArray = []
+        let passArray = []
+
+        let expect = expectsArray.every((value) => {
+            return (value.expect === true);
+        });
+        if (!expect){
+            expectsArray.filter(item => {
+                if (!item.expect) {
+                    //console.log("[ERROR CHECK 1] [requestName] " + requestName + " [checks] " + item.check)
+                    failureArray.push(item.check)
+                    //logResults(requestName, obj.request.url, obj.timings.duration, [item.check], []);
+                }
+            })
+        }
+        else {
+            //console.log("[SUCCESS CHECK 1] [requestName] " + requestName)
+            passArray.push('all checks successful')
+            //logResults(requestName, obj.request.url, obj.timings.duration, [], [requestName]);
+        }
+
+        //Log (and print) individual failed checks if enabled for functional tests
+        if (!conf.isPerformanceTest() && conf.includeJunit) {
+            logResults(requestName, obj.request.url, obj.timings.duration, failureArray, passArray);
+        }
+
+        if (conf.isPerformanceTest()) {
+            if (requestName in successRates) {
+                successRates[requestName].add(expect)
+            } else {
+                successRates["unknown"].add(expect)
+            }
+            successRates["all"].add(expect)
+        }
+        else {
+            failureCount.add(!expect)
+        }
+        return expect
+    },
+    //Re-define check from k6: add failure if check fails
+    //if junitCheckOutput == true: log check to output at the end of test to be added in junit results
+    //NOTE: This is used for performance tests. If 'addFailureIfMultipleChecks' instead, add perfTest checks in there
+    check: (obj, requestName = "", expectedStatus = 200, conditionArray, url = "", delay = 0) => {
+        let failuresArray = [];
+        let passesArray = [];
+
+        //Expected status is checked for all requests - independent of scenario
+        let result = loadTestingCheck(
+            obj,
+            { "expected status": (r) => r.status === expectedStatus },
+            requestName || {}
+        );
+        //Add to functional failed checks
+        if (!result) {
+            failuresArray.push("expected status is " + expectedStatus);
+        } else {
+            passesArray.push("expected status is " + expectedStatus);
+        }
+        //All checks if functional test is enabled
+        if (!conf.isPerformanceTest()) {
+            //Print individual failed check if enabled
+            if (conf.includeJunit) {
+                for (let check in Object.keys(conditionArray)) {
+                    if (
+                        !loadTestingCheck(
+                            obj,
+                            { check: Object.values(conditionArray)[check] },
+                            requestName || {}
+                        )
+                    ) {
+                        result = false;
+                        failuresArray.push(Object.keys(conditionArray)[check].toString());
+                    } else {
+                        passesArray.push(Object.keys(conditionArray)[check].toString());
+                    }
+                }
+            }
+            //Use default check summary - no printing of individual failed checks
+            else {
+                result = loadTestingCheck(obj, conditionArray, requestName || {});
+            }
+        }
+
+        //Log (and print) individual failed checks if enabled for functional tests
+        if (!conf.isPerformanceTest() && conf.includeJunit) {
+            logResults(requestName, url, delay, failuresArray, passesArray);
+        }
+
+        //Report on success/fail
+        if (conf.isPerformanceTest()) {
+            if (requestName in successRates) {
+                successRates[requestName].add(result)
+            } else {
+                successRates["unknown"].add(result)
+            }
+            //Also possible to add a tag to differentiate on e.g. scenario (see thresholds)
+            //successRates["all"].add(result, {mode: conf.isPerformanceTest() ? "performance" : "functional"})
+            successRates["all"].add(result)
+        }
+        else {
+            failureCount.add(!result)
+        }
+        return result
+    }
+}

--- a/test/config/env.json
+++ b/test/config/env.json
@@ -1,0 +1,10 @@
+{
+  "environments" : {
+    "staging" :{
+      "host": "https://api.staging.mittatb.no"
+    },
+    "prod" :{
+      "host": "https://api.prod.mittatb.no"
+    }
+  }
+}

--- a/test/config/functional.json
+++ b/test/config/functional.json
@@ -1,0 +1,11 @@
+{
+  "vus": 1,
+  "iterations": 1,
+  "usecase": "bff",
+  "summaryTrendStats": ["avg", "min", "med", "max", "p(95)", "p(99)", "count"],
+  "thresholds": {
+    "http_req_duration{scenario:default}": ["avg < 3000", "p(95) < 5000"],
+    "reqs_failed": ["count == 0"]
+  },
+  "junitCheckOutput": true
+}

--- a/test/config/performance.json
+++ b/test/config/performance.json
@@ -1,0 +1,25 @@
+{
+  "usecase": "bffPerformanceTest",
+  "summaryTrendStats": ["avg", "min", "med", "max", "p(95)", "p(99)", "count"],
+  "stages": [
+    {
+      "duration": "20s",
+      "target": 20
+    },
+    {
+      "duration": "10m",
+      "target": 20
+    },
+    {
+      "duration": "20s",
+      "target": 0
+    }
+  ],
+  "thresholds": {
+    "http_req_duration": ["avg < 2000", "p(95) < 5000"],
+    "http_req_duration{name:getStatus}": ["avg > 0"],
+    "http_req_duration{name:getHealth}": ["avg > 0"],
+    "reqs_success_all": ["rate > 0.95"]
+  },
+  "junitCheckOutput": false
+}

--- a/test/k6.js
+++ b/test/k6.js
@@ -1,0 +1,78 @@
+/*
+- Functional test: 1 user and 1 iteration
+- Performance test: X users over Y seconds (see config/performance.json)
+    - NB! NOT FULLY SUPPORTED at the moment
+
+Run (functional tests) - default: 1 user, 1 iteration
+$  k6 run k6.js --config=config/functional.json --env environment=[staging, prod] --env usePhoneLogIn=true
+Run (performance test) - default: 5 user, 300s duration + ramp-up/-down, "bffPerformanceTest" usecase
+$  k6 run k6.js --config=config/performance.json --env environment=[staging, prod] --env performanceTest=true
+
+With detailed output (see k6.json#handleSummary())
+$  k6 run k6.js --config=config/functional.json  --env environment=[staging, prod] --out csv=results/output.csv
+Debugging
+$  k6 run k6.js --config=config/functional.json --env environment=[staging, prod] [--http-debug || --http-debug="full"]
+
+Metrics (only performance tests):
+- response time trends per request
+- successful rate per request
+--> all request names are defined in 'config/configuration.js#reqNameList)
+ */
+
+import { sleep } from 'k6';
+import {conf} from './config/configuration.js'
+import {scn} from "./scenario.js";
+import {createJUnitCheckOutput} from "./utils/log.js";
+//WIP
+import { jUnit, textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
+
+//Performance: Setup a Trend metric per request name from conf/configuration.reqNameList
+//setupReqNameTrends()
+//Performance: Setup a Rate metric per group name from conf/configuration.groupList
+//setupSuccessRates()
+
+//Settings for the simulation
+export let options = {
+    //vus / duration / iterations set in config file depending on performance test or not (can be overrun by cli options)
+    //All custom metrics are defined in 'conf/configuration.js'
+
+    //thresholds are set in config file (config/functional.json and config/performance.json)
+};
+
+//Before the simulation starts
+export function setup() {
+    console.log("Setup")
+    console.log("  -- Usecase: " + conf.usecase());
+    console.log("  -- Environment: " + conf.host());
+}
+
+//Run simulations
+export default function () {
+    //Set up the tests for each VU in the first iteration
+    if (__ITER === 0){
+        //Any initialization
+    }
+    //Run usecase as defined from config - or cli
+    scn[conf.usecase()]()
+
+    //Create JUnit log lines for a post-k6 to pick up
+    if (!conf.isPerformanceTest() && conf.includeJunit()) {
+        createJUnitCheckOutput();
+    }
+}
+
+//Handle reporting
+export function handleSummary(data) {
+    console.log('Preparing the end-of-test summary...');
+
+    return {
+        'stdout': textSummary(data, { indent: ' ', enableColors: true}),
+        'results/junit_bff.xml': jUnit(data),
+        'results/summary_bff.json': JSON.stringify(data),
+    }
+}
+
+//After the simulation ends
+export function teardown() {
+    console.log("Teardown")
+}

--- a/test/python-tools/.gitignore
+++ b/test/python-tools/.gitignore
@@ -1,0 +1,5 @@
+*.json
+*.xml
+*.png
+*.html
+*.csv

--- a/test/python-tools/apiCheckToJUnit/apiCheckToJUnit.py
+++ b/test/python-tools/apiCheckToJUnit/apiCheckToJUnit.py
@@ -1,0 +1,274 @@
+import getopt
+import sys
+import os
+import re
+import xml.etree.ElementTree as ET
+
+'''
+# Create a JUnit file based on console output of a specific format from a k6 test
+$  k6 run tests.js --config=config/functional.json --env environment=staging --env junitCheckOutput=true --log-output=stdout --logformat=raw 2> junitLog.txt
+or
+$  k6 run tests.js --config=config/functional.json --env environment=staging --env junitCheckOutput=true --log-output=stdout --logformat=raw | tee junitLog.txt
+
+# Start
+$ apiCheckToJUnit.py --file <txt file with log> --folder <folder for input file and store junit xml>
+    -> file: file + extension
+    -> folder: path (relative is OK)
+
+# Note
+- The scripts look for prefix [junit] in the txt file
+    example ->
+    [junit][pass] true [req] searchByOrgNo [url] https://...search=NO985815534&limit=2 [check] expected status is 200 [delay] 604.064
+    [junit][pass] false [req] searchByOrgNo [url] https://...search=NO985815534&limit=2 [check] is valid [delay] 604.064
+    ...
+- The output Junit XML is with only one testsuite
+    - originally made accoring to format for Azure Pipeline (https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/test/publish-test-results?view=azure-devops&tabs=junit%2Cyaml#result-formats-mapping)
+    -> createJunit()
+    -> Also available method for one testsuites per reqName: createJunitManyTestsuites()
+    
+# Example
+$ python3 python-tools/apiCheckToJUnit/apiCheckToJUnit.py --file junitLog.txt --folder api-tests/src/main/k6/results
+
+# Output as JUnit xml
+Creates a testsuite with testcases for each test
+-> {folder}/junitFromChecks.xml
+'''
+
+
+def main(argv):
+    # Init parameters
+    file = ''
+    folder = ''
+    abs1 = False
+    abs2 = False
+
+    # Input parameters
+    try:
+        opts, args = getopt.getopt(argv, "", ["file=", "folder="])
+    except getopt.GetoptError:
+        print('apiCheckToJUnit.py --file <txt file with log> --folder <folder for input file and store junit xml>')
+        sys.exit()
+    for opt, arg in opts:
+        if opt == '--file':
+            file = arg
+            abs1 = True
+        elif opt == '--folder':
+            folder = arg
+            abs2 = True
+    # Check that the non optional parameters are set
+    if not abs1 or not abs2:
+        print('Missing "--file" and/or "--folder" parameter')
+        print('apiCheckToJUnit.py --file <txt file with log> --folder <folder for input file and store junit xml>')
+        sys.exit()
+    # Check that file exists
+    if not os.path.isfile(folder + "/" + file):
+        print("File {} does not exist. Exiting...".format(folder + "/" + file))
+        sys.exit()
+
+    # Working varaiables
+    inputFile = "{}/{}".format(folder, file)
+    junitFile = "{}/junitFromChecks.xml".format(folder)
+    apiChecks = {}
+
+    # Read log file and find all [junit] log items
+    # [junit][pass] false [req] searchByName [url] https://... [check] expected status is 200
+    with open(inputFile) as logFile:
+        for line in logFile:
+            if re.search("^\\[junit\\].*$", line):
+                # Classify by reqName and check for pass true | false
+                # msg = re.findall("\\[junit\\]\\[pass\\]\\s(.*)\\s\\[req\\]\\s(.*)\\s\\[url\\]\\s(.*)\\s\\[check\\]\\s(.*)", line)[0]
+                msg = re.findall("\\[junit\\]\\[pass\\]\\s(.*)\\s\\[req\\]\\s(.*)\\s\\[url\\]\\s(.*)\\s\\[check\\]\\s(.*)\\s\\[delay\\]\\s(.*)", line)[0]
+                result = str(msg[0])
+                reqName = str(msg[1])
+                url = str(msg[2])
+                check = str(msg[3])
+                # From ms to seconds
+                delaySecArray = str(float(msg[4]) / 1000).split(".")
+                delay = delaySecArray[0] + "." + delaySecArray[1][0:3]
+                if reqName not in apiChecks.keys():
+                    apiChecks[reqName] = {check: {url: [result, delay]}}
+                else:
+                    reqNameDict = apiChecks[reqName]
+                    if check not in reqNameDict.keys():
+                        reqNameDict[check] = {url: [result, delay]}
+                    else:
+                        # NOTE! If same url is used for a given reqName and check (i.e. random test data); the result=false will be chosen (if exists), else true (cannot store both in a Dict)
+                        checkDict = reqNameDict[check]
+                        if url in checkDict.keys():
+                            if checkDict[url][0] == "true":
+                                checkDict[url] = [result, delay]
+                        else:
+                            checkDict[url] = [result, delay]
+                        reqNameDict[check] = checkDict
+                    apiChecks[reqName] = reqNameDict
+
+
+    for reqName in apiChecks.keys():
+        for check in apiChecks[reqName].keys():
+            for url in apiChecks[reqName][check].keys():
+                print("[req] {} [check] {} [url] {} [pass] {} [delay] {}".format(reqName, check, url, apiChecks[reqName][check][url][0], apiChecks[reqName][check][url][1]))
+
+
+    # testsuites = createJunitManyTestsuites(apiChecks)
+    testsuites = createJunit(apiChecks)
+
+    # Write JUnit XML
+    tree = ET.ElementTree(testsuites)
+    tree.write(junitFile, encoding="UTF-8", xml_declaration=True)
+
+
+# Based on format: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/test/publish-test-results?view=azure-devops&tabs=junit%2Cyaml#result-formats-mapping
+# https://junit.sourceforge.net/doc/faq/faq.htm#tests_12: Only 1 failure per testcase
+def createJunit(apiChecks):
+    # JUnit structure (can be duplicate testcase.names if different test data is used for same requests)
+    '''
+    <testsuites ...>
+        <testsuite name="k6 checks" ...>
+            <testcase name="reqName1: expected status" ...>
+                <failure message="check failed for [req] reqName1 [check] expected status">
+                    http://.../1
+                </failure>
+            </testcase>
+            <testcase name="reqName1: correct no hits" ...>
+                <failure message="check failed for [req] reqName1 [check] correct no hits">
+                    http://.../2
+                </failure>
+            </testcase>
+            <testcase name="reqName1: expected status" .../>
+            <testcase name="reqName1: correct no hits" ...>
+            <testcase name="reqName2: expected status" .../>
+            <testcase name="reqName2: correct no hits" ...>
+            ...
+        </testsuite>
+    </testsuites>
+    '''
+
+    # Create JUnit XML
+    testsuites = ET.Element('testsuites')
+    testsuite = ET.SubElement(testsuites, 'testsuite')
+    testsuite.set('name', "k6 checks")
+    noTests = 0
+    noFailures = 0
+
+    for reqName in apiChecks.keys():
+        for check in apiChecks[reqName].keys():
+            for url in apiChecks[reqName][check].keys():
+                testcase = ET.SubElement(testsuite, 'testcase')
+                testcase.set('name', "{}: {}".format(reqName, check))
+                testcase.set('classname', "{}".format(reqName))
+                testcase.set('time', "{}".format(apiChecks[reqName][check][url][1]))
+                noTests += 1
+                if apiChecks[reqName][check][url][0] == "false":
+                    noFailures += 1
+                    failure = ET.SubElement(testcase, 'failure')
+                    failure.set('message', "check failed for [req] {} [check] {}".format(reqName, check))
+                    failure.text = 'failed url: {}'.format(url)
+
+        testsuite.set('tests', str(noTests))
+        testsuite.set('failures', str(noFailures))
+
+    testsuites.set('tests', str(noTests))
+    testsuites.set('failures', str(noFailures))
+
+    return testsuites
+
+
+# Not used
+def createJunitManyTestsuites(apiChecks):
+    # JUnit structure
+    '''
+    <testsuites ...>
+        <testsuite name="k6 check: reqName1" ...>
+            <testcase name="expected status" ...>
+                <failure message="http://.../1"/>
+                <failure message="http://.../2"/>
+            </testcase>
+            <testcase name="correct no hits" ...>
+                <failure message="http://.../1"/>
+            </testcase>
+        </testsuite>
+        <testsuite name="k6 check: reqName2" ...>
+            ...
+        </testsuite>
+    </testsuites>
+    '''
+
+    # Create JUnit XML
+    testsuites = ET.Element('testsuites')
+    noTestsOverall = 0
+    noFailuresOverall = 0
+
+    for reqName in apiChecks.keys():
+        noTests = 0
+        noFailures = 0
+
+        testsuite = ET.SubElement(testsuites, 'testsuite')
+        testsuite.set('name', "k6 checks: {}".format(reqName))
+        # NOTE: Only one testcase per reqName:check independent of used for different urls (due to random test data)
+        for check in apiChecks[reqName].keys():
+            testcase = ET.SubElement(testsuite, 'testcase')
+            testcase.set('name', check)
+            testcase.set('classname', reqName)
+            failureText = ""
+            delay = []
+            for url in apiChecks[reqName][check].keys():
+                noTests += 1
+                delay.append(float(apiChecks[reqName][check][url][1]))
+                if apiChecks[reqName][check][url][0] == "false":
+                    noFailures += 1
+                    failureText += url + " \n"
+            # Set failure if any
+            if (len(failureText) > 0):
+                failure = ET.SubElement(testcase, 'failure')
+                failure.set('message', "check failed for [req] {} [check] {}".format(reqName, check))
+                failure.text = 'failed url(s): \n {}'.format(failureText)
+            # Set delay to max of the urls used for this check
+            testcase.set('time', str(max(delay)))
+
+        testsuite.set('tests', str(noTests))
+        testsuite.set('failures', str(noFailures))
+        noTestsOverall += noTests
+        noFailuresOverall += noFailures
+
+    testsuites.set('tests', str(noTestsOverall))
+    testsuites.set('failures', str(noFailuresOverall))
+
+    return testsuites
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])
+
+'''
+PRE
+    # Working varaiables
+    inputFile = "{}/{}".format(folder, file)
+    junitFile = "{}/junitFromChecks.xml".format(folder)
+    apiErrors = []
+
+    # Read log file and find all [junit] log items
+    with open(inputFile) as logFile:
+        for line in logFile:
+            if re.search("^\\[junit\\].*$", line):
+                msg = str(re.findall("\\[junit\\](.*)", line)[0])
+                apiErrors.append(msg)
+
+    # Create JUnit XML
+    testsuites = ET.Element('testsuites')
+    testsuite = ET.SubElement(testsuites, 'testsuite')
+
+    for msg in apiErrors:
+        testcase = ET.SubElement(testsuite, 'testcase')
+        testcase.set('name', str(msg))
+        failure = ET.SubElement(testcase, 'failure')
+        failure.set('message', 'failed')
+    testsuite.set('name', "k6 failed checks")
+    testsuite.set('tests', str(len(apiErrors)))
+    testsuite.set('failures', str(len(apiErrors)))
+    testsuites.set('tests', str(len(apiErrors)))
+    testsuites.set('failures', str(len(apiErrors)))
+
+    # Write JUnit XML
+    tree = ET.ElementTree(testsuites)
+    tree.write(junitFile, encoding="UTF-8", xml_declaration=True)
+'''

--- a/test/python-tools/combineJUnit/combineJUnit.py
+++ b/test/python-tools/combineJUnit/combineJUnit.py
@@ -1,0 +1,76 @@
+import getopt
+import sys
+import os
+import xml.etree.ElementTree as ET
+
+'''
+# Combines one or more JUnit XML files into one JUnit XML
+
+# Start
+$ combineJUnit.py --files <list of JUnit xml files separated with ","> --folder <folder for input files and combined JUnit xml>
+    -> files: files + extension separated by ','
+    -> folder: path (relative is OK)
+
+# Example
+$ python3 python-tools/combineJUnit/combineJUnit.py --files junit_1.xml,junit_2.xml --folder api-tests/src/main/k6/results
+
+# Output as JUnit xml
+-> {folder}/combinedJUnit.xml
+'''
+
+
+def main(argv):
+    # Init parameters
+    files = []
+    folder = ''
+    abs1 = False
+    abs2 = False
+
+    # Input parameters
+    try:
+        opts, args = getopt.getopt(argv, "", ["files=", "folder="])
+    except getopt.GetoptError:
+        print('combineJUnit.py --files <list of JUnit xml files separated with ","> --folder <folder for input files and combined JUnit xml>')
+        sys.exit()
+    for opt, arg in opts:
+        if opt == '--files':
+            for file in str(arg).split(","):
+                files.append(file)
+            abs1 = True
+        elif opt == '--folder':
+            folder = arg
+            abs2 = True
+    # Check that the non optional parameters are set
+    if not abs1 or not abs2:
+        print('Missing "--files" and/or "--folder" parameter')
+        print('combineJUnit.py --files <list of JUnit xml files separated with ","> --folder <folder for input files and combined JUnit xml>')
+        sys.exit()
+    # Check that files exist
+    for file in files:
+        if not os.path.isfile(folder + "/" + file):
+            print("File {} does not exist. Exiting...".format(folder + "/" + file))
+            sys.exit()
+
+    # XML output
+    testsuitesOut = ET.Element('testsuites')
+    failures = 0
+    tests = 0
+
+    # Parse XML input files
+    for file in files:
+        treeIn = ET.parse('{}/{}'.format(folder, file))
+        testsuites = treeIn.getroot()
+        for testsuite in testsuites:
+            tests += int(testsuite.get('tests'))
+            failures += int(testsuite.get('failures'))
+            testsuitesOut.append(testsuite)
+    testsuitesOut.set('tests', str(tests))
+    testsuitesOut.set('failures', str(failures))
+
+    # Write combined XML
+    treeOut = ET.ElementTree(testsuitesOut)
+    treeOut.write("{}/combinedJUnit.xml".format(folder), encoding="UTF-8", xml_declaration=True)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/test/results/.gitignore
+++ b/test/results/.gitignore
@@ -1,0 +1,4 @@
+*.json
+*.xml
+*.csv
+*.txt

--- a/test/scenario.js
+++ b/test/scenario.js
@@ -1,0 +1,29 @@
+import { sleep } from 'k6';
+import {departuresScenario, departuresScenarioPerformance} from "./v2/v2Scenario.js";
+import {realtime} from "./v2/departures/departures.js";
+
+//Scenarios
+export const scn = {
+    test: () => test(),
+    bff: () => bff(),
+    bffPerformanceTest: () => bffPerformanceTest()
+}
+
+//Functional test
+function bff(){
+    departuresScenario()
+}
+
+//Test
+function test(){
+    realtime('NSR:Quay:73576', '2022-09-27T11:33:32.003Z')
+}
+
+//Performance test
+function bffPerformanceTest(){
+    if (__ITER === 0){
+        // Some initialization
+    }
+
+    departuresScenarioPerformance()
+}

--- a/test/utils/common.js
+++ b/test/utils/common.js
@@ -1,0 +1,34 @@
+/*
+Common functions
+ */
+
+export function randomNumber(max){
+    let rand = Math.floor(Math.random() * max);
+    if (rand === max){
+        rand = max - 1;
+    }
+    return rand;
+}
+
+export function randomNumberInclusiveInInterval(min, max){
+    let rand = Math.floor(Math.random() * (max - min));
+    rand = rand + min;
+    return rand;
+}
+
+//** List headers
+/*
+for (let p in res.request.headers) {
+        if (res.request.headers.hasOwnProperty(p)) {
+            console.log(p + ' : ' + res.request.headers[p]);
+        }
+    }
+ */
+
+//** Print request / response
+/*
+console.log("** /searchForZones **")
+console.log("REQUEST: " + res.request.body)
+console.log("RESPONSE: " + res.status_text)
+console.log("RESPONSE: " + res.body)
+ */

--- a/test/utils/headers.js
+++ b/test/utils/headers.js
@@ -1,0 +1,10 @@
+/*
+Headers used in the requests
+ */
+
+export let bffHeaders = {
+    headers: {
+        'Accept': 'application/json, text/plain, */*',
+        'User-Agent': 'bff-api-tests-k6/0.30.0',
+    }
+}

--- a/test/utils/log.js
+++ b/test/utils/log.js
@@ -1,0 +1,61 @@
+/*
+Log operations
+ */
+
+//Array to keep errors meant for JUnit
+let junitChecks = [];
+
+//Creates log lines for a post-k6 script to pick up
+export function createJUnitCheckOutput() {
+  console.log("---- JUnit information ----");
+  for (let msg of junitChecks) {
+    console.log("[junit]" + msg);
+  }
+}
+
+//Prints any errors to console (see 'config/configuration.js:metrics')
+function logErrors(reqName, url, failureArray) {
+  let outputString = "[FAIL] " + reqName + " [URL] " + url + " [FAILED_CHECKS]";
+  let failureCount = 1;
+  if (failureArray.length !== 0) {
+    for (let i = 0; i < failureArray.length; i++) {
+      outputString += " " + failureCount + ") " + failureArray[i];
+      failureCount += 1;
+    }
+    console.warn(outputString);
+  }
+}
+
+//Logs all results for junit (see 'config/configuration.js:metrics.check()')
+export function logResults(reqName, url, delay, failureArray, passArray) {
+  // Print any errors
+  logErrors(reqName, url, failureArray);
+
+  // Errors
+  for (let i = 0; i < failureArray.length; i++) {
+    const junitMsg =
+      "[pass] false [req] " +
+      reqName +
+      " [url] " +
+      url +
+      " [check] " +
+      failureArray[i] +
+      " [delay] " +
+      delay;
+    junitChecks.push(junitMsg);
+  }
+
+  // Passes
+  for (let i = 0; i < passArray.length; i++) {
+    const junitMsg =
+      "[pass] true [req] " +
+      reqName +
+      " [url] " +
+      url +
+      " [check] " +
+      passArray[i] +
+      " [delay] " +
+      delay;
+    junitChecks.push(junitMsg);
+  }
+}

--- a/test/v2/departures/departures.js
+++ b/test/v2/departures/departures.js
@@ -1,0 +1,47 @@
+import http from 'k6/http';
+import { conf, metrics } from '../../config/configuration.js'
+import {bffHeaders} from "../../utils/headers.js";
+
+export function realtime(quayIds, startTime, limit = 10){
+    const requestName = "realtime";
+    let url = `${conf.host()}/bff/v2/departures/realtime?quayIds=${quayIds}&startTime=${startTime}&limit=${limit}`
+
+    let res = http.get(url,
+        {
+            tags: { name: requestName },
+            bffHeaders
+        }
+    );
+
+    //NOTE: Mainly for performance, add a trend metric for the requestName. Have to be defined in 'configuration.js:reqNameList'
+    //Log the request in a Trend metric
+    //metrics.log(requestName, res.timings.duration);
+
+    let expects = [
+        {'check': 'expectedStatus', 'expect': res.status === 200},
+        {'check': 'expectedStatus2', 'expect': res.status === 500},
+        {'check': 'expectedStatus3', 'expect': res.status === 500},
+        //{'check': 'offer_id exists', 'expect': typeof res.json('#.offer_id') !== 'undefined'}
+        //{'check': 'order_id exists', 'expect': typeof res.json('order_id') !== 'undefined'},
+        //{'check': 'order_id length', 'expect': res.json('order_id').length === 8}
+        //{'check': 'confirmation is ok', 'expect': res.body.includes("Thanks! You can safely close this window")}
+    ]
+    metrics.addFailureIfMultipleChecks(res, requestName, expects)
+}
+
+export function realtimeCopy(quayIds, startTime, limit = 10){
+    const requestName = "realtimeCopy";
+    let url = `${conf.host()}/bff/v2/departures/realtime?quayIds=${quayIds}&startTime=${startTime}&limit=${limit}`
+
+    let res = http.get(url,
+        {
+            tags: { name: requestName },
+            bffHeaders
+        }
+    );
+
+    let expects = [
+        {'check': 'expectedStatus', 'expect': res.status === 200},
+    ]
+    metrics.addFailureIfMultipleChecks(res, requestName, expects)
+}

--- a/test/v2/v2Scenario.js
+++ b/test/v2/v2Scenario.js
@@ -1,0 +1,39 @@
+/*
+Scenario that distributes requests according to usage pattern
+ */
+
+import {sleep} from "k6";
+import {randomNumberInclusiveInInterval} from "../utils/common.js";
+import {realtime, realtimeCopy} from "./departures/departures.js";
+
+//Scenario with std pattern
+export function departuresScenario(){
+    realtime('NSR:Quay:73576', '2022-09-27T11:33:32.003Z')
+    realtimeCopy('NSR:Quay:73576', '2022-09-27T11:33:32.003Z')
+}
+
+//Performance scenario with different patterns
+export function departuresScenarioPerformance(){
+    let rand = Math.random()
+
+    // 20 %
+    if (rand < 0.2){
+        for (let i = 0; i < randomNumberInclusiveInInterval(1, 5); i++){
+            realtime()
+            sleep(1)
+        }
+    }
+    // 30 %
+    else if (rand >= 0.2 && rand < 0.5){
+        for (let i = 0; i < randomNumberInclusiveInInterval(1, 5); i++){
+            realtime()
+            sleep(1)
+        }
+    }
+    // 50 %
+    else {
+        //0. find recent tickets
+        realtime()
+        sleep(1)
+    }
+}

--- a/test/workLog.txt
+++ b/test/workLog.txt
@@ -1,0 +1,11 @@
+- legg inn kall mot et endepunkt
+- bygg utover mtp scenario, etc
+- legg opp til å kjøre kun dette eksemplet i scenario og k6.js
+? - se over og fjern mulighet for ytelsestest
+    - evt legg igjen spor / metrikker for å muliggjøre/utvide dette senere
+
+
+
+husk
+- python grafer i ytelsestestprosjektet
+- wiremock (med docker) i ytelsestestprosjektet


### PR DESCRIPTION
The aim is to make some API-tests that cover all the BFF endpoints, and can be run against both staging and production.

Each endpoint should have proper assertions. The first iteration of the tests is to add some endpoints with assertions and build on this.

The choice was to use k6 as the test run framework. k6 is written in Go for performance, while the scripting language is JavaScript, making it easier to maintain. Using k6 also enables us to use the same tests for performance tests at a later stage.