### PR TITLE
feat: Add ServiceJourneyWithEstimatedCalls

### DIFF
--- a/src/api/servicejourney/index.ts
+++ b/src/api/servicejourney/index.ts
@@ -134,7 +134,6 @@ export function serviceJourneyRoutes_v2(server: Hapi.Server) {
       },
       handler: async (request, h) => {
         const { id } = request.params;
-        console.log("FINDING FOR ID", id);
         const {
           date
         } = (request.query as unknown) as ServiceJourneyWithEstimatedCallsQuery;

--- a/src/api/servicejourney/index.ts
+++ b/src/api/servicejourney/index.ts
@@ -7,12 +7,12 @@ import {
 } from '../../service/interface';
 import {
   DeparturesForServiceJourneyQuery,
-  ServiceJourneyMapInfoQuery
+  ServiceJourneyMapInfoQuery, ServiceJourneyWithEstimatedCallsQuery
 } from '../../service/types';
 import {
   getDeparturesForServiceJourneyRequest,
   getDeparturesForServiceJourneyRequestV2,
-  getServiceJoruneyMapDataRequest
+  getServiceJoruneyMapDataRequest, getServiceJourneyWithEstimatedCallsV2
 } from './schema';
 import qs from 'querystring';
 
@@ -121,6 +121,24 @@ export function serviceJourneyRoutes_v2(server: Hapi.Server) {
           date
         } = (request.query as unknown) as DeparturesForServiceJourneyQuery;
         return await service.getDeparturesForServiceJourneyV2(id, { date });
+      }
+    });
+
+    server.route({
+      method: 'GET',
+      path: '/bff/v2/servicejourney/{id}/calls',
+      options: {
+        tags: ['api', 'stops', 'otp2'],
+        validate: getServiceJourneyWithEstimatedCallsV2,
+        description: 'Get Service Journey including its estimated calls'
+      },
+      handler: async (request, h) => {
+        const { id } = request.params;
+        console.log("FINDING FOR ID", id);
+        const {
+          date
+        } = (request.query as unknown) as ServiceJourneyWithEstimatedCallsQuery;
+        return await service.getServiceJourneyWithEstimatedCallsV2(id, { date });
       }
     });
   };

--- a/src/api/servicejourney/schema.ts
+++ b/src/api/servicejourney/schema.ts
@@ -27,3 +27,12 @@ export const getDeparturesForServiceJourneyRequestV2 = {
     date: Joi.date()
   })
 };
+
+export const getServiceJourneyWithEstimatedCallsV2 = {
+  params: Joi.object({
+    id: Joi.string().required()
+  }).required(),
+  query: Joi.object({
+    date: Joi.date()
+  })
+};

--- a/src/service/impl/fragments/jp3/estimated-calls.graphql
+++ b/src/service/impl/fragments/jp3/estimated-calls.graphql
@@ -1,0 +1,25 @@
+fragment estimatedCallWithQuay on EstimatedCall {
+  actualArrivalTime
+  actualDepartureTime
+  aimedArrivalTime
+  aimedDepartureTime
+  cancellation
+  date
+  destinationDisplay {
+    frontText
+  }
+  expectedDepartureTime
+  expectedArrivalTime
+  forAlighting
+  forBoarding
+  realtime
+  quay {
+    ...quay
+  }
+  notices {
+    ...notice
+  }
+  situations {
+    ...situation
+  }
+}

