### PR TITLE
fix: checkout main for api tests

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: tor/api-tests
+          ref: main
 
       - name: Install k6
         run: |


### PR DESCRIPTION
An error causes the API tests to check out a deleted branch. Changed to `main`.