### PR TITLE
fix: Return err when stop place is null

### DIFF
--- a/src/service/impl/departures/index.ts
+++ b/src/service/impl/departures/index.ts
@@ -27,6 +27,7 @@ import {
   filterStopPlaceFavorites,
   filterQuayFavorites
 } from './utils/favorites';
+import * as Boom from '@hapi/boom';
 
 export default (): IDeparturesService => {
   const api: IDeparturesService = {
@@ -77,7 +78,13 @@ export default (): IDeparturesService => {
         if (result.errors) {
           return Result.err(new APIError(result.errors));
         }
-
+        if (!result.data.stopPlaces.filter(Boolean).length) {
+          return Result.err(
+            Boom.resourceGone(
+              'Stop place not found or no longer available. (No matching stop places)'
+            )
+          );
+        }
         return Result.ok(result.data);
       } catch (error) {
         return Result.err(new APIError(error));


### PR DESCRIPTION
Return error when receving a list with stop places that do not exist to avoid the app crashing

<details>
<summary>Screenshot</summary>

![Simulator Screen Shot - iPhone 14 Pro - 2023-01-06 at 14 42 05](https://user-images.githubusercontent.com/85479566/211024255-f614a215-a087-4899-ada7-b854053d7b6b.png)
</details>

Close https://github.com/AtB-AS/kundevendt/issues/2558