### PR TITLE
fix: Replace omitNonBoarding with arrivalDeparture

### DIFF
--- a/src/graphql/journeyplanner-types_v3.ts
+++ b/src/graphql/journeyplanner-types_v3.ts
@@ -776,7 +776,6 @@ export type QuayEstimatedCallsArgs = {
   includeCancelledTrips?: InputMaybe<Scalars['Boolean']>;
   numberOfDepartures?: InputMaybe<Scalars['Int']>;
   numberOfDeparturesPerLineAndDestinationDisplay?: InputMaybe<Scalars['Int']>;
-  omitNonBoarding?: InputMaybe<Scalars['Boolean']>;
   startTime?: InputMaybe<Scalars['DateTime']>;
   timeRange?: InputMaybe<Scalars['Int']>;
   whiteListed?: InputMaybe<InputWhiteListed>;
@@ -1188,7 +1187,10 @@ export type RoutingParameters = {
   /** @deprecated NOT IN USE IN OTP2. */
   compactLegsByReversedSearch?: Maybe<Scalars['Boolean']>;
   debugItineraryFilter?: Maybe<Scalars['Boolean']>;
-  /** Option to disable the default filtering of GTFS-RT alerts by time. */
+  /**
+   * Option to disable the default filtering of GTFS-RT alerts by time.
+   * @deprecated This is not supported!
+   */
   disableAlertFiltering?: Maybe<Scalars['Boolean']>;
   /** If true, the remaining weight heuristic is disabled. */
   disableRemainingWeightHeuristic?: Maybe<Scalars['Boolean']>;
@@ -1240,8 +1242,6 @@ export type RoutingParameters = {
   transferSlack?: Maybe<Scalars['Int']>;
   /** Multiplicative factor on expected turning time. */
   turnReluctance?: Maybe<Scalars['Float']>;
-  /** How much less bad is waiting at the beginning of the trip (replaces waitReluctance on the first boarding). */
-  waitAtBeginningFactor?: Maybe<Scalars['Float']>;
   /** How much worse is waiting for a transit vehicle than being on a transit vehicle, as a multiplier. */
   waitReluctance?: Maybe<Scalars['Float']>;
   /** This prevents unnecessary transfers by adding a cost for boarding a vehicle. */

--- a/src/service/impl/departure-favorites/journey-gql/jp3/departure-group.graphql
+++ b/src/service/impl/departure-favorites/journey-gql/jp3/departure-group.graphql
@@ -15,7 +15,7 @@ query GroupsById(
         timeRange: $timeRange
         numberOfDeparturesPerLineAndDestinationDisplay: $limitPerLine
         numberOfDepartures: $totalLimit
-        omitNonBoarding: false
+        arrivalDeparture: both
         includeCancelledTrips: false
         whiteListed: { lines: $filterByLineIds }
       ) {
@@ -26,7 +26,7 @@ query GroupsById(
         timeRange: $timeRange
         numberOfDepartures: $totalLimit
         numberOfDeparturesPerLineAndDestinationDisplay: 1
-        omitNonBoarding: false
+        arrivalDeparture: both
         includeCancelledTrips: false
         whiteListed: { lines: $filterByLineIds }
       ) {

--- a/src/service/impl/departure-favorites/journey-gql/jp3/departure-group.graphql-gen.ts
+++ b/src/service/impl/departure-favorites/journey-gql/jp3/departure-group.graphql-gen.ts
@@ -180,7 +180,7 @@ export const GroupsByIdDocument = gql`
         timeRange: $timeRange
         numberOfDeparturesPerLineAndDestinationDisplay: $limitPerLine
         numberOfDepartures: $totalLimit
-        omitNonBoarding: false
+        arrivalDeparture: both
         includeCancelledTrips: false
         whiteListed: {lines: $filterByLineIds}
       ) {
@@ -191,7 +191,7 @@ export const GroupsByIdDocument = gql`
         timeRange: $timeRange
         numberOfDepartures: $totalLimit
         numberOfDeparturesPerLineAndDestinationDisplay: 1
-        omitNonBoarding: false
+        arrivalDeparture: both
         includeCancelledTrips: false
         whiteListed: {lines: $filterByLineIds}
       ) {

--- a/src/service/impl/departure-favorites/journey-gql/jp3/departure-time.graphql
+++ b/src/service/impl/departure-favorites/journey-gql/jp3/departure-time.graphql
@@ -10,7 +10,7 @@ query GetDepartureRealtime(
       startTime: $startTime
       numberOfDepartures: $limit
       timeRange: $timeRange
-      omitNonBoarding: false
+      arrivalDeparture: both
       includeCancelledTrips: false
     ) {
       ...estimatedCall

--- a/src/service/impl/departure-favorites/journey-gql/jp3/departure-time.graphql-gen.ts
+++ b/src/service/impl/departure-favorites/journey-gql/jp3/departure-time.graphql-gen.ts
@@ -36,7 +36,7 @@ export const GetDepartureRealtimeDocument = gql`
       startTime: $startTime
       numberOfDepartures: $limit
       timeRange: $timeRange
-      omitNonBoarding: false
+      arrivalDeparture: both
       includeCancelledTrips: false
     ) {
       ...estimatedCall


### PR DESCRIPTION
In JP3 omitNonBoarding is now deprecated, and Entur said it was replaced by the field arrivalDeparture. A value of 'both' in arrivalDeparture should give the same as 'false' in omitNonBoarding.

More context:
https://mittatb.slack.com/archives/CHLDG8C30/p1668437703909409

Acceptance criteria:
- [ ] Travel searches in the app on departures v2 should work as before