### PR TITLE
feat: expose limitPerLine attribute in APIs to get limited departures

### DIFF
--- a/src/api/departures/schema.ts
+++ b/src/api/departures/schema.ts
@@ -55,7 +55,6 @@ export const getQuayDeparturesRequest = {
     startTime: Joi.string(),
     timeRange: Joi.number().default(86400),
     numberOfDeparturesPerLineAndDestinationDisplay: Joi.number()
-
   })
 };
 

--- a/src/api/departures/schema.ts
+++ b/src/api/departures/schema.ts
@@ -21,7 +21,8 @@ export const getStopDeparturesRequest = {
     id: Joi.string().required(),
     numberOfDepartures: Joi.number().default(5),
     startTime: Joi.string(),
-    timeRange: Joi.number()
+    timeRange: Joi.number(),
+    limitPerLine: Joi.number()
   })
 };
 
@@ -42,7 +43,8 @@ export const postStopDeparturesRequest = {
     id: Joi.string().required(),
     numberOfDepartures: Joi.number().default(5),
     startTime: Joi.string(),
-    timeRange: Joi.number()
+    timeRange: Joi.number(),
+    limitPerLine: Joi.number()
   })
 };
 
@@ -51,7 +53,9 @@ export const getQuayDeparturesRequest = {
     id: Joi.string().required(),
     numberOfDepartures: Joi.number().default(10),
     startTime: Joi.string(),
-    timeRange: Joi.number().default(86400)
+    timeRange: Joi.number().default(86400),
+    numberOfDeparturesPerLineAndDestinationDisplay: Joi.number()
+
   })
 };
 
@@ -72,7 +76,8 @@ export const postQuayDeparturesRequest = {
     id: Joi.string().required(),
     numberOfDepartures: Joi.number().default(1000),
     startTime: Joi.string(),
-    timeRange: Joi.number().default(86400)
+    timeRange: Joi.number().default(86400),
+    limitPerLine: Joi.number()
   })
 };
 

--- a/src/service/impl/departures/gql/jp3/quay-departures.graphql-gen.ts
+++ b/src/service/impl/departures/gql/jp3/quay-departures.graphql-gen.ts
@@ -8,6 +8,7 @@ export type QuayDeparturesQueryVariables = Types.Exact<{
   startTime?: Types.InputMaybe<Types.Scalars['DateTime']>;
   timeRange?: Types.InputMaybe<Types.Scalars['Int']>;
   filterByLineIds?: Types.InputMaybe<Array<Types.InputMaybe<Types.Scalars['ID']>> | Types.InputMaybe<Types.Scalars['ID']>>;
+  limitPerLine?: Types.InputMaybe<Types.Scalars['Int']>;
 }>;
 
 
