### PR TITLE
feat: add timeRange query variable to realtime

### DIFF
--- a/src/api/realtime/schema.ts
+++ b/src/api/realtime/schema.ts
@@ -6,6 +6,7 @@ export const getDepartureRealtime = {
     startTime: Joi.date(),
     limit: Joi.number().default(5),
     lineIds: Joi.array().items(Joi.string()).single(),
-    limitPerLine: Joi.number()
+    limitPerLine: Joi.number(),
+    timeRange: Joi.number()
   })
 };

--- a/src/service/impl/departures/index.ts
+++ b/src/service/impl/departures/index.ts
@@ -67,7 +67,8 @@ export default (): IDeparturesService => {
           startTime,
           lineIds,
           limit: limit.numberOfDepartures,
-          limitPerLine: limit.limitPerLine
+          limitPerLine: limit.limitPerLine,
+          timeRange
         });
 
         const result = await journeyPlannerClient.query<
@@ -198,7 +199,8 @@ export default (): IDeparturesService => {
             startTime,
             lineIds,
             limit: limit.numberOfDepartures,
-            limitPerLine: limit.limitPerLine
+            limitPerLine: limit.limitPerLine,
+            timeRange
           });
         }
 

--- a/src/service/impl/realtime/departure-time.ts
+++ b/src/service/impl/realtime/departure-time.ts
@@ -15,16 +15,20 @@ export const createVariables = (
   query: DepartureRealtimeQuery
 ): GetDepartureRealtimeQueryVariables => ({
   ...query,
-  timeRange: query.timeRange ?? 72000
+  timeRange: query.timeRange ?? 86400
 });
 
+/**
+ * Trigger realtime fetch to populate cache for the query, reducing the amount
+ * of data for the initial realtime query. Can be fire-and-forget, as it's not
+ * critical if the cache is empty.
+ *
+ * To get a cache hit, `inputQuery` needs to match the query for the subsequent
+ * realtime request.
+ */
 export async function populateRealtimeCacheIfNotThere(
   inputQuery: DepartureRealtimeQuery
 ) {
-  // Trigger realtime fetch to populate cache for query
-  // Reducing the amount of data for the initial realtime query.
-  // Can be fire-and-forget, as it's not critical
-  // if the cache is empty
   try {
     const variables = createVariables(inputQuery);
     const previousResult = getPreviousExpectedFromCache(variables);

--- a/src/service/impl/realtime/departure-time.ts
+++ b/src/service/impl/realtime/departure-time.ts
@@ -15,7 +15,7 @@ export const createVariables = (
   query: DepartureRealtimeQuery
 ): GetDepartureRealtimeQueryVariables => ({
   ...query,
-  timeRange: 72000
+  timeRange: query.timeRange ?? 72000
 });
 
 export async function populateRealtimeCacheIfNotThere(

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -88,6 +88,7 @@ export type DepartureRealtimeQuery = {
   limit: number;
   limitPerLine?: number;
   lineIds?: string[];
+  timeRange?: number;
 };
 
 export type QuayDeparturesQueryVariables = {


### PR DESCRIPTION
Adds `timeRange` as an optional param to realtime queries, and sets default to 24 hours instead of 22, since that's what's used as default everywhere else.