--- a/src/service/impl/fragments/jp3/estimated-calls.graphql-gen.ts
+++ b/src/service/impl/fragments/jp3/estimated-calls.graphql-gen.ts
@@ -1,0 +1,45 @@
+import * as Types from '../../../../graphql/journeyplanner-types_v3';
+
+import { DocumentNode } from 'graphql';
+import gql from 'graphql-tag';
+import { QuayFragmentDoc } from './quays.graphql-gen';
+import { SituationFragmentDoc } from './situations.graphql-gen';
+import { NoticeFragmentDoc } from './notices.graphql-gen';
+export type EstimatedCallWithQuayFragment = { actualArrivalTime?: any, actualDepartureTime?: any, aimedArrivalTime: any, aimedDepartureTime: any, cancellation: boolean, date?: any, expectedDepartureTime: any, expectedArrivalTime: any, forAlighting: boolean, forBoarding: boolean, realtime: boolean, destinationDisplay?: { frontText?: string }, quay?: { id: string, name: string, publicCode?: string, situations: Array<{ id: string, situationNumber?: string, reportType?: Types.ReportType, summary: Array<{ language?: string, value: string }>, description: Array<{ language?: string, value: string }> }>, stopPlace?: { id: string, name: string, latitude?: number, longitude?: number }, tariffZones: Array<{ id: string, name?: string }> }, notices: Array<{ text?: string }>, situations: Array<{ id: string, situationNumber?: string, reportType?: Types.ReportType, summary: Array<{ language?: string, value: string }>, description: Array<{ language?: string, value: string }> }> };
+
+export const EstimatedCallWithQuayFragmentDoc = gql`
+    fragment estimatedCallWithQuay on EstimatedCall {
+  actualArrivalTime
+  actualDepartureTime
+  aimedArrivalTime
+  aimedDepartureTime
+  cancellation
+  date
+  destinationDisplay {
+    frontText
+  }
+  expectedDepartureTime
+  expectedArrivalTime
+  forAlighting
+  forBoarding
+  realtime
+  quay {
+    ...quay
+  }
+  notices {
+    ...notice
+  }
+  situations {
+    ...situation
+  }
+}
+    ${QuayFragmentDoc}
+${NoticeFragmentDoc}
+${SituationFragmentDoc}`;
+export type Requester<C = {}, E = unknown> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R>
+export function getSdk<C, E>(requester: Requester<C, E>) {
+  return {
+
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/src/service/impl/fragments/jp3/notices.graphql
+++ b/src/service/impl/fragments/jp3/notices.graphql
@@ -1,0 +1,3 @@
+fragment notice on Notice {
+  text
+}

--- a/src/service/impl/fragments/jp3/notices.graphql-gen.ts
+++ b/src/service/impl/fragments/jp3/notices.graphql-gen.ts
@@ -1,0 +1,18 @@
+import * as Types from '../../../../graphql/journeyplanner-types_v3';
+
+import { DocumentNode } from 'graphql';
+import gql from 'graphql-tag';
+export type NoticeFragment = { text?: string };
+
+export const NoticeFragmentDoc = gql`
+    fragment notice on Notice {
+  text
+}
+    `;
+export type Requester<C = {}, E = unknown> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R>
+export function getSdk<C, E>(requester: Requester<C, E>) {
+  return {
+
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/src/service/impl/fragments/jp3/quays.graphql
+++ b/src/service/impl/fragments/jp3/quays.graphql
@@ -1,0 +1,14 @@
+fragment quay on Quay {
+  id
+  name
+  publicCode
+  situations {
+    ...situation
+  }
+  stopPlace {
+    ...stopPlace
+  }
+  tariffZones {
+    ...tariffZone
+  }
+}

--- a/src/service/impl/fragments/jp3/quays.graphql-gen.ts
+++ b/src/service/impl/fragments/jp3/quays.graphql-gen.ts
@@ -1,0 +1,34 @@
+import * as Types from '../../../../graphql/journeyplanner-types_v3';
+
+import { DocumentNode } from 'graphql';
+import gql from 'graphql-tag';
+import { SituationFragmentDoc } from './situations.graphql-gen';
+import { StopPlaceFragmentDoc } from './stop-places.graphql-gen';
+import { TariffZoneFragmentDoc } from './tariff-zones.graphql-gen';
+export type QuayFragment = { id: string, name: string, publicCode?: string, situations: Array<{ id: string, situationNumber?: string, reportType?: Types.ReportType, summary: Array<{ language?: string, value: string }>, description: Array<{ language?: string, value: string }> }>, stopPlace?: { id: string, name: string, latitude?: number, longitude?: number }, tariffZones: Array<{ id: string, name?: string }> };
+
+export const QuayFragmentDoc = gql`
+    fragment quay on Quay {
+  id
+  name
+  publicCode
+  situations {
+    ...situation
+  }
+  stopPlace {
+    ...stopPlace
+  }
+  tariffZones {
+    ...tariffZone
+  }
+}
+    ${SituationFragmentDoc}
+${StopPlaceFragmentDoc}
+${TariffZoneFragmentDoc}`;
+export type Requester<C = {}, E = unknown> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R>
+export function getSdk<C, E>(requester: Requester<C, E>) {
+  return {
+
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/src/service/impl/fragments/jp3/service-journey.graphql
+++ b/src/service/impl/fragments/jp3/service-journey.graphql
@@ -1,0 +1,15 @@
+fragment serviceJourneyWithEstCalls on ServiceJourney {
+  id
+  transportMode
+  transportSubmode
+  publicCode
+  line {
+    publicCode
+  }
+  notices {
+    ...notice
+  }
+  estimatedCalls(date: $date) {
+    ...estimatedCallWithQuay
+  }
+}

--- a/src/service/impl/fragments/jp3/service-journey.graphql-gen.ts
+++ b/src/service/impl/fragments/jp3/service-journey.graphql-gen.ts
@@ -1,0 +1,33 @@
+import * as Types from '../../../../graphql/journeyplanner-types_v3';
+
+import { DocumentNode } from 'graphql';
+import gql from 'graphql-tag';
+import { NoticeFragmentDoc } from './notices.graphql-gen';
+import { EstimatedCallWithQuayFragmentDoc } from './estimated-calls.graphql-gen';
+export type ServiceJourneyWithEstCallsFragment = { id: string, transportMode?: Types.TransportMode, transportSubmode?: Types.TransportSubmode, publicCode?: string, line: { publicCode?: string }, notices: Array<{ text?: string }>, estimatedCalls?: Array<{ actualArrivalTime?: any, actualDepartureTime?: any, aimedArrivalTime: any, aimedDepartureTime: any, cancellation: boolean, date?: any, expectedDepartureTime: any, expectedArrivalTime: any, forAlighting: boolean, forBoarding: boolean, realtime: boolean, destinationDisplay?: { frontText?: string }, quay?: { id: string, name: string, publicCode?: string, situations: Array<{ id: string, situationNumber?: string, reportType?: Types.ReportType, summary: Array<{ language?: string, value: string }>, description: Array<{ language?: string, value: string }> }>, stopPlace?: { id: string, name: string, latitude?: number, longitude?: number }, tariffZones: Array<{ id: string, name?: string }> }, notices: Array<{ text?: string }>, situations: Array<{ id: string, situationNumber?: string, reportType?: Types.ReportType, summary: Array<{ language?: string, value: string }>, description: Array<{ language?: string, value: string }> }> }> };
+
+export const ServiceJourneyWithEstCallsFragmentDoc = gql`
+    fragment serviceJourneyWithEstCalls on ServiceJourney {
+  id
+  transportMode
+  transportSubmode
+  publicCode
+  line {
+    publicCode
+  }
+  notices {
+    ...notice
+  }
+  estimatedCalls(date: $date) {
+    ...estimatedCallWithQuay
+  }
+}
+    ${NoticeFragmentDoc}
+${EstimatedCallWithQuayFragmentDoc}`;
+export type Requester<C = {}, E = unknown> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R>
+export function getSdk<C, E>(requester: Requester<C, E>) {
+  return {
+
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/src/service/impl/fragments/jp3/stop-places.graphql
+++ b/src/service/impl/fragments/jp3/stop-places.graphql
@@ -1,0 +1,6 @@
+fragment stopPlace on StopPlace {
+  id
+  name
+  latitude
+  longitude
+}

--- a/src/service/impl/fragments/jp3/stop-places.graphql-gen.ts
+++ b/src/service/impl/fragments/jp3/stop-places.graphql-gen.ts
@@ -1,0 +1,21 @@
+import * as Types from '../../../../graphql/journeyplanner-types_v3';
+
+import { DocumentNode } from 'graphql';
+import gql from 'graphql-tag';
+export type StopPlaceFragment = { id: string, name: string, latitude?: number, longitude?: number };
+
+export const StopPlaceFragmentDoc = gql`
+    fragment stopPlace on StopPlace {
+  id
+  name
+  latitude
+  longitude
+}
+    `;
+export type Requester<C = {}, E = unknown> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R>
+export function getSdk<C, E>(requester: Requester<C, E>) {
+  return {
+
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/src/service/impl/service-journey/index.ts
+++ b/src/service/impl/service-journey/index.ts
@@ -27,6 +27,12 @@ import {
   ServiceJourneyDeparturesQuery,
   ServiceJourneyDeparturesQueryVariables
 } from './journey-gql/jp3/service-journey-departures.graphql-gen';
+import {
+  ServiceJourneyWithEstimatedCallsDocument,
+  ServiceJourneyWithEstimatedCallsQuery,
+  ServiceJourneyWithEstimatedCallsQueryVariables
+} from './journey-gql/jp3/service-journey-with-estimated-calls.graphql-gen';
+import { ServiceJourneyWithEstCallsFragment } from '../fragments/jp3/service-journey.graphql-gen';
 
 export default function serviceJourneyService(
   service: EnturServiceAPI
@@ -125,6 +131,30 @@ export function serviceJourneyService_v2(): IServiceJourneyService_v2 {
         return Result.ok(
           estimatedCalls as ServiceJourneyEstimatedCallFragment[]
         );
+      } catch (error: any) {
+        return Result.err(new APIError(error));
+      }
+    },
+    async getServiceJourneyWithEstimatedCallsV2(id, { date }) {
+      try {
+        const serviceDate = date
+          ? formatISO(date, { representation: 'date' })
+          : undefined;
+
+        const result = await journeyPlannerClient_v3.query<
+          ServiceJourneyWithEstimatedCallsQuery,
+          ServiceJourneyWithEstimatedCallsQueryVariables
+        >({
+          query: ServiceJourneyWithEstimatedCallsDocument,
+          variables: { id, date: serviceDate }
+        });
+
+        if (result.error) {
+          return Result.err(new APIError(result.error));
+        }
+
+        const serviceJourney = result.data.serviceJourney;
+        return Result.ok(serviceJourney as ServiceJourneyWithEstCallsFragment);
       } catch (error: any) {
         return Result.err(new APIError(error));
       }

--- a/src/service/impl/service-journey/journey-gql/jp3/service-journey-departures.graphql
+++ b/src/service/impl/service-journey/journey-gql/jp3/service-journey-departures.graphql
@@ -34,24 +34,6 @@ fragment serviceJourneyEstimatedCall on EstimatedCall {
   }
 }
 
-fragment notice on Notice {
-  text
-}
-
-fragment quay on Quay {
-  id
-  name
-  publicCode
-  situations {
-    ...situation
-  }
-  stopPlace {
-    ...stopPlace
-  }
-  tariffZones {
-    ...tariffZone
-  }
-}
 
 fragment line on Line {
   id
@@ -59,13 +41,6 @@ fragment line on Line {
   publicCode
   transportMode
   transportSubmode
-}
-
-fragment stopPlace on StopPlace {
-  id
-  name
-  latitude
-  longitude
 }
 
 fragment serviceJourney on ServiceJourney {

--- a/src/service/impl/service-journey/journey-gql/jp3/service-journey-departures.graphql-gen.ts
+++ b/src/service/impl/service-journey/journey-gql/jp3/service-journey-departures.graphql-gen.ts
@@ -2,8 +2,9 @@ import * as Types from '../../../../../graphql/journeyplanner-types_v3';
 
 import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+import { NoticeFragmentDoc } from '../../../fragments/jp3/notices.graphql-gen';
+import { QuayFragmentDoc } from '../../../fragments/jp3/quays.graphql-gen';
 import { SituationFragmentDoc } from '../../../fragments/jp3/situations.graphql-gen';
-import { TariffZoneFragmentDoc } from '../../../fragments/jp3/tariff-zones.graphql-gen';
 export type ServiceJourneyDeparturesQueryVariables = Types.Exact<{
   id: Types.Scalars['String'];
   date?: Types.InputMaybe<Types.Scalars['Date']>;
@@ -14,47 +15,10 @@ export type ServiceJourneyDeparturesQuery = { serviceJourney?: { estimatedCalls?
 
 export type ServiceJourneyEstimatedCallFragment = { actualArrivalTime?: any, actualDepartureTime?: any, aimedArrivalTime: any, aimedDepartureTime: any, cancellation: boolean, date?: any, expectedDepartureTime: any, expectedArrivalTime: any, forAlighting: boolean, realtime: boolean, destinationDisplay?: { frontText?: string }, notices: Array<{ text?: string }>, quay?: { id: string, name: string, publicCode?: string, situations: Array<{ id: string, situationNumber?: string, reportType?: Types.ReportType, summary: Array<{ language?: string, value: string }>, description: Array<{ language?: string, value: string }> }>, stopPlace?: { id: string, name: string, latitude?: number, longitude?: number }, tariffZones: Array<{ id: string, name?: string }> }, serviceJourney?: { id: string, journeyPattern?: { line: { id: string, name?: string, publicCode?: string, transportMode?: Types.TransportMode, transportSubmode?: Types.TransportSubmode } } }, situations: Array<{ id: string, situationNumber?: string, reportType?: Types.ReportType, summary: Array<{ language?: string, value: string }>, description: Array<{ language?: string, value: string }> }> };
 
-export type NoticeFragment = { text?: string };
-
-export type QuayFragment = { id: string, name: string, publicCode?: string, situations: Array<{ id: string, situationNumber?: string, reportType?: Types.ReportType, summary: Array<{ language?: string, value: string }>, description: Array<{ language?: string, value: string }> }>, stopPlace?: { id: string, name: string, latitude?: number, longitude?: number }, tariffZones: Array<{ id: string, name?: string }> };
-
 export type LineFragment = { id: string, name?: string, publicCode?: string, transportMode?: Types.TransportMode, transportSubmode?: Types.TransportSubmode };
-
-export type StopPlaceFragment = { id: string, name: string, latitude?: number, longitude?: number };
 
 export type ServiceJourneyFragment = { id: string, journeyPattern?: { line: { id: string, name?: string, publicCode?: string, transportMode?: Types.TransportMode, transportSubmode?: Types.TransportSubmode } } };
 
-export const NoticeFragmentDoc = gql`
-    fragment notice on Notice {
-  text
-}
-    `;
-export const StopPlaceFragmentDoc = gql`
-    fragment stopPlace on StopPlace {
-  id
-  name
-  latitude
-  longitude
-}
-    `;
-export const QuayFragmentDoc = gql`
-    fragment quay on Quay {
-  id
-  name
-  publicCode
-  situations {
-    ...situation
-  }
-  stopPlace {
-    ...stopPlace
-  }
-  tariffZones {
-    ...tariffZone
-  }
-}
-    ${SituationFragmentDoc}
-${StopPlaceFragmentDoc}
-${TariffZoneFragmentDoc}`;
 export const LineFragmentDoc = gql`
     fragment line on Line {
   id

--- a/src/service/impl/service-journey/journey-gql/jp3/service-journey-with-estimated-calls.graphql
+++ b/src/service/impl/service-journey/journey-gql/jp3/service-journey-with-estimated-calls.graphql
@@ -1,0 +1,5 @@
+query serviceJourneyWithEstimatedCalls($id: String!, $date: Date) {
+  serviceJourney(id: $id) {
+    ...serviceJourneyWithEstCalls
+  }
+}

--- a/src/service/impl/service-journey/journey-gql/jp3/service-journey-with-estimated-calls.graphql-gen.ts
+++ b/src/service/impl/service-journey/journey-gql/jp3/service-journey-with-estimated-calls.graphql-gen.ts
@@ -1,0 +1,30 @@
+import * as Types from '../../../../../graphql/journeyplanner-types_v3';
+
+import { DocumentNode } from 'graphql';
+import gql from 'graphql-tag';
+import { ServiceJourneyWithEstCallsFragmentDoc } from '../../../fragments/jp3/service-journey.graphql-gen';
+export type ServiceJourneyWithEstimatedCallsQueryVariables = Types.Exact<{
+  id: Types.Scalars['String'];
+  date?: Types.InputMaybe<Types.Scalars['Date']>;
+}>;
+
+
+export type ServiceJourneyWithEstimatedCallsQuery = { serviceJourney?: { id: string, transportMode?: Types.TransportMode, transportSubmode?: Types.TransportSubmode, publicCode?: string, line: { publicCode?: string }, notices: Array<{ text?: string }>, estimatedCalls?: Array<{ actualArrivalTime?: any, actualDepartureTime?: any, aimedArrivalTime: any, aimedDepartureTime: any, cancellation: boolean, date?: any, expectedDepartureTime: any, expectedArrivalTime: any, forAlighting: boolean, forBoarding: boolean, realtime: boolean, destinationDisplay?: { frontText?: string }, quay?: { id: string, name: string, publicCode?: string, situations: Array<{ id: string, situationNumber?: string, reportType?: Types.ReportType, summary: Array<{ language?: string, value: string }>, description: Array<{ language?: string, value: string }> }>, stopPlace?: { id: string, name: string, latitude?: number, longitude?: number }, tariffZones: Array<{ id: string, name?: string }> }, notices: Array<{ text?: string }>, situations: Array<{ id: string, situationNumber?: string, reportType?: Types.ReportType, summary: Array<{ language?: string, value: string }>, description: Array<{ language?: string, value: string }> }> }> } };
+
+
+export const ServiceJourneyWithEstimatedCallsDocument = gql`
+    query serviceJourneyWithEstimatedCalls($id: String!, $date: Date) {
+  serviceJourney(id: $id) {
+    ...serviceJourneyWithEstCalls
+  }
+}
+    ${ServiceJourneyWithEstCallsFragmentDoc}`;
+export type Requester<C = {}, E = unknown> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R>
+export function getSdk<C, E>(requester: Requester<C, E>) {
+  return {
+    serviceJourneyWithEstimatedCalls(variables: ServiceJourneyWithEstimatedCallsQueryVariables, options?: C): Promise<ServiceJourneyWithEstimatedCallsQuery> {
+      return requester<ServiceJourneyWithEstimatedCallsQuery, ServiceJourneyWithEstimatedCallsQueryVariables>(ServiceJourneyWithEstimatedCallsDocument, variables, options);
+    }
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/src/service/interface.ts
+++ b/src/service/interface.ts
@@ -42,7 +42,7 @@ import {
   StopPlaceDeparturesPayload,
   DepartureFavoritesPayload,
   DepartureFavoritesQuery,
-  QuaysCoordinatesPayload
+  QuaysCoordinatesPayload, ServiceJourneyWithEstimatedCallsQuery
 } from './types';
 import {
   StopPlaceQuayDeparturesQuery,
@@ -66,6 +66,7 @@ import { EnrollResponse } from './impl/enrollment';
 import { Boom } from '@hapi/boom';
 import { ServiceJourneyEstimatedCallFragment } from './impl/service-journey/journey-gql/jp3/service-journey-departures.graphql-gen';
 import { GetQuaysCoordinatesQuery } from './impl/quays/jp3/quays-coordinates.graphql-gen';
+import { ServiceJourneyWithEstCallsFragment } from './impl/fragments/jp3/service-journey.graphql-gen';
 
 export interface IGeocoderService {
   getFeatures(query: FeaturesQuery): Promise<Result<Feature[], APIError>>;
@@ -96,6 +97,10 @@ export interface IServiceJourneyService_v2 {
     id: string,
     query: DeparturesForServiceJourneyQuery
   ): Promise<Result<ServiceJourneyEstimatedCallFragment[] | null, APIError>>;
+  getServiceJourneyWithEstimatedCallsV2(
+    id: string,
+    query: ServiceJourneyWithEstimatedCallsQuery
+  ): Promise<Result<ServiceJourneyWithEstCallsFragment | null, APIError>>;
 }
 
 export interface ITrips_v2 {

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -211,6 +211,10 @@ export interface DeparturesForServiceJourneyQuery {
   date?: Date;
 }
 
+export interface ServiceJourneyWithEstimatedCallsQuery {
+  date?: Date;
+}
+
 export interface ServiceJourneyMapInfoQuery {
   fromQuayId: string;
   toQuayId?: string;

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -383,6 +383,26 @@ paths:
           schema:
             type: string
           description: Successful
+  '/bff/v2/servicejourney/{id}/calls':
+    get:
+      summary: Get ServiceJourney including EstimatedCalls
+      operationId: getBffV2ServicejourneyIdCalls
+      parameters:
+        - type: string
+          name: id
+          in: path
+          required: true
+        - type: string
+          format: date
+          name: date
+          in: query
+      tags:
+        - bff
+      responses:
+        default:
+          schema:
+            type: string
+          description: Successful
   '/bff/v2/servicejourney/{id}/polyline':
     get:
       summary: Get Map info for a serviceJourney


### PR DESCRIPTION
The main new feature is adding notices, however since this was already a
non-backward compatible change the old ServiceJourneyDepartures endpoint
was replaced with a new ServiceJourneyWithEstimatedCalls endpoint to fix
some illogical structuring of the old query.

Some examples:
- The old endpoint retrieved serviceJourney fields through each
  estimated call. This is not necessary as the root element is the
  same serviceJourney that every call references.
- The old endpoint accessed the line (for publicCode) through
  serviceJourney -> estimatedCall -> serviceJourney -> journeyPattern ->
  line, when it could be serviceJourney -> line.
- TransportMode and TransportSubmode were queried on line when it can be
  queried directly on the serviceJourney.

Also created reusable fragments for the fragments used in the new
endpoint.

Resolves https://github.com/AtB-AS/kundevendt/issues/2881