@@ -15,7 +16,7 @@ export type QuayDeparturesQuery = { quay?: { id: string, description?: string, p
 
 
 export const QuayDeparturesDocument = gql`
-    query quayDepartures($id: String!, $numberOfDepartures: Int, $startTime: DateTime, $timeRange: Int, $filterByLineIds: [ID]) {
+    query quayDepartures($id: String!, $numberOfDepartures: Int, $startTime: DateTime, $timeRange: Int, $filterByLineIds: [ID], $limitPerLine: Int) {
   quay(id: $id) {
     id
     description
@@ -27,6 +28,7 @@ export const QuayDeparturesDocument = gql`
       timeRange: $timeRange
       includeCancelledTrips: true
       whiteListed: {lines: $filterByLineIds}
+      numberOfDeparturesPerLineAndDestinationDisplay: $limitPerLine,
     ) {
       date
       expectedDepartureTime

--- a/src/service/impl/departures/gql/jp3/quay-departures.graphql-gen.ts
+++ b/src/service/impl/departures/gql/jp3/quay-departures.graphql-gen.ts
@@ -7,59 +7,104 @@ export type QuayDeparturesQueryVariables = Types.Exact<{
   numberOfDepartures?: Types.InputMaybe<Types.Scalars['Int']>;
   startTime?: Types.InputMaybe<Types.Scalars['DateTime']>;
   timeRange?: Types.InputMaybe<Types.Scalars['Int']>;
-  filterByLineIds?: Types.InputMaybe<Array<Types.InputMaybe<Types.Scalars['ID']>> | Types.InputMaybe<Types.Scalars['ID']>>;
+  filterByLineIds?: Types.InputMaybe<
+    | Array<Types.InputMaybe<Types.Scalars['ID']>>
+    | Types.InputMaybe<Types.Scalars['ID']>
+  >;
   limitPerLine?: Types.InputMaybe<Types.Scalars['Int']>;
 }>;
 
-
-export type QuayDeparturesQuery = { quay?: { id: string, description?: string, publicCode?: string, name: string, estimatedCalls: Array<{ date?: any, expectedDepartureTime: any, aimedDepartureTime: any, realtime: boolean, cancellation: boolean, quay?: { id: string }, destinationDisplay?: { frontText?: string }, serviceJourney?: { id: string, line: { id: string, description?: string, publicCode?: string, transportMode?: Types.TransportMode, transportSubmode?: Types.TransportSubmode } } }> } };
-
+export type QuayDeparturesQuery = {
+  quay?: {
+    id: string;
+    description?: string;
+    publicCode?: string;
+    name: string;
+    estimatedCalls: Array<{
+      date?: any;
+      expectedDepartureTime: any;
+      aimedDepartureTime: any;
+      realtime: boolean;
+      cancellation: boolean;
+      quay?: { id: string };
+      destinationDisplay?: { frontText?: string };
+      serviceJourney?: {
+        id: string;
+        line: {
+          id: string;
+          description?: string;
+          publicCode?: string;
+          transportMode?: Types.TransportMode;
+          transportSubmode?: Types.TransportSubmode;
+        };
+      };
+    }>;
+  };
+};
 
 export const QuayDeparturesDocument = gql`
-    query quayDepartures($id: String!, $numberOfDepartures: Int, $startTime: DateTime, $timeRange: Int, $filterByLineIds: [ID], $limitPerLine: Int) {
-  quay(id: $id) {
-    id
-    description
-    publicCode
-    name
-    estimatedCalls(
-      numberOfDepartures: $numberOfDepartures
-      startTime: $startTime
-      timeRange: $timeRange
-      includeCancelledTrips: true
-      whiteListed: {lines: $filterByLineIds}
-      numberOfDeparturesPerLineAndDestinationDisplay: $limitPerLine,
-    ) {
-      date
-      expectedDepartureTime
-      aimedDepartureTime
-      realtime
-      cancellation
-      quay {
-        id
-      }
-      destinationDisplay {
-        frontText
-      }
-      serviceJourney {
-        id
-        line {
+  query quayDepartures(
+    $id: String!
+    $numberOfDepartures: Int
+    $startTime: DateTime
+    $timeRange: Int
+    $filterByLineIds: [ID]
+    $limitPerLine: Int
+  ) {
+    quay(id: $id) {
+      id
+      description
+      publicCode
+      name
+      estimatedCalls(
+        numberOfDepartures: $numberOfDepartures
+        startTime: $startTime
+        timeRange: $timeRange
+        includeCancelledTrips: true
+        whiteListed: { lines: $filterByLineIds }
+        numberOfDeparturesPerLineAndDestinationDisplay: $limitPerLine
+      ) {
+        date
+        expectedDepartureTime
+        aimedDepartureTime
+        realtime
+        cancellation
+        quay {
           id
-          description
-          publicCode
-          transportMode
-          transportSubmode
+        }
+        destinationDisplay {
+          frontText
+        }
+        serviceJourney {
+          id
+          line {
+            id
+            description
+            publicCode
+            transportMode
+            transportSubmode
+          }
         }
       }
     }
   }
-}
-    `;
-export type Requester<C= {}> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R>
+`;
+export type Requester<C = {}> = <R, V>(
+  doc: DocumentNode,
+  vars?: V,
+  options?: C
+) => Promise<R>;
 export function getSdk<C>(requester: Requester<C>) {
   return {
-    quayDepartures(variables: QuayDeparturesQueryVariables, options?: C): Promise<QuayDeparturesQuery> {
-      return requester<QuayDeparturesQuery, QuayDeparturesQueryVariables>(QuayDeparturesDocument, variables, options);
+    quayDepartures(
+      variables: QuayDeparturesQueryVariables,
+      options?: C
+    ): Promise<QuayDeparturesQuery> {
+      return requester<QuayDeparturesQuery, QuayDeparturesQueryVariables>(
+        QuayDeparturesDocument,
+        variables,
+        options
+      );
     }
   };
 }

--- a/src/service/impl/departures/index.ts
+++ b/src/service/impl/departures/index.ts
@@ -84,7 +84,7 @@ export default (): IDeparturesService => {
       }
     },
     async getStopQuayDepartures(
-      { id, numberOfDepartures = 10, startTime, timeRange },
+      { id, numberOfDepartures = 10, startTime, timeRange, limitPerLine },
       payload
     ) {
       const favorites = payload?.favorites;
@@ -111,7 +111,8 @@ export default (): IDeparturesService => {
             startTime,
             timeRange,
             filterByLineIds: favorites?.map(f => f.lineId),
-            ...limit
+            limitPerLine,
+            ...limit,
           }
         });
 
@@ -135,7 +136,8 @@ export default (): IDeparturesService => {
         id,
         numberOfDepartures = 1000,
         startTime,
-        timeRange = 86400 // 24 hours
+        timeRange = 86400, // 24 hours
+        limitPerLine
       },
       payload
     ) {
@@ -151,7 +153,8 @@ export default (): IDeparturesService => {
             numberOfDepartures,
             startTime,
             timeRange,
-            filterByLineIds: favorites?.map(f => f.lineId)
+            filterByLineIds: favorites?.map(f => f.lineId),
+            limitPerLine
           }
         });
 

--- a/src/service/impl/departures/index.ts
+++ b/src/service/impl/departures/index.ts
@@ -96,10 +96,13 @@ export default (): IDeparturesService => {
          */
         const limit = favorites
           ? {
-              limitPerLine: numberOfDepartures,
+              limitPerLine: limitPerLine ?? numberOfDepartures,
               numberOfDepartures: numberOfDepartures * 10
             }
-          : { numberOfDepartures: numberOfDepartures };
+          : {
+              limitPerLine,
+              numberOfDepartures
+            };
 
         const result = await journeyPlannerClient_v3.query<
           StopPlaceQuayDeparturesQuery,
@@ -111,8 +114,7 @@ export default (): IDeparturesService => {
             startTime,
             timeRange,
             filterByLineIds: favorites?.map(f => f.lineId),
-            limitPerLine,
-            ...limit,
+            ...limit
           }
         });
 


### PR DESCRIPTION
This is needed to get one entry per line so that we can use that in improved favorites flow i.e. https://github.com/AtB-AS/kundevendt/issues/2593