### PR TITLE
test: error handling for api tests

### DIFF
--- a/test/src/config/configuration.ts
+++ b/test/src/config/configuration.ts
@@ -74,7 +74,7 @@ export const metrics = {
   },
   //Add to failure rate if one of multiple checks is false
   //Format expectsArray: [{'check': '<description>', 'expect': '<check>'}, {...}, ...]
-  addFailureIfMultipleChecks(
+  checkForFailures(
     urls: string[],
     duration: number,
     requestName: string,

--- a/test/src/k6.ts
+++ b/test/src/k6.ts
@@ -19,7 +19,6 @@ import { Options } from 'k6/options';
 import { conf } from './config/configuration';
 import { scn } from './scenario';
 import { createJUnitCheckOutput } from './utils/log';
-//WIP
 /* @ts-ignore */
 import { jUnit, textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
 

--- a/test/src/scenario.ts
+++ b/test/src/scenario.ts
@@ -43,7 +43,7 @@ const bff = (): void => {
 const test = (): void => {
   const searchDate = getNextThursday();
   //departuresScenario(searchDate);
-  serviceJourneyScenario(searchDate);
+  serviceJourneyScenarioV1(searchDate);
 };
 
 //Performance test

--- a/test/src/v1/geocoder/geocoder.ts
+++ b/test/src/v1/geocoder/geocoder.ts
@@ -24,51 +24,67 @@ export function geocoderFeatures(
       tags: { name: requestName },
       headers: bffHeadersGet
     });
-    const json = res.json() as GeocoderFeatureResponseType;
 
     const expects: ExpectsType = [
       { check: 'should have status 200', expect: res.status === 200 }
     ];
 
-    // Asserts
-    for (let expResult of test.expectedResults) {
-      expects.push(
-        {
-          check: `should include "${expResult.id}"`,
-          expect: json
-            .map(feature => feature.properties.id)
-            .includes(expResult.id)
-        },
-        {
-          check: `should have correct name for "${expResult.id}"`,
-          expect:
-            json.filter(feature => feature.properties.id === expResult.id)[0]
-              .properties.name === expResult.name
-        },
-        {
-          check: `should include category "${expResult.category}" for "${expResult.id}"`,
-          expect: json
-            .filter(feature => feature.properties.id === expResult.id)[0]
-            .properties.category.flat()
-            .includes(expResult.category)
-        }
+    try {
+      const json = res.json() as GeocoderFeatureResponseType;
+
+      // Asserts
+      for (let expResult of test.expectedResults) {
+        expects.push(
+          {
+            check: `should include "${expResult.id}"`,
+            expect: json
+              .map(feature => feature.properties.id)
+              .includes(expResult.id)
+          },
+          {
+            check: `should have correct name for "${expResult.id}"`,
+            expect:
+              json.filter(feature => feature.properties.id === expResult.id)[0]
+                .properties.name === expResult.name
+          },
+          {
+            check: `should include category "${expResult.category}" for "${expResult.id}"`,
+            expect: json
+              .filter(feature => feature.properties.id === expResult.id)[0]
+              .properties.category.flat()
+              .includes(expResult.category)
+          }
+        );
+      }
+
+      // Assert if more hits
+      if (test.moreResults) {
+        expects.push({
+          check: `should have more hits than ${test.expectedResults.length}`,
+          expect: json.length > test.expectedResults.length
+        });
+      }
+
+      metrics.checkForFailures(
+        [res.request.url],
+        res.timings.duration,
+        requestName,
+        expects
+      );
+    } catch (exp) {
+      //throw exp
+      metrics.checkForFailures(
+        [res.request.url],
+        res.timings.duration,
+        requestName,
+        [
+          {
+            check: `${exp}`,
+            expect: false
+          }
+        ]
       );
     }
-
-    // Assert if more hits
-    if (test.moreResults) {
-      expects.push({
-        check: `should have more hits than ${test.expectedResults.length}`,
-        expect: json.length > test.expectedResults.length
-      });
-    }
-
-    metrics.addFailureIfMultipleChecks(
-      [res.request.url],
-      res.timings.duration,
-      requestName,
-      expects
-    );
   }
 }
 
@@ -88,50 +104,66 @@ export function geocoderReverse(
       tags: { name: requestName },
       headers: bffHeadersGet
     });
-    const json = res.json() as GeocoderReverseResponseType;
 
     const expects: ExpectsType = [
       { check: 'should have status 200', expect: res.status === 200 }
     ];
 
-    // Asserts
-    for (let expResult of test.expectedResults) {
-      expects.push(
-        {
-          check: `should include "${expResult.id}"`,
-          expect: json
-            .map(feature => feature.properties.id)
-            .includes(expResult.id)
-        },
-        {
-          check: `should have correct name for "${expResult.id}"`,
-          expect:
-            json.filter(feature => feature.properties.id === expResult.id)[0]
-              .properties.name === expResult.name
-        },
-        {
-          check: `should include category "${expResult.category}" for "${expResult.id}"`,
-          expect: json
-            .filter(feature => feature.properties.id === expResult.id)[0]
-            .properties.category.flat()
-            .includes(expResult.category)
-        }
+    try {
+      const json = res.json() as GeocoderReverseResponseType;
+
+      // Asserts
+      for (let expResult of test.expectedResults) {
+        expects.push(
+          {
+            check: `should include "${expResult.id}"`,
+            expect: json
+              .map(feature => feature.properties.id)
+              .includes(expResult.id)
+          },
+          {
+            check: `should have correct name for "${expResult.id}"`,
+            expect:
+              json.filter(feature => feature.properties.id === expResult.id)[0]
+                .properties.name === expResult.name
+          },
+          {
+            check: `should include category "${expResult.category}" for "${expResult.id}"`,
+            expect: json
+              .filter(feature => feature.properties.id === expResult.id)[0]
+              .properties.category.flat()
+              .includes(expResult.category)
+          }
+        );
+      }
+
+      // Assert if more hits
+      if (test.moreResults) {
+        expects.push({
+          check: `should have more hits than ${test.expectedResults.length}`,
+          expect: json.length > test.expectedResults.length
+        });
+      }
+
+      metrics.checkForFailures(
+        [res.request.url],
+        res.timings.duration,
+        requestName,
+        expects
+      );
+    } catch (exp) {
+      //throw exp
+      metrics.checkForFailures(
+        [res.request.url],
+        res.timings.duration,
+        requestName,
+        [
+          {
+            check: `${exp}`,
+            expect: false
+          }
+        ]
       );
     }
-
-    // Assert if more hits
-    if (test.moreResults) {
-      expects.push({
-        check: `should have more hits than ${test.expectedResults.length}`,
-        expect: json.length > test.expectedResults.length
-      });
-    }
-
-    metrics.addFailureIfMultipleChecks(
-      [res.request.url],
-      res.timings.duration,
-      requestName,
-      expects
-    );
   }
 }

--- a/test/src/v1/servicejourney/servicejourney.ts
+++ b/test/src/v1/servicejourney/servicejourney.ts
@@ -1,8 +1,9 @@
 import http from 'k6/http';
 import { ExpectsType, conf, metrics } from '../../config/configuration';
 import { bffHeadersGet, bffHeadersPost } from '../../utils/headers';
-import { serviceJourneyTestDataType } from '../types';
+import { serviceJourneyTestDataType } from '../../v2/types';
 import { JSONArray, JSONValue } from 'k6';
+import { TripsQuery } from '../../../../src/service/impl/trips/journey-gql/trip.graphql-gen';
 
 export const serviceJourneyDepartures = (
   testData: serviceJourneyTestDataType,
@@ -15,15 +16,33 @@ export const serviceJourneyDepartures = (
     )}`;
 
     // Get service journey id
-    const urlTrip = `${conf.host()}/bff/v1/journey/trip`;
-    test.query.searchDate = searchTime;
+    const urlTrip = `${conf.host()}/bff/v2/trips`;
+    test.query.when = searchTime;
     const resTrip = http.post(urlTrip, JSON.stringify(test.query), {
       tags: { name: requestName },
       headers: bffHeadersPost
     });
-    const serviceJourneyId = resTrip.json(
-      '@this.0.legs.0.serviceJourney.id'
-    ) as string;
+    let serviceJourneyId = '';
+
+    const expects: ExpectsType = [
+      {
+        check: 'should have status 200 on /trip',
+        expect: resTrip.status === 200
+      }
+    ];
+
+    try {
+      const jsonTrip = resTrip.json() as TripsQuery;
+      const tripNumber =
+        jsonTrip.trip.tripPatterns[0].legs[0].mode === 'bus' ? 0 : 1;
+      serviceJourneyId = jsonTrip.trip.tripPatterns[tripNumber].legs[0]
+        .serviceJourney!.id;
+    } catch (exp) {
+      expects.push({
+        check: `${exp}`,
+        expect: false
+      });
+    }
 
     const urlSJD = `${conf.host()}/bff/v1/servicejourney/${serviceJourneyId}/departures?date=${searchDate}`;
     const resSJD = http.get(urlSJD, {
@@ -31,33 +50,32 @@ export const serviceJourneyDepartures = (
       headers: bffHeadersGet
     });
 
-    const expects: ExpectsType = [
-      {
-        check: 'should have status 200 on /trip',
-        expect: resTrip.status === 200
-      },
-      {
-        check: 'should have status 200 on /servicejourney',
-        expect: resSJD.status === 200
-      }
-    ];
-
-    // Assert
-    expects.push(
-      {
-        check: 'should have departures',
-        expect: (resSJD.json('value.#') as number) > 0
-      },
-      {
-        check: 'should only have departures for the service journey',
-        expect:
-          (resSJD.json('value.#.serviceJourney.id') as JSONArray).filter(
-            (e: JSONValue) => (e as string) !== serviceJourneyId
-          ).length === 0
-      }
-    );
-
-    metrics.addFailureIfMultipleChecks(
+    try {
+      // Assert
+      expects.push(
+        {
+          check: 'should have status 200 on /servicejourney',
+          expect: resSJD.status === 200
+        },
+        {
+          check: 'should have departures',
+          expect: (resSJD.json('value.#') as number) > 0
+        },
+        {
+          check: 'should only have departures for the service journey',
+          expect:
+            (resSJD.json('value.#.serviceJourney.id') as JSONArray).filter(
+              (e: JSONValue) => (e as string) !== serviceJourneyId
+            ).length === 0
+        }
+      );
+    } catch (exp) {
+      expects.push({
+        check: `${exp}`,
+        expect: false
+      });
+    }
+    metrics.checkForFailures(
       [resTrip.request.url, resSJD.request.url],
       resTrip.timings.duration + resSJD.timings.duration,
       requestName,
@@ -75,59 +93,83 @@ export function serviceJourneyPolyline(
     const requestName = `v1_serviceJourneyPolyline_${testData.scenarios.indexOf(
       test
     )}`;
+    let totDuration = 0;
 
     // Get necessary parameters
-    const urlTrip = `${conf.host()}/bff/v1/journey/trip`;
-    test.query.searchDate = searchTime;
+    const urlTrip = `${conf.host()}/bff/v2/trips`;
+    test.query.when = searchTime;
     const resTrip = http.post(urlTrip, JSON.stringify(test.query), {
       tags: { name: requestName },
-      headers: bffHeadersGet
+      headers: bffHeadersPost
     });
-    const serviceJourneyId = resTrip.json(
-      '@this.0.legs.0.serviceJourney.id'
-    ) as string;
-    const fromQuayId = resTrip.json(
-      '@this.0.legs.0.fromPlace.quay.id'
-    ) as string;
-    const toQuayId = resTrip.json('@this.0.legs.0.toPlace.quay.id') as string;
+    totDuration += resTrip.timings.duration;
 
-    // Both to and from
-    const urlPoly = `${conf.host()}/bff/v1/servicejourney/${serviceJourneyId}/polyline?fromQuayId=${fromQuayId}&toQuayId=${toQuayId}`;
-    const resPoly = http.get(urlPoly, {
-      tags: { name: requestName },
-      headers: bffHeadersGet
-    });
-    // Only from
-    const urlPoly2 = `${conf.host()}/bff/v1/servicejourney/${serviceJourneyId}/polyline?fromQuayId=${fromQuayId}`;
-    const resPoly2 = http.get(urlPoly2, {
-      tags: { name: requestName },
-      headers: bffHeadersGet
-    });
+    try {
+      const jsonTrip = resTrip.json() as TripsQuery;
+      let serviceJourneyId = '';
+      let fromQuayId = '';
+      let toQuayId = '';
 
-    const expects: ExpectsType = [
-      {
-        check: 'should have status 200 on /trip',
-        expect: resTrip.status === 200
-      },
-      {
-        check: 'should have status 200 on /polyline',
-        expect: resPoly.status === 200 && resPoly2.status === 200
-      },
-      {
-        check: 'should have map legs from /polyline',
-        expect:
-          (resPoly.json('mapLegs.#') as number) > 0 &&
-          (resPoly2.json('mapLegs.#') as number) > 0
+      // Walk through the trip patterns
+      for (let trip of jsonTrip.trip.tripPatterns) {
+        // Only consider direct busses
+        if (trip.legs.length === 1 && trip.legs[0].mode === 'bus') {
+          serviceJourneyId = trip.legs[0].serviceJourney!.id;
+          fromQuayId = trip.legs[0].fromPlace.quay!.id;
+          toQuayId = trip.legs[0].toPlace.quay!.id;
+          break;
+        }
       }
-    ];
 
-    metrics.addFailureIfMultipleChecks(
-      [resTrip.request.url, resPoly.request.url, resPoly2.request.url],
-      resTrip.timings.duration +
-        resPoly.timings.duration +
-        resPoly2.timings.duration,
-      requestName,
-      expects
-    );
+      // Both to and from
+      const urlPoly = `${conf.host()}/bff/v1/servicejourney/${serviceJourneyId}/polyline?fromQuayId=${fromQuayId}&toQuayId=${toQuayId}`;
+      const resPoly = http.get(urlPoly, {
+        tags: { name: requestName },
+        headers: bffHeadersGet
+      });
+      // Only from
+      const urlPoly2 = `${conf.host()}/bff/v1/servicejourney/${serviceJourneyId}/polyline?fromQuayId=${fromQuayId}`;
+      const resPoly2 = http.get(urlPoly2, {
+        tags: { name: requestName },
+        headers: bffHeadersGet
+      });
+      totDuration += resPoly.timings.duration + resPoly2.timings.duration;
+
+      const expects: ExpectsType = [
+        {
+          check: 'should have status 200 on /trip',
+          expect: resTrip.status === 200
+        },
+        {
+          check: 'should have status 200 on /polyline',
+          expect: resPoly.status === 200 && resPoly2.status === 200
+        },
+        {
+          check: 'should have map legs from /polyline',
+          expect:
+            (resPoly.json('mapLegs.#') as number) > 0 &&
+            (resPoly2.json('mapLegs.#') as number) > 0
+        }
+      ];
+
+      metrics.checkForFailures(
+        [resTrip.request.url, resPoly.request.url, resPoly2.request.url],
+        totDuration,
+        requestName,
+        expects
+      );
+    } catch (exp) {
+      metrics.checkForFailures(
+        [`${conf.host()}/bff/v1/servicejourney/`],
+        totDuration,
+        requestName,
+        [
+          {
+            check: `${exp}`,
+            expect: false
+          }
+        ]
+      );
+    }
   }
 }

--- a/test/src/v1/v1Scenario.ts
+++ b/test/src/v1/v1Scenario.ts
@@ -7,9 +7,9 @@ import {
   departuresGroupedTestData,
   geocoderFeaturesTestData,
   geocoderReverseTestData,
-  tripTestData,
-  serviceJourneyTestData
+  tripTestData
 } from './testData/testData';
+import { serviceJourneyTestData } from '../v2/testData/testData';
 import { geocoderFeatures, geocoderReverse } from './geocoder';
 import { trip } from './journey';
 import {

--- a/test/src/v2/departures/departures.ts
+++ b/test/src/v2/departures/departures.ts
@@ -20,41 +20,60 @@ export function realtime(
     tags: { name: requestName },
     headers: bffHeadersGet
   });
-  const json = res.json() as RealtimeResponseType;
-
-  // Get departure times
-  const depTimes = [];
-  const serviceJourneys = Object.keys(json[quayId].departures);
-  for (let journey of serviceJourneys) {
-    depTimes.push(
-      json[quayId].departures[journey].timeData.expectedDepartureTime
-    );
-  }
 
   const expects: ExpectsType = [
     {
       check: 'should have status 200',
       expect: res.status === 200
-    },
-    {
-      check: 'should have correct quayId',
-      expect: json[quayId].quayId === quayId
-    },
-    {
-      check: 'should have 10 departures',
-      expect: Object.keys(json[quayId].departures).length === 10
-    },
-    {
-      check: 'should have departure times after start time',
-      expect: departsAfterExpectedStartTime(depTimes, startTime)
     }
   ];
-  metrics.addFailureIfMultipleChecks(
-    [res.request.url],
-    res.timings.duration,
-    requestName,
-    expects
-  );
+
+  try {
+    const json = res.json() as RealtimeResponseType;
+
+    // Get departure times
+    const depTimes = [];
+    const serviceJourneys = Object.keys(json[quayId].departures);
+    for (let journey of serviceJourneys) {
+      depTimes.push(
+        json[quayId].departures[journey].timeData.expectedDepartureTime
+      );
+    }
+
+    expects.push(
+      {
+        check: 'should have correct quayId',
+        expect: json[quayId].quayId === quayId
+      },
+      {
+        check: 'should have 10 departures',
+        expect: Object.keys(json[quayId].departures).length === 10
+      },
+      {
+        check: 'should have departure times after start time',
+        expect: departsAfterExpectedStartTime(depTimes, startTime)
+      }
+    );
+    metrics.checkForFailures(
+      [res.request.url],
+      res.timings.duration,
+      requestName,
+      expects
+    );
+  } catch (exp) {
+    //throw exp
+    metrics.checkForFailures(
+      [res.request.url],
+      res.timings.duration,
+      requestName,
+      [
+        {
+          check: `${exp}`,
+          expect: false
+        }
+      ]
+    );
+  }
 }
 
 export function stopDepartures(
@@ -70,35 +89,54 @@ export function stopDepartures(
     tags: { name: requestName },
     headers: bffHeadersPost
   });
-  const json = res.json() as StopPlaceQuayDeparturesQuery;
 
   const expects: ExpectsType = [
     {
       check: 'should have status 200',
       expect: res.status === 200
-    },
-    {
-      check: 'should have correct stopId',
-      expect: json.stopPlace!.id === stopId
-    },
-    {
-      check: 'should have correct number of quays',
-      expect: json.stopPlace!.quays!.length === 2
-    },
-    {
-      check: 'should only include start date quay 1',
-      expect:
-        json
-          .stopPlace!.quays!.map(quay => quay.estimatedCalls[0].date)
-          .filter(date => date !== startDate).length === 0
     }
   ];
-  metrics.addFailureIfMultipleChecks(
-    [res.request.url],
-    res.timings.duration,
-    requestName,
-    expects
-  );
+
+  try {
+    const json = res.json() as StopPlaceQuayDeparturesQuery;
+
+    expects.push(
+      {
+        check: 'should have correct stopId',
+        expect: json.stopPlace!.id === stopId
+      },
+      {
+        check: 'should have correct number of quays',
+        expect: json.stopPlace!.quays!.length === 2
+      },
+      {
+        check: 'should only include start date quay 1',
+        expect:
+          json
+            .stopPlace!.quays!.map(quay => quay.estimatedCalls[0].date)
+            .filter(date => date !== startDate).length === 0
+      }
+    );
+    metrics.checkForFailures(
+      [res.request.url],
+      res.timings.duration,
+      requestName,
+      expects
+    );
+  } catch (exp) {
+    //throw exp
+    metrics.checkForFailures(
+      [res.request.url],
+      res.timings.duration,
+      requestName,
+      [
+        {
+          check: `${exp}`,
+          expect: false
+        }
+      ]
+    );
+  }
 }
 
 export function stopDeparturesPOSTandGET(
@@ -119,22 +157,37 @@ export function stopDeparturesPOSTandGET(
     headers: bffHeadersPost
   });
 
-  const expects: ExpectsType = [
-    { check: 'should have status 200', expect: resGET.status === 200 },
-    { check: 'should have status 200', expect: resPOST.status === 200 },
-    {
-      check: 'should have equal responses',
-      expect:
-        (resGET.json() as JSONObject).toString() ===
-        (resPOST.json() as JSONObject).toString()
-    }
-  ];
-  metrics.addFailureIfMultipleChecks(
-    [resGET.request.url],
-    resGET.timings.duration + resPOST.timings.duration,
-    requestName,
-    expects
-  );
+  try {
+    const expects: ExpectsType = [
+      { check: 'should have status 200', expect: resGET.status === 200 },
+      { check: 'should have status 200', expect: resPOST.status === 200 },
+      {
+        check: 'should have equal responses',
+        expect:
+          (resGET.json() as JSONObject).toString() ===
+          (resPOST.json() as JSONObject).toString()
+      }
+    ];
+    metrics.checkForFailures(
+      [resGET.request.url],
+      resGET.timings.duration + resPOST.timings.duration,
+      requestName,
+      expects
+    );
+  } catch (exp) {
+    //throw exp
+    metrics.checkForFailures(
+      [resGET.request.url],
+      resGET.timings.duration + resPOST.timings.duration,
+      requestName,
+      [
+        {
+          check: `${exp}`,
+          expect: false
+        }
+      ]
+    );
+  }
 }
 
 // Check that stop departures corresponds to the individual quay departures
@@ -149,35 +202,51 @@ export function quayDeparturesVsStopDepartures(
     tags: { name: requestName },
     headers: bffHeadersPost
   });
-  const jsonSD = resSD.json() as StopPlaceQuayDeparturesQuery;
 
-  // Check equality on each quay
-  const quays = jsonSD.stopPlace!.quays!.map(el => el.id);
-  for (let quay of quays) {
-    const urlQD = `${conf.host()}/bff/v2/departures/quay-departures?id=${quay}&numberOfDepartures=10&startTime=${startDate}T00:00:00.000Z&timeRange=86400`;
-    const resQD = http.post(urlQD, '{}', {
-      tags: { name: requestName },
-      headers: bffHeadersPost
-    });
-    const jsonQD = resQD.json() as QuayDeparturesQuery;
+  try {
+    const jsonSD = resSD.json() as StopPlaceQuayDeparturesQuery;
 
-    const expects: ExpectsType = [
-      { check: 'should have status 200', expect: resSD.status === 200 },
-      { check: 'should have status 200', expect: resQD.status === 200 },
-      {
-        check: 'should return same quay departures',
-        expect: isEqual(
-          jsonSD.stopPlace!.quays!.filter(quayEl => quayEl.id === quay)[0]
-            .estimatedCalls,
-          jsonQD.quay?.estimatedCalls!
-        )
-      }
-    ];
-    metrics.addFailureIfMultipleChecks(
-      [resSD.request.url, resQD.request.url],
-      resSD.timings.duration + resQD.timings.duration,
-      `${requestName}_${quay}`,
-      expects
+    // Check equality on each quay
+    const quays = jsonSD.stopPlace!.quays!.map(el => el.id);
+    for (let quay of quays) {
+      const urlQD = `${conf.host()}/bff/v2/departures/quay-departures?id=${quay}&numberOfDepartures=10&startTime=${startDate}T00:00:00.000Z&timeRange=86400`;
+      const resQD = http.post(urlQD, '{}', {
+        tags: { name: requestName },
+        headers: bffHeadersPost
+      });
+      const jsonQD = resQD.json() as QuayDeparturesQuery;
+
+      const expects: ExpectsType = [
+        { check: 'should have status 200', expect: resSD.status === 200 },
+        { check: 'should have status 200', expect: resQD.status === 200 },
+        {
+          check: 'should return same quay departures',
+          expect: isEqual(
+            jsonSD.stopPlace!.quays!.filter(quayEl => quayEl.id === quay)[0]
+              .estimatedCalls,
+            jsonQD.quay?.estimatedCalls!
+          )
+        }
+      ];
+      metrics.checkForFailures(
+        [resSD.request.url, resQD.request.url],
+        resSD.timings.duration + resQD.timings.duration,
+        `${requestName}_${quay}`,
+        expects
+      );
+    }
+  } catch (exp) {
+    //throw exp
+    metrics.checkForFailures(
+      [resSD.request.url],
+      resSD.timings.duration,
+      requestName,
+      [
+        {
+          check: `${exp}`,
+          expect: false
+        }
+      ]
     );
   }
 }
@@ -195,27 +264,46 @@ export function quayDepartures(
     tags: { name: requestName },
     headers: bffHeadersPost
   });
-  const json = res.json() as QuayDeparturesQuery;
 
   const expects: ExpectsType = [
-    { check: 'should have status 200', expect: res.status === 200 },
-    {
-      check: 'should have correct quayId',
-      expect: json.quay!.id === quayId
-    },
-    {
-      check: 'should only include start date',
-      expect:
-        json.quay!.estimatedCalls.filter(call => call.date !== startDate)
-          .length === 0
-    }
+    { check: 'should have status 200', expect: res.status === 200 }
   ];
-  metrics.addFailureIfMultipleChecks(
-    [res.request.url],
-    res.timings.duration,
-    requestName,
-    expects
-  );
+
+  try {
+    const json = res.json() as QuayDeparturesQuery;
+
+    expects.push(
+      {
+        check: 'should have correct quayId',
+        expect: json.quay!.id === quayId
+      },
+      {
+        check: 'should only include start date',
+        expect:
+          json.quay!.estimatedCalls.filter(call => call.date !== startDate)
+            .length === 0
+      }
+    );
+    metrics.checkForFailures(
+      [res.request.url],
+      res.timings.duration,
+      requestName,
+      expects
+    );
+  } catch (exp) {
+    //throw exp
+    metrics.checkForFailures(
+      [res.request.url],
+      res.timings.duration,
+      requestName,
+      [
+        {
+          check: `${exp}`,
+          expect: false
+        }
+      ]
+    );
+  }
 }
 
 export function quayDeparturesPOSTandGET(
@@ -238,20 +326,36 @@ export function quayDeparturesPOSTandGET(
 
   const expects: ExpectsType = [
     { check: 'should have status 200', expect: resGET.status === 200 },
-    { check: 'should have status 200', expect: resPOST.status === 200 },
-    {
+    { check: 'should have status 200', expect: resPOST.status === 200 }
+  ];
+
+  try {
+    expects.push({
       check: 'should have equal responses',
       expect:
         (resGET.json() as JSONObject).toString() ===
         (resPOST.json() as JSONObject).toString()
-    }
-  ];
-  metrics.addFailureIfMultipleChecks(
-    [resGET.request.url],
-    resGET.timings.duration + resPOST.timings.duration,
-    requestName,
-    expects
-  );
+    });
+    metrics.checkForFailures(
+      [resGET.request.url],
+      resGET.timings.duration + resPOST.timings.duration,
+      requestName,
+      expects
+    );
+  } catch (exp) {
+    //throw exp
+    metrics.checkForFailures(
+      [resGET.request.url],
+      resGET.timings.duration + resPOST.timings.duration,
+      requestName,
+      [
+        {
+          check: `${exp}`,
+          expect: false
+        }
+      ]
+    );
+  }
 }
 
 // Check that realtime updates for a quay corresponds to quay departures
@@ -262,48 +366,69 @@ export function realtimeForQuayDepartures(quayId: string, startDate: string) {
     tags: { name: requestName },
     headers: bffHeadersPost
   });
-  const jsonQD = resQD.json() as QuayDeparturesQuery;
-
-  // Get realtime to compare
-  const urlR = `${conf.host()}/bff/v2/departures/realtime?quayIds=${quayId}&startTime=${startDate}T00:00:00.000Z&limit=10`;
-  const resR = http.get(urlR, {
-    tags: { name: requestName },
-    headers: bffHeadersGet
-  });
-  const jsonR = resR.json() as RealtimeResponseType;
-  // Get departure times
-  const depTimes = [];
-  const serviceJourneys = Object.keys(jsonR[quayId].departures);
-  for (let journey of serviceJourneys) {
-    depTimes.push(
-      jsonR[quayId].departures[journey].timeData.expectedDepartureTime
-    );
-  }
 
   const expects: ExpectsType = [
-    { check: 'should have status 200', expect: resQD.status === 200 },
-    { check: 'should have status 200', expect: resR.status === 200 },
-    {
-      check: 'should return correct realtime departure times',
-      expect: isEqual(
-        jsonQD
-          .quay!.estimatedCalls.map(call => call.expectedDepartureTime)
-          .sort(),
-        depTimes.sort()
-      )
-    },
-    {
-      check: 'should return correct service journeys',
-      expect: isEqual(
-        jsonQD.quay!.estimatedCalls.map(call => call.serviceJourney!.id).sort(),
-        Object.keys(jsonR[quayId].departures).sort()
-      )
-    }
+    { check: 'should have status 200', expect: resQD.status === 200 }
   ];
-  metrics.addFailureIfMultipleChecks(
-    [resQD.request.url, resR.request.url],
-    resQD.timings.duration + resR.timings.duration,
-    requestName,
-    expects
-  );
+
+  try {
+    const jsonQD = resQD.json() as QuayDeparturesQuery;
+
+    // Get realtime to compare
+    const urlR = `${conf.host()}/bff/v2/departures/realtime?quayIds=${quayId}&startTime=${startDate}T00:00:00.000Z&limit=10`;
+    const resR = http.get(urlR, {
+      tags: { name: requestName },
+      headers: bffHeadersGet
+    });
+    const jsonR = resR.json() as RealtimeResponseType;
+    // Get departure times
+    const depTimes = [];
+    const serviceJourneys = Object.keys(jsonR[quayId].departures);
+    for (let journey of serviceJourneys) {
+      depTimes.push(
+        jsonR[quayId].departures[journey].timeData.expectedDepartureTime
+      );
+    }
+
+    expects.push(
+      { check: 'should have status 200', expect: resR.status === 200 },
+      {
+        check: 'should return correct realtime departure times',
+        expect: isEqual(
+          jsonQD
+            .quay!.estimatedCalls.map(call => call.expectedDepartureTime)
+            .sort(),
+          depTimes.sort()
+        )
+      },
+      {
+        check: 'should return correct service journeys',
+        expect: isEqual(
+          jsonQD
+            .quay!.estimatedCalls.map(call => call.serviceJourney!.id)
+            .sort(),
+          Object.keys(jsonR[quayId].departures).sort()
+        )
+      }
+    );
+    metrics.checkForFailures(
+      [resQD.request.url, resR.request.url],
+      resQD.timings.duration + resR.timings.duration,
+      requestName,
+      expects
+    );
+  } catch (exp) {
+    //throw exp
+    metrics.checkForFailures(
+      [resQD.request.url],
+      resQD.timings.duration,
+      requestName,
+      [
+        {
+          check: `${exp}`,
+          expect: false
+        }
+      ]
+    );
+  }
 }

--- a/test/src/v2/departures/favorites.ts
+++ b/test/src/v2/departures/favorites.ts
@@ -20,73 +20,89 @@ export function departureFavorites(
       tags: { name: requestName },
       headers: bffHeadersPost
     });
-    const json = res.json() as FavoriteResponseType;
 
-    const expStopPlaceIds = test.favorites.map(e => e.stopId).sort();
-    const resStopPlaceIds = json.data.map(fav => fav.stopPlace.id).sort();
-    const expQuayIds = test.favorites.map(e => e.quayId).sort();
-    const expLineIds = test.favorites.map(e => e.lineId).sort();
-    const resQuayIds = json.data
-      .map(fav => fav.quays.map(quay => quay.quay.id))
-      .flat();
+    try {
+      const json = res.json() as FavoriteResponseType;
 
-    const expects: ExpectsType = [
-      { check: 'should have status 200', expect: res.status === 200 }
-    ];
+      const expStopPlaceIds = test.favorites.map(e => e.stopId).sort();
+      const resStopPlaceIds = json.data.map(fav => fav.stopPlace.id).sort();
+      const expQuayIds = test.favorites.map(e => e.quayId).sort();
+      const expLineIds = test.favorites.map(e => e.lineId).sort();
+      const resQuayIds = json.data
+        .map(fav => fav.quays.map(quay => quay.quay.id))
+        .flat();
 
-    //Correct stop places
-    expects.push({
-      check: `should have correct stop place(s)`,
-      expect: resStopPlaceIds.toString() === expStopPlaceIds.toString()
-    });
-    // Correct quays
-    for (let quayId of expQuayIds) {
+      const expects: ExpectsType = [
+        { check: 'should have status 200', expect: res.status === 200 }
+      ];
+
+      //Correct stop places
       expects.push({
-        check: `should include quay '${quayId}'`,
-        expect: resQuayIds.includes(quayId)
+        check: `should have correct stop place(s)`,
+        expect: resStopPlaceIds.toString() === expStopPlaceIds.toString()
       });
-    }
-    // Correct lineId, date on departures and number of departures - only for those requested
-    for (let stopPlace of json.data) {
-      for (let quay of stopPlace.quays) {
-        if (expQuayIds.includes(quay.quay.id)) {
-          expects.push({
-            check: `quay '${quay.quay.id}' should have departures`,
-            expect: quay.group.length > 0
-          });
-          for (let line of quay.group) {
-            expects.push(
-              {
-                check: `should have correct line from quay '${quay.quay.id}'`,
-                expect: expLineIds.includes(line.lineInfo.lineId)
-              },
-              {
-                check: `should have correct date for departures from quay '${quay.quay.id}'`,
-                expect:
-                  line.departures.filter(dep => dep.serviceDate !== startDate)
-                    .length === 0
-              },
-              {
-                check: `should have correct number of departures from quay '${quay.quay.id}'`,
-                expect: line.departures.length === limitPerLine
-              }
-            );
+      // Correct quays
+      for (let quayId of expQuayIds) {
+        expects.push({
+          check: `should include quay '${quayId}'`,
+          expect: resQuayIds.includes(quayId)
+        });
+      }
+      // Correct lineId, date on departures and number of departures - only for those requested
+      for (let stopPlace of json.data) {
+        for (let quay of stopPlace.quays) {
+          if (expQuayIds.includes(quay.quay.id)) {
+            expects.push({
+              check: `quay '${quay.quay.id}' should have departures`,
+              expect: quay.group.length > 0
+            });
+            for (let line of quay.group) {
+              expects.push(
+                {
+                  check: `should have correct line from quay '${quay.quay.id}'`,
+                  expect: expLineIds.includes(line.lineInfo.lineId)
+                },
+                {
+                  check: `should have correct date for departures from quay '${quay.quay.id}'`,
+                  expect:
+                    line.departures.filter(dep => dep.serviceDate !== startDate)
+                      .length === 0
+                },
+                {
+                  check: `should have correct number of departures from quay '${quay.quay.id}'`,
+                  expect: line.departures.length === limitPerLine
+                }
+              );
+            }
+          } else {
+            expects.push({
+              check: `quay '${quay.quay.id}' should not have departures`,
+              expect: quay.group.length === 0
+            });
           }
-        } else {
-          expects.push({
-            check: `quay '${quay.quay.id}' should not have departures`,
-            expect: quay.group.length === 0
-          });
         }
       }
-    }
 
-    metrics.addFailureIfMultipleChecks(
-      [res.request.url],
-      res.timings.duration,
-      requestName,
-      expects
-    );
+      metrics.checkForFailures(
+        [res.request.url],
+        res.timings.duration,
+        requestName,
+        expects
+      );
+    } catch (exp) {
+      //throw exp
+      metrics.checkForFailures(
+        [res.request.url],
+        res.timings.duration,
+        requestName,
+        [
+          {
+            check: `${exp}`,
+            expect: false
+          }
+        ]
+      );
+    }
   }
 }
 
@@ -105,7 +121,6 @@ export function departureFavoritesVsQuayDepartures(
     tags: { name: requestName },
     headers: bffHeadersPost
   });
-  const jsonFav = resFav.json() as FavoriteResponseType;
 
   // Get departures to assert favorite results
   const urlDep = `${conf.host()}/bff/v2/departures/quay-departures?id=${
@@ -115,43 +130,60 @@ export function departureFavoritesVsQuayDepartures(
     tags: { name: requestName },
     headers: bffHeadersPost
   });
-  const jsonDep = resDep.json() as QuayDeparturesQuery;
 
-  const expects: ExpectsType = [
-    {
-      check: 'should have status 200',
-      expect: resFav.status === 200 && resDep.status === 200
-    }
-  ];
+  try {
+    const jsonFav = resFav.json() as FavoriteResponseType;
+    const jsonDep = resDep.json() as QuayDeparturesQuery;
 
-  // Assert: same service journeys and  aimed dep time as /quay-departures:
-  const serviceJourneyFavorites = jsonFav.data[0].quays
-    .filter(quay => quay.quay.id === testScenario.favorites[0].quayId)[0]
-    .group[0].departures.map(dep => dep.serviceJourneyId);
-  const serviceJourneyDepartures = jsonDep.quay!.estimatedCalls.map(
-    call => call.serviceJourney!.id
-  );
-  const aimedTimeFavorites = jsonFav.data[0].quays
-    .filter(quay => quay.quay.id === testScenario.favorites[0].quayId)[0]
-    .group[0].departures.map(dep => dep.aimedTime);
-  const aimedTimeDepartures = jsonDep.quay!.estimatedCalls.map(
-    call => call.aimedDepartureTime
-  );
-  expects.push(
-    {
-      check: 'favorite departures should have the same service journeys',
-      expect: isEqual(serviceJourneyFavorites, serviceJourneyDepartures)
-    },
-    {
-      check: 'favorite departures should have the same aimed time',
-      expect: isEqual(aimedTimeFavorites, aimedTimeDepartures)
-    }
-  );
+    const expects: ExpectsType = [
+      {
+        check: 'should have status 200',
+        expect: resFav.status === 200 && resDep.status === 200
+      }
+    ];
 
-  metrics.addFailureIfMultipleChecks(
-    [resFav.request.url, resDep.request.url],
-    resFav.timings.duration + resDep.timings.duration,
-    requestName,
-    expects
-  );
+    // Assert: same service journeys and  aimed dep time as /quay-departures:
+    const serviceJourneyFavorites = jsonFav.data[0].quays
+      .filter(quay => quay.quay.id === testScenario.favorites[0].quayId)[0]
+      .group[0].departures.map(dep => dep.serviceJourneyId);
+    const serviceJourneyDepartures = jsonDep.quay!.estimatedCalls.map(
+      call => call.serviceJourney!.id
+    );
+    const aimedTimeFavorites = jsonFav.data[0].quays
+      .filter(quay => quay.quay.id === testScenario.favorites[0].quayId)[0]
+      .group[0].departures.map(dep => dep.aimedTime);
+    const aimedTimeDepartures = jsonDep.quay!.estimatedCalls.map(
+      call => call.aimedDepartureTime
+    );
+    expects.push(
+      {
+        check: 'favorite departures should have the same service journeys',
+        expect: isEqual(serviceJourneyFavorites, serviceJourneyDepartures)
+      },
+      {
+        check: 'favorite departures should have the same aimed time',
+        expect: isEqual(aimedTimeFavorites, aimedTimeDepartures)
+      }
+    );
+
+    metrics.checkForFailures(
+      [resFav.request.url, resDep.request.url],
+      resFav.timings.duration + resDep.timings.duration,
+      requestName,
+      expects
+    );
+  } catch (exp) {
+    //throw exp
+    metrics.checkForFailures(
+      [resFav.request.url, resDep.request.url],
+      resFav.timings.duration + resDep.timings.duration,
+      requestName,
+      [
+        {
+          check: `${exp}`,
+          expect: false
+        }
+      ]
+    );
+  }
 }

--- a/test/src/v2/servicejourney/servicejourney.ts
+++ b/test/src/v2/servicejourney/servicejourney.ts
@@ -27,62 +27,77 @@ export function serviceJourneyDepartures(
       tags: { name: requestName },
       headers: bffHeadersPost
     });
