### PR TITLE
feat: add filter by line to realtime endpoint

### DIFF
--- a/src/api/realtime/schema.ts
+++ b/src/api/realtime/schema.ts
@@ -3,9 +3,9 @@ import Joi from 'joi';
 export const getDepartureRealtime = {
   query: Joi.object({
     quayIds: Joi.array().items(Joi.string()).default([]).single(),
-    lineIds: Joi.array().items(Joi.string()).single(),
     startTime: Joi.date(),
     limit: Joi.number().default(5),
+    lineIds: Joi.array().items(Joi.string()).single(),
     limitPerLine: Joi.number()
   })
 };

--- a/src/api/realtime/schema.ts
+++ b/src/api/realtime/schema.ts
@@ -3,7 +3,9 @@ import Joi from 'joi';
 export const getDepartureRealtime = {
   query: Joi.object({
     quayIds: Joi.array().items(Joi.string()).default([]).single(),
+    lineIds: Joi.array().items(Joi.string()).single(),
     startTime: Joi.date(),
-    limit: Joi.number().default(5)
+    limit: Joi.number().default(5),
+    limitPerLine: Joi.number()
   })
 };

--- a/src/service/impl/departures-grouped/departure-group.ts
+++ b/src/service/impl/departures-grouped/departure-group.ts
@@ -40,6 +40,8 @@ export async function getDeparturesGroupedNearest(
       variables: {
         stopIds: favorites.map(f => f.stopId)
       },
+      // With fetch policy set to `cache-first`, apollo client will return data
+      // from the cache, or fetch new data and populate the cache.
       fetchPolicy: 'cache-first'
     });
 

--- a/src/service/impl/realtime/departure-time.ts
+++ b/src/service/impl/realtime/departure-time.ts
@@ -37,6 +37,8 @@ export async function populateCacheIfNotThere(
     >({
       query: GetDepartureRealtimeDocument,
       variables,
+      // With fetch policy set to `cache-first`, apollo client will return data
+      // from the cache, or fetch new data and populate the cache.
       fetchPolicy: 'cache-first'
     });
   } catch (e) {}

--- a/src/service/impl/realtime/departure-time.ts
+++ b/src/service/impl/realtime/departure-time.ts
@@ -36,7 +36,7 @@ export async function populateCacheIfNotThere(
       GetDepartureRealtimeQueryVariables
     >({
       query: GetDepartureRealtimeDocument,
-      variables: createVariables(inputQuery),
+      variables,
       fetchPolicy: 'cache-first'
     });
   } catch (e) {}
@@ -114,9 +114,8 @@ export function getPreviousExpectedFromCache(
       query: GetDepartureRealtimeDocument,
       variables
     });
-    if (!result) {
-      return undefined;
-    }
+    if (!result) return undefined;
+
     return mapToPreviousResultsHash(result);
   } catch (e) {
     // Nothing in the cache.

--- a/src/service/impl/realtime/index.ts
+++ b/src/service/impl/realtime/index.ts
@@ -30,7 +30,8 @@ export default (): IRealtimeService => {
         if (result.errors) {
           return Result.err(new APIError(result.errors));
         }
-        return Result.ok(mapToDepartureRealtime(result.data, previousResult));
+        const mapped = mapToDepartureRealtime(result.data, previousResult);
+        return Result.ok(mapped);
       } catch (error) {
         return Result.err(new APIError(error));
       }

--- a/src/service/impl/realtime/index.ts
+++ b/src/service/impl/realtime/index.ts
@@ -24,7 +24,10 @@ export default (): IRealtimeService => {
           GetDepartureRealtimeQueryVariables
         >({
           query: GetDepartureRealtimeDocument,
-          variables
+          variables,
+          // With fetch policy set to `network-only`, apollo client will always
+          // fetch and return new data, then update the cache afterwards.
+          fetchPolicy: 'network-only'
         });
 
         if (result.errors) {

--- a/src/service/impl/realtime/journey-gql/departure-time.graphql
+++ b/src/service/impl/realtime/journey-gql/departure-time.graphql
@@ -3,15 +3,21 @@ query GetDepartureRealtime(
   $startTime: DateTime!
   $timeRange: Int!
   $limit: Int!
+  $limitPerLine: Int
+  $lineIds: [ID]
 ) {
   quays(ids: $quayIds) {
     id
     estimatedCalls(
       startTime: $startTime
-      numberOfDepartures: $limit
+      numberOfDepartures: $limit,
+      numberOfDeparturesPerLineAndDestinationDisplay: $limitPerLine
       timeRange: $timeRange
       arrivalDeparture: departures
       includeCancelledTrips: false
+      whiteListed: {
+        lines: $lineIds
+      }
     ) {
       ...estimatedCall
     }

--- a/src/service/impl/realtime/journey-gql/departure-time.graphql-gen.ts
+++ b/src/service/impl/realtime/journey-gql/departure-time.graphql-gen.ts
@@ -7,6 +7,8 @@ export type GetDepartureRealtimeQueryVariables = Types.Exact<{
   startTime: Types.Scalars['DateTime'];
   timeRange: Types.Scalars['Int'];
   limit: Types.Scalars['Int'];
+  limitPerLine?: Types.InputMaybe<Types.Scalars['Int']>;
+  lineIds?: Types.InputMaybe<Array<Types.InputMaybe<Types.Scalars['ID']>> | Types.InputMaybe<Types.Scalars['ID']>>;
 }>;
 
 
@@ -29,15 +31,17 @@ export const EstimatedCallFragmentDoc = gql`
 }
     `;
 export const GetDepartureRealtimeDocument = gql`
-    query GetDepartureRealtime($quayIds: [String]!, $startTime: DateTime!, $timeRange: Int!, $limit: Int!) {
+    query GetDepartureRealtime($quayIds: [String]!, $startTime: DateTime!, $timeRange: Int!, $limit: Int!, $limitPerLine: Int, $lineIds: [ID]) {
   quays(ids: $quayIds) {
     id
     estimatedCalls(
       startTime: $startTime
       numberOfDepartures: $limit
+      numberOfDeparturesPerLineAndDestinationDisplay: $limitPerLine
       timeRange: $timeRange
       arrivalDeparture: departures
       includeCancelledTrips: false
+      whiteListed: {lines: $lineIds}
     ) {
       ...estimatedCall
     }

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -85,6 +85,8 @@ export type DepartureRealtimeQuery = {
   quayIds: string[];
   startTime: Date;
   limit: number;
+  limitPerLine?: number;
+  lineIds?: string[];
 };
 
 export type StopPlaceDeparturesPayload = {


### PR DESCRIPTION
Related to https://github.com/AtB-AS/mittatb-app/pull/3303

- Adds ability to filter realtime departures by lines, which is useful for favorites (both dashboard and departures in the app).
- Fixes an issue with caching of realtime departures due to missing `fetchPolicy`. (For reference: [Understanding Apollo Fetch Policies](https://medium.com/@galen.corey/understanding-apollo-fetch-policies-705b5ad71980))

resolves https://github.com/AtB-AS/kundevendt/issues/3252