### PR TITLE
feat: upgrade map polyline endpoints to OTP2

### DIFF
--- a/src/service/impl/service-journey/serviceJourney.ts
+++ b/src/service/impl/service-journey/serviceJourney.ts
@@ -1,3 +1,4 @@
+import { journeyPlannerClient_v3 } from '../../../graphql/graphql-client';
 import {
   MapInfoWithFromAndToQuayV2Document,
   MapInfoWithFromAndToQuayV2Query,
@@ -6,7 +7,6 @@ import {
   MapInfoWithFromQuayV2Query,
   MapInfoWithFromQuayV2QueryVariables
 } from './journey-gql/jp3/service-journey-map.graphql-gen';
-import { journeyPlannerClient } from '../../../graphql/graphql-client';
 
 export async function getMapInfoWithFromQuay(
   serviceJourneyId: string,
@@ -16,7 +16,7 @@ export async function getMapInfoWithFromQuay(
     serviceJourneyId,
     fromQuayId
   };
-  const result = await journeyPlannerClient.query<
+  const result = await journeyPlannerClient_v3.query<
     MapInfoWithFromQuayV2Query,
     MapInfoWithFromQuayV2QueryVariables
   >({
@@ -37,7 +37,7 @@ export async function getMapInfoWithFromAndToQuay(
     fromQuayId,
     toQuayId
   };
-  const result = await journeyPlannerClient.query<
+  const result = await journeyPlannerClient_v3.query<
     MapInfoWithFromAndToQuayV2Query,
     MapInfoWithFromAndToQuayV2QueryVariables
   >({


### PR DESCRIPTION
The GET `/bff/v2/servicejourney/{id}/polyline` endpoint was using the old journeyPlannerClient with OTP1, despite using OPT2 typing. Looks like an mistaken implementation introduced in e358e3ef6837c343c1e1a298bfde1ac96a70db22. 

This updates to `journeyPlannerClient_v3`, with OTP2.

This is a change that affects pre-existing versions of the app. So we should test older versions before we push this to prod.