-    const jsonTrip = resTrip.json() as TripsQuery;
-    const tripNumber =
-      jsonTrip.trip.tripPatterns[0].legs[0].mode === 'bus' ? 0 : 1;
-    const serviceJourneyId = jsonTrip.trip.tripPatterns[tripNumber].legs[0]
-      .serviceJourney!.id;
 
-    const urlSJD = `${conf.host()}/bff/v2/servicejourney/${serviceJourneyId}/departures?date=${searchDate}`;
-    const resSJD = http.get(urlSJD, {
-      tags: { name: requestName },
-      headers: bffHeadersGet
-    });
-    const jsonSJD = resSJD.json() as ServiceJourneyDeparturesResponseType;
+    try {
+      const jsonTrip = resTrip.json() as TripsQuery;
+      const tripNumber =
+        jsonTrip.trip.tripPatterns[0].legs[0].mode === 'bus' ? 0 : 1;
+      const serviceJourneyId = jsonTrip.trip.tripPatterns[tripNumber].legs[0]
+        .serviceJourney!.id;
 
-    const expects: ExpectsType = [
-      {
-        check: 'should have status 200 on /trip',
-        expect: resTrip.status === 200
-      },
-      {
-        check: 'should have status 200 on /servicejourney',
-        expect: resSJD.status === 200
-      }
-    ];
+      const urlSJD = `${conf.host()}/bff/v2/servicejourney/${serviceJourneyId}/departures?date=${searchDate}`;
+      const resSJD = http.get(urlSJD, {
+        tags: { name: requestName },
+        headers: bffHeadersGet
+      });
+      const jsonSJD = resSJD.json() as ServiceJourneyDeparturesResponseType;
 
-    if (resSJD.status === 200) {
-      // Assert service journey id
-      expects.push(
+      const expects: ExpectsType = [
         {
-          check: 'should have departures',
-          expect: jsonSJD.value.length > 0
+          check: 'should have status 200 on /trip',
+          expect: resTrip.status === 200
         },
         {
-          check: 'should only have departures for the service journey',
-          expect:
-            jsonSJD.value
-              .map(dep => dep.serviceJourney!.id)
-              .filter(id => id !== serviceJourneyId).length === 0
+          check: 'should have status 200 on /servicejourney',
+          expect: resSJD.status === 200
         }
-      );
-      // Assert expected start time from travel search
-      const expStartTime =
-        jsonTrip.trip.tripPatterns[tripNumber].legs[0].expectedStartTime;
-      expects.push({
-        check: 'should have correct expected start time',
-        expect: jsonSJD.value
-          .map(dep => dep.expectedDepartureTime)
-          .includes(expStartTime)
-      });
-    }
+      ];
 
-    metrics.addFailureIfMultipleChecks(
-      [resTrip.request.url, resSJD.request.url],
-      resTrip.timings.duration + resSJD.timings.duration,
-      requestName,
-      expects
-    );
+      if (resSJD.status === 200) {
+        // Assert service journey id
+        expects.push(
+          {
+            check: 'should have departures',
+            expect: jsonSJD.value.length > 0
+          },
+          {
+            check: 'should only have departures for the service journey',
+            expect:
+              jsonSJD.value
+                .map(dep => dep.serviceJourney!.id)
+                .filter(id => id !== serviceJourneyId).length === 0
+          }
+        );
+        // Assert expected start time from travel search
+        const expStartTime =
+          jsonTrip.trip.tripPatterns[tripNumber].legs[0].expectedStartTime;
+        expects.push({
+          check: 'should have correct expected start time',
+          expect: jsonSJD.value
+            .map(dep => dep.expectedDepartureTime)
+            .includes(expStartTime)
+        });
+      }
+
+      metrics.checkForFailures(
+        [resTrip.request.url, resSJD.request.url],
+        resTrip.timings.duration + resSJD.timings.duration,
+        requestName,
+        expects
+      );
+    } catch (exp) {
+      metrics.checkForFailures(
+        [resTrip.request.url],
+        resTrip.timings.duration,
+        requestName,
+        [
+          {
+            check: `${exp}`,
+            expect: false
+          }
+        ]
+      );
+    }
   }
 }
 
