### PR TITLE
test: step to fail the workflow if error

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -36,7 +36,7 @@ jobs:
           cd test && yarn webpack
 
       - name: Run API tests
-        run: ./k6 run test/dist/k6.js --env environment=staging --env runFrom=root --log-output=stdout --logformat=raw | tee test/dist/results/junitLog.txt
+        run: ./k6 run test/dist/k6.js --env environment=staging --env runFrom=root --log-output=stdout --log-format=raw | tee test/dist/results/junitLog.txt
 
       - name: Create JUnit from checks
         run: python python-tools/apiCheckToJUnit/apiCheckToJUnit.py --file junitLog.txt --folder dist/results
@@ -52,3 +52,7 @@ jobs:
           name: junit-results
           path: ./test/dist/results/combinedJUnit.xml
           retention-days: 5
+
+      - name: Re-run API tests
+        run: ./k6 run test/dist/k6.js --env environment=staging --env runFrom=root
+

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -3,7 +3,7 @@ name: API-tests
 on:
   push:
     branches:
-      - tor/api-test-yml
+      - main
   schedule:
     - cron: '0 5,7,11,14 * * *'
   workflow_dispatch:
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: tor/api-test-yml
+          ref: main
 
       - name: Install k6
         run: |

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -3,7 +3,7 @@ name: API-tests
 on:
   push:
     branches:
-      - main
+      - tor/api-test-yml
   schedule:
     - cron: '0 5,7,11,14 * * *'
   workflow_dispatch:
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: main
+          ref: tor/api-test-yml
 
       - name: Install k6
         run: |

--- a/test/src/v2/servicejourney/servicejourney.ts
+++ b/test/src/v2/servicejourney/servicejourney.ts
@@ -33,7 +33,7 @@ export function serviceJourneyDepartures(
     const serviceJourneyId = jsonTrip.trip.tripPatterns[tripNumber].legs[0]
       .serviceJourney!.id;
 
-    const urlSJD = `${conf.host()}/bff/v2/servicejourneyXX/${serviceJourneyId}/departures?date=${searchDate}`;
+    const urlSJD = `${conf.host()}/bff/v2/servicejourney/${serviceJourneyId}/departures?date=${searchDate}`;
     const resSJD = http.get(urlSJD, {
       tags: { name: requestName },
       headers: bffHeadersGet

--- a/test/src/v2/servicejourney/servicejourney.ts
+++ b/test/src/v2/servicejourney/servicejourney.ts
@@ -33,7 +33,7 @@ export function serviceJourneyDepartures(
     const serviceJourneyId = jsonTrip.trip.tripPatterns[tripNumber].legs[0]
       .serviceJourney!.id;
 
-    const urlSJD = `${conf.host()}/bff/v2/servicejourney/${serviceJourneyId}/departures?date=${searchDate}`;
+    const urlSJD = `${conf.host()}/bff/v2/servicejourneyXX/${serviceJourneyId}/departures?date=${searchDate}`;
     const resSJD = http.get(urlSJD, {
       tags: { name: requestName },
       headers: bffHeadersGet


### PR DESCRIPTION
The `Run API tests` step does not fail the tests since the `| ...` is always successful. Adds a new step that fails the workflow (a cheapy trick, I know).