### PR TITLE
test: api tests for mobility endpoints

### DIFF
--- a/test/src/scenario.ts
+++ b/test/src/scenario.ts
@@ -2,7 +2,8 @@ import {
   departuresScenario,
   departuresScenarioPerformance,
   serviceJourneyScenario,
-  tripsScenario
+  tripsScenario,
+  mobilityScenario
 } from './v2/v2Scenario';
 import { getNextThursday } from './utils/utils';
 import {
@@ -11,7 +12,6 @@ import {
   journeyScenarioV1,
   serviceJourneyScenarioV1
 } from './v1/v1Scenario';
-import { realtimeScenario } from './v2/departures';
 
 //Scenarios
 export const scn = (usecase: string): void => {
@@ -38,12 +38,12 @@ const bff = (): void => {
   departuresScenario(searchDate);
   tripsScenario(searchDate);
   serviceJourneyScenario(searchDate);
+  mobilityScenario();
 };
 
 //Test
 const test = (): void => {
-  const searchDate = getNextThursday();
-  realtimeScenario(searchDate);
+  mobilityScenario();
 };
 
 //Performance test

--- a/test/src/v2/mobility/index.ts
+++ b/test/src/v2/mobility/index.ts
@@ -1,0 +1,2 @@
+export { vehicles } from './vehicles';
+export { stations } from './stations';

--- a/test/src/v2/mobility/stations.ts
+++ b/test/src/v2/mobility/stations.ts
@@ -1,0 +1,98 @@
+import { conf, ExpectsType, metrics } from '../../config/configuration';
+import http from 'k6/http';
+import { bffHeadersGet } from '../../utils/headers';
+import {
+  Query,
+  Station
+} from '../../../../src/graphql/mobility/mobility-types_v2';
+import { randomNumber } from '../../utils/utils';
+
+export function stations(range: number = 250) {
+  const requestName = `v2_stations_${range}`;
+  // coordinates around Trondheim city center
+  const lat = `63.4304571134${randomNumber(1000, true)}`;
+  const lon = `10.39810091257${randomNumber(1000, true)}`;
+  const url = `${conf.host()}/bff/v2/mobility/stations?lat=${lat}&lon=${lon}&range=${range}`;
+
+  const res = http.get(url, {
+    tags: { name: requestName },
+    headers: bffHeadersGet
+  });
+
+  try {
+    const json = res.json() as Query;
+    const stations = json.stations! as Station[];
+    const numberOfStations = stations.length;
+
+    const expects: ExpectsType = [
+      { check: 'should have status 200', expect: res.status === 200 }
+    ];
+
+    if (numberOfStations != 0) {
+      expects.push(
+        {
+          check: 'capacity is >= 0',
+          expect:
+            stations.filter(s => s.capacity! >= 0).length === numberOfStations
+        },
+        {
+          check: 'number of bikes and docks available equals capacity',
+          expect:
+            stations.filter(
+              s => s.numBikesAvailable + s.numDocksAvailable! === s.capacity
+            ).length === numberOfStations
+        },
+        {
+          check: 'vehicles have a price per use',
+          expect:
+            stations.filter(s => s.pricingPlans[0].price > 0).length ===
+            numberOfStations
+        },
+        {
+          check: 'vehicles have a price per minute',
+          expect:
+            stations.filter(s => s.pricingPlans[0].perMinPricing?.length! > 0)
+              .length === numberOfStations
+        },
+        {
+          check: 'an app link to the operator exists',
+          expect:
+            stations.filter(
+              s =>
+                s.system.rentalApps?.android?.storeUri?.length! > 0 &&
+                s.system.rentalApps?.ios?.storeUri?.length! > 0
+            ).length === numberOfStations
+        },
+        {
+          check: 'an url to the operator exists',
+          expect:
+            stations.filter(
+              s =>
+                s.rentalUris?.android?.length! > 0 &&
+                s.rentalUris?.ios?.length! > 0
+            ).length === numberOfStations
+        }
+      );
+    }
+
+    metrics.checkForFailures(
+      [res.request.url],
+      res.timings.duration,
+      requestName,
+      expects
+    );
+  } catch (exp) {
+    //throw exp
+    metrics.checkForFailures(
+      [res.request.url],
+      res.timings.duration,
+      requestName,
+      [
+        {
+          check: `${exp}`,
+          expect: false
+        }
+      ]
+    );
+  }
+}

--- a/test/src/v2/mobility/vehicles.ts
+++ b/test/src/v2/mobility/vehicles.ts
@@ -1,0 +1,102 @@
+import { conf, ExpectsType, metrics } from '../../config/configuration';
+import http from 'k6/http';
+import { bffHeadersGet } from '../../utils/headers';
+import {
+  Query,
+  Vehicle
+} from '../../../../src/graphql/mobility/mobility-types_v2';
+import { randomNumber } from '../../utils/utils';
+
+export function vehicles(range: number = 200) {
+  const requestName = `v2_vehicles_${range}`;
+  const formFactor = 'SCOOTER';
+  // coordinates around Oslo city center
+  const lat = `59.9133041843${randomNumber(1000, true)}`;
+  const lon = `10.73546589554${randomNumber(1000, true)}`;
+  const url = `${conf.host()}/bff/v2/mobility/vehicles?formFactors=${formFactor}&lat=${lat}&lon=${lon}&range=${range}`;
+
+  const res = http.get(url, {
+    tags: { name: requestName },
+    headers: bffHeadersGet
+  });
+
+  try {
+    const json = res.json() as Query;
+    const vehicles = json.vehicles! as Vehicle[];
+    const numberOfVehicles = vehicles.length;
+
+    const expects: ExpectsType = [
+      { check: 'should have status 200', expect: res.status === 200 }
+    ];
+    if (numberOfVehicles != 0) {
+      expects.push(
+        {
+          check: 'currentFuelPercent is 0-100',
+          expect:
+            vehicles.filter(
+              v => v.currentFuelPercent! >= 0 && v.currentFuelPercent! <= 100
+            ).length === numberOfVehicles
+        },
+        {
+          check: 'type of vehicle is correct',
+          expect:
+            vehicles.filter(v => v.vehicleType.formFactor === formFactor)
+              .length === numberOfVehicles
+        },
+        {
+          check: 'vehicles have a price per use',
+          expect:
+            vehicles.filter(v => v.pricingPlan.price > 0).length ===
+            numberOfVehicles
+        },
+        {
+          check: 'vehicles have a price per minute',
+          expect:
+            vehicles.filter(v =>
+              v.pricingPlan.perMinPricing?.filter(
+                price => price.interval === 1 && price.rate > 0
+              )
+            ).length === numberOfVehicles
+        },
+        {
+          check: 'an app link to the operator exists',
+          expect:
+            vehicles.filter(
+              v =>
+                v.system.rentalApps?.android?.storeUri?.length! > 0 &&
+                v.system.rentalApps?.ios?.storeUri?.length! > 0
+            ).length === numberOfVehicles
+        },
+        {
+          check: 'an url to the operator exists',
+          expect:
+            vehicles.filter(
+              v =>
+                v.rentalUris?.android?.length! > 0 &&
+                v.rentalUris?.ios?.length! > 0
+            ).length === numberOfVehicles
+        }
+      );
+    }
+
+    metrics.checkForFailures(
+      [res.request.url],
+      res.timings.duration,
+      requestName,
+      expects
+    );
+  } catch (exp) {
+    //throw exp
+    metrics.checkForFailures(
+      [res.request.url],
+      res.timings.duration,
+      requestName,
+      [
+        {
+          check: `${exp}`,
+          expect: false
+        }
+      ]
+    );
+  }
+}

--- a/test/src/v2/v2Scenario.ts
+++ b/test/src/v2/v2Scenario.ts
@@ -35,6 +35,7 @@ import {
   serviceJourneyDepartures,
   serviceJourneyCalls
 } from './servicejourney';
+import { stations, vehicles } from './mobility';
 
 //Scenario with std pattern
 export const departuresScenario = (searchDate: string): void => {
@@ -69,6 +70,12 @@ export const serviceJourneyScenario = (searchDate: string): void => {
   serviceJourneyDepartures(serviceJourneyTestData, searchDate);
   serviceJourneyCalls(serviceJourneyTestData, searchDate);
   polyline(serviceJourneyTestData, searchDate);
+};
+
+export const mobilityScenario = (): void => {
+  // Requests
+  vehicles(200);
+  stations(250);
 };
 
 //Performance scenario with different patterns


### PR DESCRIPTION
Added API-tests for:
- mobility/vehicles: searches in Oslo and verifies the results
- mobility/stations: searches in Trondheim and verifies the results