@@ -104,77 +119,92 @@ export function serviceJourneyCalls(
       tags: { name: requestName },
       headers: bffHeadersPost
     });
-    const jsonTrip = resTrip.json() as TripsQuery;
-    const tripNumber =
-      jsonTrip.trip.tripPatterns[0].legs[0].mode === 'bus' ? 0 : 1;
-    const serviceJourneyId = jsonTrip.trip.tripPatterns[tripNumber].legs[0]
-      .serviceJourney!.id;
-    const lineId = serviceJourneyId.split(':')[2].split('_')[0];
 
-    const urlSJC = `${conf.host()}/bff/v2/servicejourney/${serviceJourneyId}/calls?date=${searchDate}`;
-    const resSJC = http.get(urlSJC, {
-      tags: { name: requestName },
-      headers: bffHeadersGet
-    });
-    const jsonSJC = resSJC.json() as ServiceJourneyCallsResponseType;
+    try {
+      const jsonTrip = resTrip.json() as TripsQuery;
+      const tripNumber =
+        jsonTrip.trip.tripPatterns[0].legs[0].mode === 'bus' ? 0 : 1;
+      const serviceJourneyId = jsonTrip.trip.tripPatterns[tripNumber].legs[0]
+        .serviceJourney!.id;
+      const lineId = serviceJourneyId.split(':')[2].split('_')[0];
 
-    const expects: ExpectsType = [
-      {
-        check: 'should have status 200 on /trip',
-        expect: resTrip.status === 200
-      },
-      {
-        check: 'should have status 200 on /servicejourney',
-        expect: resSJC.status === 200
-      }
-    ];
-
-    if (resSJC.status === 200) {
-      // Assert service journey id and line id
-      expects.push(
-        {
-          check: 'should have departures',
-          expect: jsonSJC.value.estimatedCalls.length > 0
-        },
-        {
-          check: 'should return correct service journey',
-          expect: jsonSJC.value.id === serviceJourneyId
-        },
-        {
-          check: 'should have correct line id',
-          expect: jsonSJC.value.line.publicCode === lineId
-        }
-      );
-      // Assert situations only on estimated call level
-      expects.push(
-        {
-          check: 'should not have situations on top level',
-          expect: resSJC.json('value.situations') === undefined
-        },
-        {
-          check: 'should have situations on estimated call',
-          expect:
-            jsonSJC.value.estimatedCalls.map(call => call.situations).length >=
-            0
-        }
-      );
-      // Assert expected start time from travel search
-      const expStartTime =
-        jsonTrip.trip.tripPatterns[tripNumber].legs[0].expectedStartTime;
-      expects.push({
-        check: 'should have correct expected start time',
-        expect: jsonSJC.value.estimatedCalls
-          .map(call => call.expectedDepartureTime)
-          .includes(expStartTime)
+      const urlSJC = `${conf.host()}/bff/v2/servicejourney/${serviceJourneyId}/calls?date=${searchDate}`;
+      const resSJC = http.get(urlSJC, {
+        tags: { name: requestName },
+        headers: bffHeadersGet
       });
-    }
+      const jsonSJC = resSJC.json() as ServiceJourneyCallsResponseType;
 
-    metrics.addFailureIfMultipleChecks(
-      [resTrip.request.url, resSJC.request.url],
-      resTrip.timings.duration + resSJC.timings.duration,
-      requestName,
-      expects
-    );
+      const expects: ExpectsType = [
+        {
+          check: 'should have status 200 on /trip',
+          expect: resTrip.status === 200
+        },
+        {
+          check: 'should have status 200 on /servicejourney',
+          expect: resSJC.status === 200
+        }
+      ];
+
+      if (resSJC.status === 200) {
+        // Assert service journey id and line id
+        expects.push(
+          {
+            check: 'should have departures',
+            expect: jsonSJC.value.estimatedCalls.length > 0
+          },
+          {
+            check: 'should return correct service journey',
+            expect: jsonSJC.value.id === serviceJourneyId
+          },
+          {
+            check: 'should have correct line id',
+            expect: jsonSJC.value.line.publicCode === lineId
+          }
+        );
+        // Assert situations only on estimated call level
+        expects.push(
+          {
+            check: 'should not have situations on top level',
+            expect: resSJC.json('value.situations') === undefined
+          },
+          {
+            check: 'should have situations on estimated call',
+            expect:
+              jsonSJC.value.estimatedCalls.map(call => call.situations)
+                .length >= 0
+          }
+        );
+        // Assert expected start time from travel search
+        const expStartTime =
+          jsonTrip.trip.tripPatterns[tripNumber].legs[0].expectedStartTime;
+        expects.push({
+          check: 'should have correct expected start time',
+          expect: jsonSJC.value.estimatedCalls
+            .map(call => call.expectedDepartureTime)
+            .includes(expStartTime)
+        });
+      }
+
+      metrics.checkForFailures(
+        [resTrip.request.url, resSJC.request.url],
+        resTrip.timings.duration + resSJC.timings.duration,
+        requestName,
+        expects
+      );
+    } catch (exp) {
+      metrics.checkForFailures(
+        [resTrip.request.url],
+        resTrip.timings.duration,
+        requestName,
+        [
+          {
+            check: `${exp}`,
+            expect: false
+          }
+        ]
+      );
+    }
   }
 }
 
