### PR TITLE
revert: "chore: deprecate endpoint `bff/v1/geocoder/features` (#168)"

### DIFF
--- a/src/api/geocoder/index.ts
+++ b/src/api/geocoder/index.ts
@@ -40,11 +40,6 @@ export default (server: Hapi.Server) => (service: IGeocoderService) => {
       cache: {
         expiresIn: DEFAULT_CACHE_TTL,
         privacy: 'public'
-      },
-      plugins: {
-        'hapi-swagger': {
-          deprecated: true
-        }
       }
     },
     handler: async (request, h) => {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -168,7 +168,6 @@ paths:
           schema:
             type: string
           description: Successful
-      deprecated: true
   /bff/v1/geocoder/reverse:
     get:
       summary: 'Find addresses, POIs and stop places near the given coordinates'


### PR DESCRIPTION
This reverts commit 3cf6ae87ea6d0c1ade345b7c90ca4c0cf83a012c

@tormoseng Noticed that the `bff/v1/geocoder/features` endpoint is still in use when using autocomplete in search in the app. Therefore, the endpoint should not be deprecated.