### PR TITLE
fix: return departures only from departure favorites

### DIFF
--- a/src/graphql/journeyplanner-types_v3.ts
+++ b/src/graphql/journeyplanner-types_v3.ts
@@ -10,13 +10,27 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
+  /** List of coordinates like: [[60.89, 11.12], [62.56, 12.10]] */
   Coordinates: any;
+  /** Local date using the ISO 8601 format: `YYYY-MM-DD`. Example: `2020-05-17`. */
   Date: any;
+  /**
+   * DateTime format accepting ISO 8601 dates with time zone offset.
+   *
+   * Format:  `YYYY-MM-DD'T'hh:mm[:ss](Z|±01:00)`
+   *
+   * Example: `2017-04-23T18:25:43+02:00` or `2017-04-23T16:25:43Z`
+   */
   DateTime: any;
+  /** A linear function to calculate a value(y) based on a parameter (x): `y = f(x) = a + bx`. It allows setting both a constant(a) and a coefficient(b) and the use those in the computation. Format: `a + b x`. Example: `1800 + 2.0 x` */
   DoubleFunction: any;
+  /** Duration in a lenient ISO-8601 duration format. Example P2DT2H12M40S, 2d2h12m40s or 1h */
   Duration: any;
+  /** Time using the format: HH:mm:SS. Example: 18:25:SS */
   LocalTime: any;
+  /** A 64-bit signed integer */
   Long: any;
+  /** Time using the format: `HH:MM:SS`. Example: `18:25:43` */
   Time: any;
 };
 
@@ -1375,6 +1389,8 @@ export type StopPlace = PlaceInterface & {
   parent?: Maybe<StopPlace>;
   /** Returns all quays that are children of this stop place */
   quays?: Maybe<Array<Maybe<Quay>>>;
+  /** Get all situations active for the stop place. Situations affecting individual quays are not returned, and should be fetched directly from the quay. */
+  situations: Array<PtSituationElement>;
   tariffZones: Array<Maybe<TariffZone>>;
   timeZone?: Maybe<Scalars['String']>;
   /** The transport modes of quays under this stop place. */

--- a/src/service/impl/departure-favorites/journey-gql/jp3/departure-group.graphql
+++ b/src/service/impl/departure-favorites/journey-gql/jp3/departure-group.graphql
@@ -15,7 +15,7 @@ query GroupsById(
         timeRange: $timeRange
         numberOfDeparturesPerLineAndDestinationDisplay: $limitPerLine
         numberOfDepartures: $totalLimit
-        arrivalDeparture: both
+        arrivalDeparture: departures
         includeCancelledTrips: false
         whiteListed: { lines: $filterByLineIds }
       ) {
@@ -26,7 +26,7 @@ query GroupsById(
         timeRange: $timeRange
         numberOfDepartures: $totalLimit
         numberOfDeparturesPerLineAndDestinationDisplay: 1
-        arrivalDeparture: both
+        arrivalDeparture: departures
         includeCancelledTrips: false
         whiteListed: { lines: $filterByLineIds }
       ) {

--- a/src/service/impl/departure-favorites/journey-gql/jp3/departure-group.graphql-gen.ts
+++ b/src/service/impl/departure-favorites/journey-gql/jp3/departure-group.graphql-gen.ts
@@ -154,7 +154,7 @@ export const GroupsByIdDocument = gql`
         timeRange: $timeRange
         numberOfDeparturesPerLineAndDestinationDisplay: $limitPerLine
         numberOfDepartures: $totalLimit
-        arrivalDeparture: both
+        arrivalDeparture: departures
         includeCancelledTrips: false
         whiteListed: {lines: $filterByLineIds}
       ) {
@@ -165,7 +165,7 @@ export const GroupsByIdDocument = gql`
         timeRange: $timeRange
         numberOfDepartures: $totalLimit
         numberOfDeparturesPerLineAndDestinationDisplay: 1
-        arrivalDeparture: both
+        arrivalDeparture: departures
         includeCancelledTrips: false
         whiteListed: {lines: $filterByLineIds}
       ) {

--- a/src/service/impl/departure-favorites/journey-gql/jp3/departure-time.graphql
+++ b/src/service/impl/departure-favorites/journey-gql/jp3/departure-time.graphql
@@ -10,7 +10,7 @@ query GetDepartureRealtime(
       startTime: $startTime
       numberOfDepartures: $limit
       timeRange: $timeRange
-      arrivalDeparture: both
+      arrivalDeparture: departures
       includeCancelledTrips: false
     ) {
       ...estimatedCall

--- a/src/service/impl/departure-favorites/journey-gql/jp3/departure-time.graphql-gen.ts
+++ b/src/service/impl/departure-favorites/journey-gql/jp3/departure-time.graphql-gen.ts
@@ -36,7 +36,7 @@ export const GetDepartureRealtimeDocument = gql`
       startTime: $startTime
       numberOfDepartures: $limit
       timeRange: $timeRange
-      arrivalDeparture: both
+      arrivalDeparture: departures
       includeCancelledTrips: false
     ) {
       ...estimatedCall


### PR DESCRIPTION
Not entirely sure why this was set to `both`, but there may have been a reason that means we should keep this as-is. In OTP1, the equivalent field is called `omitNonBoarding`, and departures v1 have this set to `omitNonBoarding: false`. Do you remember @mikaelbr?

fixes https://github.com/AtB-AS/kundevendt/issues/3072