@@ -195,98 +225,113 @@ export function polyline(
       tags: { name: requestName },
       headers: bffHeadersPost
     });
-    const jsonTrip = resTrip.json() as TripsQuery;
 
-    const expects: ExpectsType = [
-      {
-        check: 'should have status 200 on /trip',
-        expect: resTrip.status === 200
+    try {
+      const jsonTrip = resTrip.json() as TripsQuery;
+
+      const expects: ExpectsType = [
+        {
+          check: 'should have status 200 on /trip',
+          expect: resTrip.status === 200
+        }
+      ];
+
+      const urlList = [urlTrip];
+      let polylineDuration = 0.0;
+      // Walk through the trip patterns
+      for (let trip of jsonTrip.trip.tripPatterns) {
+        // Only consider direct busses
+        if (trip.legs.length === 1 && trip.legs[0].mode === 'bus') {
+          const fromCoords = [
+            useNoDecimals(trip.legs[0].fromPlace.latitude, 2),
+            useNoDecimals(trip.legs[0].fromPlace.longitude, 2)
+          ];
+          const toCoords = [
+            useNoDecimals(trip.legs[0].toPlace.latitude, 2),
+            useNoDecimals(trip.legs[0].toPlace.longitude, 2)
+          ];
+          const serviceJourney = trip.legs[0].serviceJourney!.id;
+          const fromQuay = trip.legs[0].fromPlace.quay!.id;
+          const toQuay = trip.legs[0].toPlace.quay!.id;
+
+          // Only from
+          const urlPolyline = `${conf.host()}/bff/v2/servicejourney/${serviceJourney}/polyline?fromQuayId=${fromQuay}`;
+          // Both from and to
+          const urlPolyline2 = `${conf.host()}/bff/v2/servicejourney/${serviceJourney}/polyline?fromQuayId=${fromQuay}&toQuayId=${toQuay}`;
+          urlList.push(urlPolyline, urlPolyline2);
+
+          const resPolyline = http.get(urlPolyline, {
+            tags: { name: requestName },
+            headers: bffHeadersGet
+          });
+          polylineDuration += resPolyline.timings.duration;
+          const jsonPoly = resPolyline.json() as PolylineSimplifiedResponseType;
+          const resPolyline2 = http.get(urlPolyline2, {
+            tags: { name: requestName },
+            headers: bffHeadersGet
+          });
+          polylineDuration += resPolyline2.timings.duration;
+          const jsonPoly2 = resPolyline2.json() as PolylineSimplifiedResponseType;
+
+          const startCoordsPolyline = [
+            useNoDecimals(jsonPoly.start.latitude, 2),
+            useNoDecimals(jsonPoly.start.longitude, 2)
+          ];
+          const stopCoordsPolyline = [
+            useNoDecimals(jsonPoly.stop.latitude, 2),
+            useNoDecimals(jsonPoly.stop.longitude, 2)
+          ];
+          const startCoordsPolyline2 = [
+            useNoDecimals(jsonPoly2.start.latitude, 2),
+            useNoDecimals(jsonPoly2.start.longitude, 2)
+          ];
+          const stopCoordsPolyline2 = [
+            useNoDecimals(jsonPoly2.stop.latitude, 2),
+            useNoDecimals(jsonPoly2.stop.longitude, 2)
+          ];
+
+          expects.push(
+            {
+              check: 'should have status 200 on /polyline',
+              expect: resPolyline.status === 200 && resPolyline2.status === 200
+            },
+            {
+              check: 'should have correct start coordinates with from',
+              expect: isEqual(fromCoords, startCoordsPolyline)
+            },
+            {
+              check: 'should have correct start coordinates with from and to',
+              expect: isEqual(fromCoords, startCoordsPolyline2)
+            },
+            {
+              check: 'should have correct stop coordinates with from',
+              expect: isEqual(toCoords, stopCoordsPolyline)
+            },
+            {
+              check: 'should have correct stop coordinates with from and to',
+              expect: isEqual(toCoords, stopCoordsPolyline2)
+            }
+          );
+        }
       }
-    ];
-
-    const urlList = [urlTrip];
-    let polylineDuration = 0.0;
-    // Walk through the trip patterns
-    for (let trip of jsonTrip.trip.tripPatterns) {
-      // Only consider direct busses
-      if (trip.legs.length === 1 && trip.legs[0].mode === 'bus') {
-        const fromCoords = [
-          useNoDecimals(trip.legs[0].fromPlace.latitude, 2),
-          useNoDecimals(trip.legs[0].fromPlace.longitude, 2)
-        ];
-        const toCoords = [
-          useNoDecimals(trip.legs[0].toPlace.latitude, 2),
-          useNoDecimals(trip.legs[0].toPlace.longitude, 2)
-        ];
-        const serviceJourney = trip.legs[0].serviceJourney!.id;
-        const fromQuay = trip.legs[0].fromPlace.quay!.id;
-        const toQuay = trip.legs[0].toPlace.quay!.id;
-
-        // Only from
-        const urlPolyline = `${conf.host()}/bff/v2/servicejourney/${serviceJourney}/polyline?fromQuayId=${fromQuay}`;
-        // Both from and to
-        const urlPolyline2 = `${conf.host()}/bff/v2/servicejourney/${serviceJourney}/polyline?fromQuayId=${fromQuay}&toQuayId=${toQuay}`;
-        urlList.push(urlPolyline, urlPolyline2);
-
-        const resPolyline = http.get(urlPolyline, {
-          tags: { name: requestName },
-          headers: bffHeadersGet
-        });
-        polylineDuration += resPolyline.timings.duration;
-        const jsonPoly = resPolyline.json() as PolylineSimplifiedResponseType;
-        const resPolyline2 = http.get(urlPolyline2, {
-          tags: { name: requestName },
-          headers: bffHeadersGet
-        });
-        polylineDuration += resPolyline2.timings.duration;
-        const jsonPoly2 = resPolyline2.json() as PolylineSimplifiedResponseType;
-
-        const startCoordsPolyline = [
-          useNoDecimals(jsonPoly.start.latitude, 2),
-          useNoDecimals(jsonPoly.start.longitude, 2)
-        ];
-        const stopCoordsPolyline = [
-          useNoDecimals(jsonPoly.stop.latitude, 2),
-          useNoDecimals(jsonPoly.stop.longitude, 2)
-        ];
-        const startCoordsPolyline2 = [
-          useNoDecimals(jsonPoly2.start.latitude, 2),
-          useNoDecimals(jsonPoly2.start.longitude, 2)
-        ];
-        const stopCoordsPolyline2 = [
-          useNoDecimals(jsonPoly2.stop.latitude, 2),
-          useNoDecimals(jsonPoly2.stop.longitude, 2)
-        ];
-
-        expects.push(
+      metrics.checkForFailures(
+        urlList,
+        resTrip.timings.duration + polylineDuration,
+        requestName,
+        expects
+      );
+    } catch (exp) {
+      metrics.checkForFailures(
+        [resTrip.request.url],
+        resTrip.timings.duration,
+        requestName,
+        [
           {
-            check: 'should have status 200 on /polyline',
-            expect: resPolyline.status === 200 && resPolyline2.status === 200
-          },
-          {
-            check: 'should have correct start coordinates with from',
-            expect: isEqual(fromCoords, startCoordsPolyline)
-          },
-          {
-            check: 'should have correct start coordinates with from and to',
-            expect: isEqual(fromCoords, startCoordsPolyline2)
-          },
-          {
-            check: 'should have correct stop coordinates with from',
-            expect: isEqual(toCoords, stopCoordsPolyline)
-          },
-          {
-            check: 'should have correct stop coordinates with from and to',
-            expect: isEqual(toCoords, stopCoordsPolyline2)
+            check: `${exp}`,
+            expect: false
           }
-        );
-      }
+        ]
+      );
     }
-    metrics.addFailureIfMultipleChecks(
-      urlList,
-      resTrip.timings.duration + polylineDuration,
-      requestName,
-      expects
-    );
   }
 }

