### PR TITLE
test: update mobility API tests

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: tor/update-mobility-tests
+          ref: main
 
       - name: Install k6
         run: |

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: main
+          ref: tor/update-mobility-tests
 
       - name: Install k6
         run: |
@@ -76,5 +76,5 @@ jobs:
           retention-days: 5
 
       - name: Re-run API tests
-        run: ./k6 run test/dist/k6.js --env host=${{ env.INPUT_URL }} --env runFrom=root --quiet
+        run: ./k6 run test/dist/k6.js --env host=${{ env.INPUT_URL }} --env runFrom=root --env printJUnit=false --quiet
 

--- a/test/src/config/configuration.ts
+++ b/test/src/config/configuration.ts
@@ -62,6 +62,15 @@ export const conf = {
   // The options descibed in ./*Config.json
   options(): ConfigType {
     return options;
+  },
+  // Whether to print a JUnit summary (default in ./*Config.json)
+  printJUnit(): boolean {
+    if (__ENV.printJUnit === 'true') {
+      return true;
+    } else if (__ENV.printJUnit === 'false') {
+      return false;
+    }
+    return this.options().junitCheckOutput;
   }
 };
 

--- a/test/src/k6.ts
+++ b/test/src/k6.ts
@@ -49,7 +49,7 @@ export default () => {
   scn(conf.usecase());
 
   //Create JUnit log lines for a post-k6-processor to pick up
-  if (conf.options().junitCheckOutput) {
+  if (conf.printJUnit()) {
     createJUnitCheckOutput();
   }
 };

--- a/test/src/v2/mobility/index.ts
+++ b/test/src/v2/mobility/index.ts
@@ -1,2 +1,3 @@
 export { vehicles } from './vehicles';
 export { stations } from './stations';
+export { vehicleByIdScenario } from './scenario';

--- a/test/src/v2/mobility/scenario.ts
+++ b/test/src/v2/mobility/scenario.ts
@@ -1,0 +1,15 @@
+import { vehicle, vehicles } from './vehicles';
+import { VehicleInfoType } from '../types/mobility';
+
+// Get vehicles and ask for a specific vehicle
+export function vehicleByIdScenario(): void {
+  let vehicleInfo: VehicleInfoType = vehicles(200);
+  if (vehicleInfo !== undefined) {
+    vehicle(vehicleInfo, 100);
+  }
+
+  vehicleInfo = vehicles(300);
+  if (vehicleInfo !== undefined) {
+    vehicle(vehicleInfo, 100);
+  }
+}

--- a/test/src/v2/types/mobility.ts
+++ b/test/src/v2/types/mobility.ts
@@ -1,0 +1,8 @@
+export type VehicleInfoType =
+  | {
+      id: string;
+      lat: number;
+      lon: number;
+      currentFuelPercent: number;
+    }
+  | undefined;

--- a/test/src/v2/v2Scenario.ts
+++ b/test/src/v2/v2Scenario.ts
@@ -35,7 +35,7 @@ import {
   serviceJourneyDepartures,
   serviceJourneyCalls
 } from './servicejourney';
-import { stations, vehicles } from './mobility';
+import { stations, vehicleByIdScenario, vehicles } from './mobility';
 
 //Scenario with std pattern
 export const departuresScenario = (searchDate: string): void => {
@@ -76,6 +76,8 @@ export const mobilityScenario = (): void => {
   // Requests
   vehicles(200);
   stations(250);
+
+  vehicleByIdScenario();
 };
 
 //Performance scenario with different patterns


### PR DESCRIPTION
Update the API tests with correct response from `v2/mobility/vehicles` and subsequent request for a specific vehicle id in `v2/mobility/vehicle`.

Also, update with the possibility to NOT output JUnit results as the log will be cleaner and easier to understand.