--- a/test/src/v2/testData/testData.ts
+++ b/test/src/v2/testData/testData.ts
@@ -115,14 +115,14 @@ export const departureFavoritesTestData: departureFavoritesTestDataType = {
     {
       favorites: [
         {
-          lineId: "ATB:Line:2_2",
-          quayId: "NSR:Quay:73152",
-          quayName: "Ladeveien",
-          stopId: "NSR:StopPlace:42686",
-          lineNumber: "2",
-          lineName: "Strindheim via Lade",
-          lineTransportationMode: "bus",
-          lineTransportationSubMode: "localBus",
+          lineId: 'ATB:Line:2_2',
+          quayId: 'NSR:Quay:73152',
+          quayName: 'Ladeveien',
+          stopId: 'NSR:StopPlace:42686',
+          lineNumber: '2',
+          lineName: 'Strindheim via Lade',
+          lineTransportationMode: 'bus',
+          lineTransportationSubMode: 'localBus'
         }
       ]
     },


### PR DESCRIPTION
In case there is an error in a response, and the tests want to parse it as json, an error is thrown so that the rest of the tests are not run. This PR adds try-catch to be able to run the rest of the tests in case of an error - and output the error in a proper way.

This PR also fixes an error where the v1/journey/trip provided a servicejourney id for the servicejourney requests/tests. Now the endpoint /v2/trips is used instead.