### PR TITLE
feat: Fetch scooters and stations by id

### DIFF
--- a/src/api/mobility/index.ts
+++ b/src/api/mobility/index.ts
@@ -1,7 +1,7 @@
 import Hapi from '@hapi/hapi';
 import { IMobilityService } from '../../service/interface';
-import { StationsQuery, VehicleQuery, VehiclesQuery } from "../../service/types";
-import { getVehiclesRequest, getStationsRequest, getVehicleRequest } from "./schema";
+import { CarStationQuery, StationsQuery, VehicleQuery, VehiclesQuery } from "../../service/types";
+import { getVehiclesRequest, getStationsRequest, getVehicleRequest, getCarStationRequest } from "./schema";
 
 export default (server: Hapi.Server) => (service: IMobilityService) => {
   server.route({
@@ -49,6 +49,21 @@ export default (server: Hapi.Server) => (service: IMobilityService) => {
       const payload = request.query as unknown as StationsQuery;
 
       return (await service.getStations(payload)).unwrap();
+    }
+  });
+
+  server.route({
+    method: 'GET',
+    path: '/bff/v2/mobility/station/car',
+    options: {
+      tags: ['api', 'mobility', 'station', 'car'],
+      validate: getCarStationRequest,
+      description: 'Get details about a single car station'
+    },
+    handler: async request => {
+      const payload = request.query as unknown as CarStationQuery;
+
+      return (await service.getCarStation(payload)).unwrap();
     }
   });
 };

--- a/src/api/mobility/index.ts
+++ b/src/api/mobility/index.ts
@@ -28,12 +28,7 @@ export default (server: Hapi.Server) => (service: IMobilityService) => {
     },
     handler: async request => {
       const payload = request.query as unknown as VehicleQuery;
-      return (await service.getVehiclesExtended(payload))
-        .unwrap()
-        .vehicles
-        ?.filter(v => v.id === payload.id)
-        .at(0);
-
+      return (await service.getVehicle(payload)).unwrap()
     }
   });
 

--- a/src/api/mobility/index.ts
+++ b/src/api/mobility/index.ts
@@ -1,6 +1,6 @@
 import Hapi from '@hapi/hapi';
 import { IMobilityService } from '../../service/interface';
-import { CarStationQuery, StationsQuery, VehicleQuery, VehiclesQuery } from "../../service/types";
+import { BikeStationQuery, CarStationQuery, StationsQuery, VehicleQuery, VehiclesQuery } from "../../service/types";
 import { getVehiclesRequest, getStationsRequest, getVehicleRequest, getCarStationRequest } from "./schema";
 
 export default (server: Hapi.Server) => (service: IMobilityService) => {
@@ -64,6 +64,21 @@ export default (server: Hapi.Server) => (service: IMobilityService) => {
       const payload = request.query as unknown as CarStationQuery;
 
       return (await service.getCarStation(payload)).unwrap();
+    }
+  });
+
+  server.route({
+    method: 'GET',
+    path: '/bff/v2/mobility/station/bike',
+    options: {
+      tags: ['api', 'mobility', 'station', 'bike'],
+      validate: getCarStationRequest,
+      description: 'Get details about a single bike station'
+    },
+    handler: async request => {
+      const payload = request.query as unknown as BikeStationQuery;
+
+      return (await service.getBikeStation(payload)).unwrap();
     }
   });
 };

--- a/src/api/mobility/schema.ts
+++ b/src/api/mobility/schema.ts
@@ -16,15 +16,7 @@ export const getVehiclesRequest = {
 };
 export const getVehicleRequest = {
   query: Joi.object({
-    id: Joi.string().required(),
-    formFactors: Joi.array()
-      .items(Joi.string())
-      .optional()
-      .default(FormFactor.Scooter)
-      .single(),
-    lat: Joi.number().required(),
-    lon: Joi.number().required(),
-    range: Joi.number().default(100).optional()
+    ids: Joi.array().items(Joi.string()).required().single()
   })
 };
 

--- a/src/api/mobility/schema.ts
+++ b/src/api/mobility/schema.ts
@@ -41,3 +41,8 @@ export const getStationsRequest = {
     operators: Joi.array().items(Joi.string()).optional().single()
   })
 };
+export const getCarStationRequest = {
+  query: Joi.object({
+    ids: Joi.array().items(Joi.string()).required().single()
+  })
+};

--- a/src/graphql/mobility/mobility-types_v2.ts
+++ b/src/graphql/mobility/mobility-types_v2.ts
@@ -120,8 +120,11 @@ export type Query = {
   codespaces?: Maybe<Array<Maybe<Scalars['String']>>>;
   geofencingZones?: Maybe<Array<Maybe<GeofencingZones>>>;
   operators?: Maybe<Array<Maybe<Operator>>>;
+  station?: Maybe<Station>;
   stations?: Maybe<Array<Maybe<Station>>>;
+  /** @deprecated stationsById is deprecated. Use stations query instead. */
   stationsById?: Maybe<Array<Maybe<Station>>>;
+  vehicle?: Maybe<Vehicle>;
   vehicles?: Maybe<Array<Maybe<Vehicle>>>;
 };
 
@@ -131,15 +134,21 @@ export type QueryGeofencingZonesArgs = {
 };
 
 
+export type QueryStationArgs = {
+  id: Scalars['String'];
+};
+
+
 export type QueryStationsArgs = {
   availableFormFactors?: InputMaybe<Array<InputMaybe<FormFactor>>>;
   availablePropulsionTypes?: InputMaybe<Array<InputMaybe<PropulsionType>>>;
   codespaces?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   count?: InputMaybe<Scalars['Int']>;
-  lat: Scalars['Float'];
-  lon: Scalars['Float'];
+  ids?: InputMaybe<Array<Scalars['String']>>;
+  lat?: InputMaybe<Scalars['Float']>;
+  lon?: InputMaybe<Scalars['Float']>;
   operators?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  range: Scalars['Int'];
+  range?: InputMaybe<Scalars['Int']>;
   systems?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
@@ -149,17 +158,23 @@ export type QueryStationsByIdArgs = {
 };
 
 
+export type QueryVehicleArgs = {
+  id: Scalars['String'];
+};
+
+
 export type QueryVehiclesArgs = {
   codespaces?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   count?: InputMaybe<Scalars['Int']>;
   formFactors?: InputMaybe<Array<InputMaybe<FormFactor>>>;
+  ids?: InputMaybe<Array<Scalars['String']>>;
   includeDisabled?: InputMaybe<Scalars['Boolean']>;
   includeReserved?: InputMaybe<Scalars['Boolean']>;
-  lat: Scalars['Float'];
-  lon: Scalars['Float'];
+  lat?: InputMaybe<Scalars['Float']>;
+  lon?: InputMaybe<Scalars['Float']>;
   operators?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   propulsionTypes?: InputMaybe<Array<InputMaybe<PropulsionType>>>;
-  range: Scalars['Int'];
+  range?: InputMaybe<Scalars['Int']>;
   systems?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 

--- a/src/service/impl/fragments/mobility-gql/shared.graphql
+++ b/src/service/impl/fragments/mobility-gql/shared.graphql
@@ -72,3 +72,15 @@ fragment system on System {
         ...rentalApps
     }
 }
+
+fragment vehicleRange on VehicleType {
+    maxRangeMeters
+}
+fragment vehicleType on VehicleType {
+    ...vehicleRange
+    id
+    formFactor
+    name {
+        ...translatedString
+    }
+}

--- a/src/service/impl/fragments/mobility-gql/shared.graphql-gen.ts
+++ b/src/service/impl/fragments/mobility-gql/shared.graphql-gen.ts
@@ -22,6 +22,13 @@ export type BrandAssetsFragment = { brandImageUrl: string, brandImageUrlDark?: s
 
 export type SystemFragment = { operator: OperatorFragment, name: TranslatedStringFragment, brandAssets?: BrandAssetsFragment, rentalApps?: RentalAppsFragment };
 
+export type VehicleRangeFragment = { maxRangeMeters?: number };
+
+export type VehicleTypeFragment = (
+  { id: string, formFactor: Types.FormFactor, name?: TranslatedStringFragment }
+  & VehicleRangeFragment
+);
+
 export const PricingSegmentFragmentDoc = gql`
     fragment pricingSegment on PricingSegment {
   rate
@@ -110,6 +117,22 @@ export const SystemFragmentDoc = gql`
 ${TranslatedStringFragmentDoc}
 ${BrandAssetsFragmentDoc}
 ${RentalAppsFragmentDoc}`;
+export const VehicleRangeFragmentDoc = gql`
+    fragment vehicleRange on VehicleType {
+  maxRangeMeters
+}
+    `;
+export const VehicleTypeFragmentDoc = gql`
+    fragment vehicleType on VehicleType {
+  ...vehicleRange
+  id
+  formFactor
+  name {
+    ...translatedString
+  }
+}
+    ${VehicleRangeFragmentDoc}
+${TranslatedStringFragmentDoc}`;
 export type Requester<C = {}, E = unknown> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R>
 export function getSdk<C, E>(requester: Requester<C, E>) {
   return {

--- a/src/service/impl/fragments/mobility-gql/stations.graphql
+++ b/src/service/impl/fragments/mobility-gql/stations.graphql
@@ -1,13 +1,26 @@
-fragment station on Station {
+fragment vehicleTypeAvailabilityBasic on VehicleTypeAvailability {
+    count
+    vehicleType {
+        formFactor
+    }
+}
+
+
+fragment stationBasic on Station {
     id
     lat
     lon
+    vehicleTypesAvailable {
+        ...vehicleTypeAvailabilityBasic
+    }
+}
+
+fragment bikeStation on Station {
+    ...stationBasic
+    numDocksAvailable
     name {
         ...translatedString
     }
-    capacity
-    numBikesAvailable
-    numDocksAvailable
     pricingPlans {
         ...pricingPlan
     }
@@ -17,4 +30,44 @@ fragment station on Station {
     rentalUris {
         ...rentalUris
     }
+}
+
+fragment carVehicleType on VehicleType {
+    formFactor
+    propulsionType
+    maxRangeMeters
+    riderCapacity
+    make
+    model
+    name {
+        ...translatedString
+    }
+    vehicleAccessories
+}
+
+fragment carAvailability on VehicleTypeAvailability {
+    count
+    vehicleType {
+        ...carVehicleType
+    }
+}
+
+fragment carStation on Station {
+    ...stationBasic
+    name {
+        ...translatedString
+    }
+    pricingPlans {
+        ...pricingPlan
+    }
+    system {
+        ...system
+    }
+    rentalUris {
+        ...rentalUris
+    }
+    vehicleTypesAvailable {
+        ...carAvailability
+    }
+
 }

--- a/src/service/impl/fragments/mobility-gql/vehicles.graphql
+++ b/src/service/impl/fragments/mobility-gql/vehicles.graphql
@@ -1,14 +1,3 @@
-fragment vehicleRange on VehicleType {
-    maxRangeMeters
-}
-fragment vehicleType on VehicleType {
-    ...vehicleRange
-    id
-    formFactor
-    name {
-        ...translatedString
-    }
-}
 
 fragment vehicleBasic on Vehicle {
     id

--- a/src/service/impl/fragments/mobility-gql/vehicles.graphql-gen.ts
+++ b/src/service/impl/fragments/mobility-gql/vehicles.graphql-gen.ts
@@ -1,16 +1,9 @@
 import * as Types from '../../../../graphql/mobility/mobility-types_v2';
 
-import { TranslatedStringFragment, PricingPlanFragment, SystemFragment, RentalUrisFragment } from './shared.graphql-gen';
+import { VehicleRangeFragment, VehicleTypeFragment, PricingPlanFragment, SystemFragment, RentalUrisFragment } from './shared.graphql-gen';
 import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
-import { TranslatedStringFragmentDoc, PricingPlanFragmentDoc, SystemFragmentDoc, RentalUrisFragmentDoc } from './shared.graphql-gen';
-export type VehicleRangeFragment = { maxRangeMeters?: number };
-
-export type VehicleTypeFragment = (
-  { id: string, formFactor: Types.FormFactor, name?: TranslatedStringFragment }
-  & VehicleRangeFragment
-);
-
+import { VehicleRangeFragmentDoc, VehicleTypeFragmentDoc, PricingPlanFragmentDoc, SystemFragmentDoc, RentalUrisFragmentDoc } from './shared.graphql-gen';
 export type VehicleBasicFragment = { id: string, lat: number, lon: number, currentFuelPercent?: number, currentRangeMeters: number, vehicleType: VehicleRangeFragment };
 
 export type VehicleExtendedFragment = (
@@ -18,11 +11,6 @@ export type VehicleExtendedFragment = (
   & VehicleBasicFragment
 );
 
-export const VehicleRangeFragmentDoc = gql`
-    fragment vehicleRange on VehicleType {
-  maxRangeMeters
-}
-    `;
 export const VehicleBasicFragmentDoc = gql`
     fragment vehicleBasic on Vehicle {
   id
@@ -35,17 +23,6 @@ export const VehicleBasicFragmentDoc = gql`
   }
 }
     ${VehicleRangeFragmentDoc}`;
-export const VehicleTypeFragmentDoc = gql`
-    fragment vehicleType on VehicleType {
-  ...vehicleRange
-  id
-  formFactor
-  name {
-    ...translatedString
-  }
-}
-    ${VehicleRangeFragmentDoc}
-${TranslatedStringFragmentDoc}`;
 export const VehicleExtendedFragmentDoc = gql`
     fragment vehicleExtended on Vehicle {
   ...vehicleBasic

--- a/src/service/impl/mobility/index.ts
+++ b/src/service/impl/mobility/index.ts
@@ -3,6 +3,8 @@ import { Result } from "@badrap/result";
 import { APIError } from "../../types";
 import { mobilityClient } from "../../../graphql/graphql-client";
 import {
+  GetBikeStationDocument,
+  GetBikeStationQuery, GetBikeStationQueryVariables,
   GetCarStationDocument,
   GetCarStationQuery,
   GetCarStationQueryVariables,
@@ -103,6 +105,23 @@ export default (): IMobilityService => ({
         GetCarStationQueryVariables
       >({
         query: GetCarStationDocument,
+        variables: query
+      });
+      if (result.errors) {
+        return Result.err(new APIError(result.errors));
+      }
+      return Result.ok(result.data);
+    } catch (error) {
+      return Result.err(new APIError(error));
+    }
+  },
+  async getBikeStation(query) {
+    try {
+      const result = await mobilityClient.query<
+        GetBikeStationQuery,
+        GetBikeStationQueryVariables
+      >({
+        query: GetBikeStationDocument,
         variables: query
       });
       if (result.errors) {

--- a/src/service/impl/mobility/index.ts
+++ b/src/service/impl/mobility/index.ts
@@ -2,7 +2,14 @@ import { GetVehiclesQuery, IMobilityService } from "../../interface";
 import { Result } from "@badrap/result";
 import { APIError } from "../../types";
 import { mobilityClient } from "../../../graphql/graphql-client";
-import { GetStationsDocument, GetStationsQuery, GetStationsQueryVariables } from "./mobility-gql/stations.graphql-gen";
+import {
+  GetCarStationDocument,
+  GetCarStationQuery,
+  GetCarStationQueryVariables,
+  GetStationsDocument,
+  GetStationsQuery,
+  GetStationsQueryVariables
+} from "./mobility-gql/stations.graphql-gen";
 import {
   GetVehiclesBasicDocument,
   GetVehiclesBasicQuery,
@@ -79,6 +86,23 @@ export default (): IMobilityService => ({
         GetStationsQueryVariables
       >({
         query: GetStationsDocument,
+        variables: query
+      });
+      if (result.errors) {
+        return Result.err(new APIError(result.errors));
+      }
+      return Result.ok(result.data);
+    } catch (error) {
+      return Result.err(new APIError(error));
+    }
+  },
+  async getCarStation(query) {
+    try {
+      const result = await mobilityClient.query<
+        GetCarStationQuery,
+        GetCarStationQueryVariables
+      >({
+        query: GetCarStationDocument,
         variables: query
       });
       if (result.errors) {

--- a/src/service/impl/mobility/index.ts
+++ b/src/service/impl/mobility/index.ts
@@ -1,4 +1,4 @@
-import { GetVehiclesQuery, IMobilityService } from "../../interface";
+import { GetVehiclesListQuery, IMobilityService } from "../../interface";
 import { Result } from "@badrap/result";
 import { APIError } from "../../types";
 import { mobilityClient } from "../../../graphql/graphql-client";
@@ -13,15 +13,15 @@ import {
   GetStationsQueryVariables
 } from "./mobility-gql/stations.graphql-gen";
 import {
-  GetVehiclesBasicDocument,
-  GetVehiclesBasicQuery,
-  GetVehiclesBasicQueryVariables,
-  GetVehiclesExtendedDocument,
-  GetVehiclesExtendedQuery,
-  GetVehiclesExtendedQueryVariables
+  GetVehicleDocument,
+  GetVehicleQuery, GetVehicleQueryVariables,
+  GetVehiclesDocument,
+  GetVehiclesQuery,
+  GetVehiclesQueryVariables
 } from "./mobility-gql/vehicles.graphql-gen";
 
-const calculateFuelPercent = <T extends GetVehiclesBasicQuery | GetVehiclesExtendedQuery>(data: T): T => ({
+
+const calculateFuelPercent = <T extends GetVehicleQuery | GetVehiclesQuery>(data: T): T => ({
   ...data,
   vehicles: data?.vehicles?.map(vehicle => ({
     ...vehicle,
@@ -36,7 +36,7 @@ const calculateFuelPercent = <T extends GetVehiclesBasicQuery | GetVehiclesExten
   }))
 });
 
-const stripProps = (data: GetVehiclesBasicQuery): GetVehiclesQuery => ({
+const stripProps = (data: GetVehiclesQuery): GetVehiclesListQuery => ({
   ...data,
   vehicles: data.vehicles?.map(v => ({
     id: v.id,
@@ -50,10 +50,10 @@ export default (): IMobilityService => ({
   async getVehicles(query) {
     try {
       const result = await mobilityClient.query<
-        GetVehiclesBasicQuery,
-        GetVehiclesBasicQueryVariables
+        GetVehiclesQuery,
+        GetVehiclesQueryVariables
       >({
-        query: GetVehiclesBasicDocument,
+        query: GetVehiclesDocument,
         variables: query
       });
       if (result.errors) {
@@ -64,13 +64,14 @@ export default (): IMobilityService => ({
       return Result.err(new APIError(error));
     }
   },
-  async getVehiclesExtended(query) {
+
+  async getVehicle(query) {
     try {
       const result = await mobilityClient.query<
-        GetVehiclesExtendedQuery,
-        GetVehiclesExtendedQueryVariables
+        GetVehicleQuery,
+        GetVehicleQueryVariables
       >({
-        query: GetVehiclesExtendedDocument,
+        query: GetVehicleDocument,
         variables: query
       });
       if (result.errors) {
@@ -81,6 +82,7 @@ export default (): IMobilityService => ({
       return Result.err(new APIError(error));
     }
   },
+
   async getStations(query) {
     try {
       const result = await mobilityClient.query<
@@ -98,6 +100,7 @@ export default (): IMobilityService => ({
       return Result.err(new APIError(error));
     }
   },
+
   async getCarStation(query) {
     try {
       const result = await mobilityClient.query<
@@ -115,6 +118,7 @@ export default (): IMobilityService => ({
       return Result.err(new APIError(error));
     }
   },
+
   async getBikeStation(query) {
     try {
       const result = await mobilityClient.query<

--- a/src/service/impl/mobility/mobility-gql/stations.graphql
+++ b/src/service/impl/mobility/mobility-gql/stations.graphql
@@ -1,5 +1,5 @@
 query getStations($lat: Float!, $lon: Float!, $range: Int!, $availableFormFactors: [FormFactor]) {
     stations(lat: $lat, lon: $lon, range: $range, availableFormFactors: $availableFormFactors) {
-        ...station
+        ...stationBasic
     }
 }

--- a/src/service/impl/mobility/mobility-gql/stations.graphql
+++ b/src/service/impl/mobility/mobility-gql/stations.graphql
@@ -4,14 +4,14 @@ query getStations($lat: Float!, $lon: Float!, $range: Int!, $availableFormFactor
     }
 }
 
-query getCarStation($ids: [String]!) {
-    stationsById(ids: $ids) {
+query getCarStation($ids: [String!]) {
+    stations(ids: $ids) {
         ...carStation
     }
 }
 
-query getBikeStation($ids: [String]!) {
-    stationsById(ids: $ids) {
+query getBikeStation($ids: [String!]) {
+    stations(ids: $ids) {
         ...bikeStation
     }
 }

--- a/src/service/impl/mobility/mobility-gql/stations.graphql
+++ b/src/service/impl/mobility/mobility-gql/stations.graphql
@@ -9,3 +9,9 @@ query getCarStation($ids: [String]!) {
         ...carStation
     }
 }
+
+query getBikeStation($ids: [String]!) {
+    stationsById(ids: $ids) {
+        ...bikeStation
+    }
+}

--- a/src/service/impl/mobility/mobility-gql/stations.graphql
+++ b/src/service/impl/mobility/mobility-gql/stations.graphql
@@ -3,3 +3,9 @@ query getStations($lat: Float!, $lon: Float!, $range: Int!, $availableFormFactor
         ...stationBasic
     }
 }
+
+query getCarStation($ids: [String]!) {
+    stationsById(ids: $ids) {
+        ...carStation
+    }
+}

--- a/src/service/impl/mobility/mobility-gql/stations.graphql-gen.ts
+++ b/src/service/impl/mobility/mobility-gql/stations.graphql-gen.ts
@@ -15,18 +15,18 @@ export type GetStationsQueryVariables = Types.Exact<{
 export type GetStationsQuery = { stations?: Array<StationBasicFragment> };
 
 export type GetCarStationQueryVariables = Types.Exact<{
-  ids: Array<Types.InputMaybe<Types.Scalars['String']>> | Types.InputMaybe<Types.Scalars['String']>;
+  ids?: Types.InputMaybe<Array<Types.Scalars['String']> | Types.Scalars['String']>;
 }>;
 
 
-export type GetCarStationQuery = { stationsById?: Array<CarStationFragment> };
+export type GetCarStationQuery = { stations?: Array<CarStationFragment> };
 
 export type GetBikeStationQueryVariables = Types.Exact<{
-  ids: Array<Types.InputMaybe<Types.Scalars['String']>> | Types.InputMaybe<Types.Scalars['String']>;
+  ids?: Types.InputMaybe<Array<Types.Scalars['String']> | Types.Scalars['String']>;
 }>;
 
 
-export type GetBikeStationQuery = { stationsById?: Array<BikeStationFragment> };
+export type GetBikeStationQuery = { stations?: Array<BikeStationFragment> };
 
 
 export const GetStationsDocument = gql`
@@ -42,15 +42,15 @@ export const GetStationsDocument = gql`
 }
     ${StationBasicFragmentDoc}`;
 export const GetCarStationDocument = gql`
-    query getCarStation($ids: [String]!) {
-  stationsById(ids: $ids) {
+    query getCarStation($ids: [String!]) {
+  stations(ids: $ids) {
     ...carStation
   }
 }
     ${CarStationFragmentDoc}`;
 export const GetBikeStationDocument = gql`
-    query getBikeStation($ids: [String]!) {
-  stationsById(ids: $ids) {
+    query getBikeStation($ids: [String!]) {
+  stations(ids: $ids) {
     ...bikeStation
   }
 }
@@ -61,10 +61,10 @@ export function getSdk<C, E>(requester: Requester<C, E>) {
     getStations(variables: GetStationsQueryVariables, options?: C): Promise<GetStationsQuery> {
       return requester<GetStationsQuery, GetStationsQueryVariables>(GetStationsDocument, variables, options);
     },
-    getCarStation(variables: GetCarStationQueryVariables, options?: C): Promise<GetCarStationQuery> {
+    getCarStation(variables?: GetCarStationQueryVariables, options?: C): Promise<GetCarStationQuery> {
       return requester<GetCarStationQuery, GetCarStationQueryVariables>(GetCarStationDocument, variables, options);
     },
-    getBikeStation(variables: GetBikeStationQueryVariables, options?: C): Promise<GetBikeStationQuery> {
+    getBikeStation(variables?: GetBikeStationQueryVariables, options?: C): Promise<GetBikeStationQuery> {
       return requester<GetBikeStationQuery, GetBikeStationQueryVariables>(GetBikeStationDocument, variables, options);
     }
   };

--- a/src/service/impl/mobility/mobility-gql/stations.graphql-gen.ts
+++ b/src/service/impl/mobility/mobility-gql/stations.graphql-gen.ts
@@ -1,9 +1,9 @@
 import * as Types from '../../../../graphql/mobility/mobility-types_v2';
 
-import { StationBasicFragment } from '../../fragments/mobility-gql/stations.graphql-gen';
+import { StationBasicFragment, CarStationFragment } from '../../fragments/mobility-gql/stations.graphql-gen';
 import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
-import { StationBasicFragmentDoc } from '../../fragments/mobility-gql/stations.graphql-gen';
+import { StationBasicFragmentDoc, CarStationFragmentDoc } from '../../fragments/mobility-gql/stations.graphql-gen';
 export type GetStationsQueryVariables = Types.Exact<{
   lat: Types.Scalars['Float'];
   lon: Types.Scalars['Float'];
@@ -13,6 +13,13 @@ export type GetStationsQueryVariables = Types.Exact<{
 
 
 export type GetStationsQuery = { stations?: Array<StationBasicFragment> };
+
+export type GetCarStationQueryVariables = Types.Exact<{
+  ids: Array<Types.InputMaybe<Types.Scalars['String']>> | Types.InputMaybe<Types.Scalars['String']>;
+}>;
+
+
+export type GetCarStationQuery = { stationsById?: Array<CarStationFragment> };
 
 
 export const GetStationsDocument = gql`
@@ -27,11 +34,21 @@ export const GetStationsDocument = gql`
   }
 }
     ${StationBasicFragmentDoc}`;
+export const GetCarStationDocument = gql`
+    query getCarStation($ids: [String]!) {
+  stationsById(ids: $ids) {
+    ...carStation
+  }
+}
+    ${CarStationFragmentDoc}`;
 export type Requester<C = {}, E = unknown> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R>
 export function getSdk<C, E>(requester: Requester<C, E>) {
   return {
     getStations(variables: GetStationsQueryVariables, options?: C): Promise<GetStationsQuery> {
       return requester<GetStationsQuery, GetStationsQueryVariables>(GetStationsDocument, variables, options);
+    },
+    getCarStation(variables: GetCarStationQueryVariables, options?: C): Promise<GetCarStationQuery> {
+      return requester<GetCarStationQuery, GetCarStationQueryVariables>(GetCarStationDocument, variables, options);
     }
   };
 }

--- a/src/service/impl/mobility/mobility-gql/stations.graphql-gen.ts
+++ b/src/service/impl/mobility/mobility-gql/stations.graphql-gen.ts
@@ -1,9 +1,9 @@
 import * as Types from '../../../../graphql/mobility/mobility-types_v2';
 
-import { StationBasicFragment, CarStationFragment } from '../../fragments/mobility-gql/stations.graphql-gen';
+import { StationBasicFragment, CarStationFragment, BikeStationFragment } from '../../fragments/mobility-gql/stations.graphql-gen';
 import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
-import { StationBasicFragmentDoc, CarStationFragmentDoc } from '../../fragments/mobility-gql/stations.graphql-gen';
+import { StationBasicFragmentDoc, CarStationFragmentDoc, BikeStationFragmentDoc } from '../../fragments/mobility-gql/stations.graphql-gen';
 export type GetStationsQueryVariables = Types.Exact<{
   lat: Types.Scalars['Float'];
   lon: Types.Scalars['Float'];
@@ -20,6 +20,13 @@ export type GetCarStationQueryVariables = Types.Exact<{
 
 
 export type GetCarStationQuery = { stationsById?: Array<CarStationFragment> };
+
+export type GetBikeStationQueryVariables = Types.Exact<{
+  ids: Array<Types.InputMaybe<Types.Scalars['String']>> | Types.InputMaybe<Types.Scalars['String']>;
+}>;
+
+
+export type GetBikeStationQuery = { stationsById?: Array<BikeStationFragment> };
 
 
 export const GetStationsDocument = gql`
@@ -41,6 +48,13 @@ export const GetCarStationDocument = gql`
   }
 }
     ${CarStationFragmentDoc}`;
+export const GetBikeStationDocument = gql`
+    query getBikeStation($ids: [String]!) {
+  stationsById(ids: $ids) {
+    ...bikeStation
+  }
+}
+    ${BikeStationFragmentDoc}`;
 export type Requester<C = {}, E = unknown> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R>
 export function getSdk<C, E>(requester: Requester<C, E>) {
   return {
@@ -49,6 +63,9 @@ export function getSdk<C, E>(requester: Requester<C, E>) {
     },
     getCarStation(variables: GetCarStationQueryVariables, options?: C): Promise<GetCarStationQuery> {
       return requester<GetCarStationQuery, GetCarStationQueryVariables>(GetCarStationDocument, variables, options);
+    },
+    getBikeStation(variables: GetBikeStationQueryVariables, options?: C): Promise<GetBikeStationQuery> {
+      return requester<GetBikeStationQuery, GetBikeStationQueryVariables>(GetBikeStationDocument, variables, options);
     }
   };
 }

--- a/src/service/impl/mobility/mobility-gql/stations.graphql-gen.ts
+++ b/src/service/impl/mobility/mobility-gql/stations.graphql-gen.ts
@@ -1,9 +1,9 @@
 import * as Types from '../../../../graphql/mobility/mobility-types_v2';
 
-import { StationFragment } from '../../fragments/mobility-gql/stations.graphql-gen';
+import { StationBasicFragment } from '../../fragments/mobility-gql/stations.graphql-gen';
 import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
-import { StationFragmentDoc } from '../../fragments/mobility-gql/stations.graphql-gen';
+import { StationBasicFragmentDoc } from '../../fragments/mobility-gql/stations.graphql-gen';
 export type GetStationsQueryVariables = Types.Exact<{
   lat: Types.Scalars['Float'];
   lon: Types.Scalars['Float'];
@@ -12,7 +12,7 @@ export type GetStationsQueryVariables = Types.Exact<{
 }>;
 
 
-export type GetStationsQuery = { stations?: Array<StationFragment> };
+export type GetStationsQuery = { stations?: Array<StationBasicFragment> };
 
 
 export const GetStationsDocument = gql`
@@ -23,10 +23,10 @@ export const GetStationsDocument = gql`
     range: $range
     availableFormFactors: $availableFormFactors
   ) {
-    ...station
+    ...stationBasic
   }
 }
-    ${StationFragmentDoc}`;
+    ${StationBasicFragmentDoc}`;
 export type Requester<C = {}, E = unknown> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R>
 export function getSdk<C, E>(requester: Requester<C, E>) {
   return {

--- a/src/service/impl/mobility/mobility-gql/vehicles.graphql
+++ b/src/service/impl/mobility/mobility-gql/vehicles.graphql
@@ -1,11 +1,11 @@
-query getVehiclesBasic($lat: Float!, $lon: Float!, $range: Int!, $formFactors: [FormFactor]) {
+query getVehicles($lat: Float!, $lon: Float!, $range: Int!, $formFactors: [FormFactor]) {
     vehicles(lat: $lat, lon: $lon, range: $range, formFactors: $formFactors) {
         ...vehicleBasic
     }
 }
 
-query getVehiclesExtended($lat: Float!, $lon: Float!, $range: Int!, $formFactors: [FormFactor]) {
-    vehicles(lat: $lat, lon: $lon, range: $range, formFactors: $formFactors) {
+query getVehicle($ids: [String!]) {
+    vehicles(ids: $ids) {
         ...vehicleExtended
     }
 }

--- a/src/service/impl/mobility/mobility-gql/vehicles.graphql-gen.ts
+++ b/src/service/impl/mobility/mobility-gql/vehicles.graphql-gen.ts
@@ -4,7 +4,7 @@ import { VehicleBasicFragment, VehicleExtendedFragment } from '../../fragments/m
 import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
 import { VehicleBasicFragmentDoc, VehicleExtendedFragmentDoc } from '../../fragments/mobility-gql/vehicles.graphql-gen';
-export type GetVehiclesBasicQueryVariables = Types.Exact<{
+export type GetVehiclesQueryVariables = Types.Exact<{
   lat: Types.Scalars['Float'];
   lon: Types.Scalars['Float'];
   range: Types.Scalars['Int'];
@@ -12,29 +12,26 @@ export type GetVehiclesBasicQueryVariables = Types.Exact<{
 }>;
 
 
-export type GetVehiclesBasicQuery = { vehicles?: Array<VehicleBasicFragment> };
+export type GetVehiclesQuery = { vehicles?: Array<VehicleBasicFragment> };
 
-export type GetVehiclesExtendedQueryVariables = Types.Exact<{
-  lat: Types.Scalars['Float'];
-  lon: Types.Scalars['Float'];
-  range: Types.Scalars['Int'];
-  formFactors?: Types.InputMaybe<Array<Types.InputMaybe<Types.FormFactor>> | Types.InputMaybe<Types.FormFactor>>;
+export type GetVehicleQueryVariables = Types.Exact<{
+  ids?: Types.InputMaybe<Array<Types.Scalars['String']> | Types.Scalars['String']>;
 }>;
 
 
-export type GetVehiclesExtendedQuery = { vehicles?: Array<VehicleExtendedFragment> };
+export type GetVehicleQuery = { vehicles?: Array<VehicleExtendedFragment> };
 
 
-export const GetVehiclesBasicDocument = gql`
-    query getVehiclesBasic($lat: Float!, $lon: Float!, $range: Int!, $formFactors: [FormFactor]) {
+export const GetVehiclesDocument = gql`
+    query getVehicles($lat: Float!, $lon: Float!, $range: Int!, $formFactors: [FormFactor]) {
   vehicles(lat: $lat, lon: $lon, range: $range, formFactors: $formFactors) {
     ...vehicleBasic
   }
 }
     ${VehicleBasicFragmentDoc}`;
-export const GetVehiclesExtendedDocument = gql`
-    query getVehiclesExtended($lat: Float!, $lon: Float!, $range: Int!, $formFactors: [FormFactor]) {
-  vehicles(lat: $lat, lon: $lon, range: $range, formFactors: $formFactors) {
+export const GetVehicleDocument = gql`
+    query getVehicle($ids: [String!]) {
+  vehicles(ids: $ids) {
     ...vehicleExtended
   }
 }
@@ -42,11 +39,11 @@ export const GetVehiclesExtendedDocument = gql`
 export type Requester<C = {}, E = unknown> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R>
 export function getSdk<C, E>(requester: Requester<C, E>) {
   return {
-    getVehiclesBasic(variables: GetVehiclesBasicQueryVariables, options?: C): Promise<GetVehiclesBasicQuery> {
-      return requester<GetVehiclesBasicQuery, GetVehiclesBasicQueryVariables>(GetVehiclesBasicDocument, variables, options);
+    getVehicles(variables: GetVehiclesQueryVariables, options?: C): Promise<GetVehiclesQuery> {
+      return requester<GetVehiclesQuery, GetVehiclesQueryVariables>(GetVehiclesDocument, variables, options);
     },
-    getVehiclesExtended(variables: GetVehiclesExtendedQueryVariables, options?: C): Promise<GetVehiclesExtendedQuery> {
-      return requester<GetVehiclesExtendedQuery, GetVehiclesExtendedQueryVariables>(GetVehiclesExtendedDocument, variables, options);
+    getVehicle(variables?: GetVehicleQueryVariables, options?: C): Promise<GetVehicleQuery> {
+      return requester<GetVehicleQuery, GetVehicleQueryVariables>(GetVehicleDocument, variables, options);
     }
   };
 }

--- a/src/service/interface.ts
+++ b/src/service/interface.ts
@@ -1,26 +1,27 @@
-import { Result } from '@badrap/result';
-import { Feature, TripPattern } from '@entur/sdk';
-import { Boom } from '@hapi/boom';
-import * as Trips from '../types/trips';
+import { Result } from "@badrap/result";
+import { Feature, TripPattern } from "@entur/sdk";
+import { Boom } from "@hapi/boom";
+import * as Trips from "../types/trips";
 import {
   StopPlaceQuayDeparturesQuery,
   StopPlaceQuayDeparturesQueryVariables
-} from './impl/departures/journey-gql/stop-departures.graphql-gen';
-import {
-  StopsDetailsQuery,
-  StopsDetailsQueryVariables
-} from './impl/departures/journey-gql/stops-details.graphql-gen';
+} from "./impl/departures/journey-gql/stop-departures.graphql-gen";
+import { StopsDetailsQuery, StopsDetailsQueryVariables } from "./impl/departures/journey-gql/stops-details.graphql-gen";
 import {
   NearestStopPlacesQuery,
   NearestStopPlacesQueryVariables
-} from './impl/departures/journey-gql/stops-nearest.graphql-gen';
-import { EnrollResponse } from './impl/enrollment';
-import { ServiceJourneyWithEstCallsFragment } from './impl/fragments/journey-gql/service-journey.graphql-gen';
-import { GetQuaysCoordinatesQuery } from './impl/quays/journey-gql/quays-coordinates.graphql-gen';
-import { ServiceJourneyEstimatedCallFragment } from './impl/service-journey/journey-gql/service-journey-departures.graphql-gen';
-import { DepartureGroupMetadata } from './impl/departures-grouped/departure-group';
+} from "./impl/departures/journey-gql/stops-nearest.graphql-gen";
+import { EnrollResponse } from "./impl/enrollment";
+import { ServiceJourneyWithEstCallsFragment } from "./impl/fragments/journey-gql/service-journey.graphql-gen";
+import { GetQuaysCoordinatesQuery } from "./impl/quays/journey-gql/quays-coordinates.graphql-gen";
 import {
-  APIError, BikeStationQuery, CarStationQuery,
+  ServiceJourneyEstimatedCallFragment
+} from "./impl/service-journey/journey-gql/service-journey-departures.graphql-gen";
+import { DepartureGroupMetadata } from "./impl/departures-grouped/departure-group";
+import {
+  APIError,
+  BikeStationQuery,
+  CarStationQuery,
   DepartureFavoritesPayload,
   DepartureFavoritesQuery,
   DepartureGroupsPayload,
@@ -39,23 +40,18 @@ import {
   ServiceJourneyWithEstimatedCallsQuery,
   StationsQuery,
   TripPatternsQuery,
+  VehicleQuery,
   VehiclesQuery
 } from "./types";
-import {
-  TripsQuery,
-  TripsQueryVariables
-} from './impl/trips/journey-gql/trip.graphql-gen';
+import { TripsQuery, TripsQueryVariables } from "./impl/trips/journey-gql/trip.graphql-gen";
 import {
   GetBikeStationQuery,
   GetCarStationQuery,
   GetStationsQuery
 } from "./impl/mobility/mobility-gql/stations.graphql-gen";
-import {
-  DeparturesQuery,
-  DeparturesQueryVariables
-} from './impl/departures/journey-gql/departures.graphql-gen';
-import { GetVehiclesBasicQuery, GetVehiclesExtendedQuery } from "./impl/mobility/mobility-gql/vehicles.graphql-gen";
+import { DeparturesQuery, DeparturesQueryVariables } from "./impl/departures/journey-gql/departures.graphql-gen";
 import { VehicleBasicFragment } from "./impl/fragments/mobility-gql/vehicles.graphql-gen";
+import { GetVehicleQuery, GetVehiclesQuery } from "./impl/mobility/mobility-gql/vehicles.graphql-gen";
 
 export interface IGeocoderService {
   getFeatures(query: FeaturesQuery): Promise<Result<Feature[], APIError>>;
@@ -144,16 +140,16 @@ export interface IVehiclesService {
   ): Promise<Result<ServiceJourneyVehicles, APIError>>;
 }
 
-export type VehicleFragment = Pick<VehicleBasicFragment, 'id' | 'lat' | 'lon'>
-export type GetVehiclesQuery = Omit<GetVehiclesBasicQuery, 'vehicles'> & { vehicles?: Array<VehicleFragment>}
+export type VehicleFragment = Pick<VehicleBasicFragment, 'id' | 'lat' | 'lon' | 'currentFuelPercent'>
+export type GetVehiclesListQuery = Omit<GetVehiclesQuery, 'vehicles'> & { vehicles?: Array<VehicleFragment>}
 
 export interface IMobilityService {
   getVehicles(
     query: VehiclesQuery
-  ): Promise<Result<GetVehiclesQuery, APIError>>;
-  getVehiclesExtended(
-    query: VehiclesQuery
-  ): Promise<Result<GetVehiclesExtendedQuery, APIError>>;
+  ): Promise<Result<GetVehiclesListQuery, APIError>>;
+  getVehicle(
+    query: VehicleQuery
+  ): Promise<Result<GetVehicleQuery, APIError>>;
   getStations(
     query: StationsQuery
   ): Promise<Result<GetStationsQuery, APIError>>;

--- a/src/service/interface.ts
+++ b/src/service/interface.ts
@@ -20,7 +20,7 @@ import { GetQuaysCoordinatesQuery } from './impl/quays/journey-gql/quays-coordin
 import { ServiceJourneyEstimatedCallFragment } from './impl/service-journey/journey-gql/service-journey-departures.graphql-gen';
 import { DepartureGroupMetadata } from './impl/departures-grouped/departure-group';
 import {
-  APIError, CarStationQuery,
+  APIError, BikeStationQuery, CarStationQuery,
   DepartureFavoritesPayload,
   DepartureFavoritesQuery,
   DepartureGroupsPayload,
@@ -45,7 +45,11 @@ import {
   TripsQuery,
   TripsQueryVariables
 } from './impl/trips/journey-gql/trip.graphql-gen';
-import { GetCarStationQuery, GetStationsQuery } from "./impl/mobility/mobility-gql/stations.graphql-gen";
+import {
+  GetBikeStationQuery,
+  GetCarStationQuery,
+  GetStationsQuery
+} from "./impl/mobility/mobility-gql/stations.graphql-gen";
 import {
   DeparturesQuery,
   DeparturesQueryVariables
@@ -153,8 +157,10 @@ export interface IMobilityService {
   getStations(
     query: StationsQuery
   ): Promise<Result<GetStationsQuery, APIError>>;
-
   getCarStation(
     query: CarStationQuery
   ): Promise<Result<GetCarStationQuery, APIError>>;
+  getBikeStation(
+    query: BikeStationQuery
+  ): Promise<Result<GetBikeStationQuery, APIError>>;
 }

--- a/src/service/interface.ts
+++ b/src/service/interface.ts
@@ -20,7 +20,7 @@ import { GetQuaysCoordinatesQuery } from './impl/quays/journey-gql/quays-coordin
 import { ServiceJourneyEstimatedCallFragment } from './impl/service-journey/journey-gql/service-journey-departures.graphql-gen';
 import { DepartureGroupMetadata } from './impl/departures-grouped/departure-group';
 import {
-  APIError,
+  APIError, CarStationQuery,
   DepartureFavoritesPayload,
   DepartureFavoritesQuery,
   DepartureGroupsPayload,
@@ -40,12 +40,12 @@ import {
   StationsQuery,
   TripPatternsQuery,
   VehiclesQuery
-} from './types';
+} from "./types";
 import {
   TripsQuery,
   TripsQueryVariables
 } from './impl/trips/journey-gql/trip.graphql-gen';
-import { GetStationsQuery } from './impl/mobility/mobility-gql/stations.graphql-gen';
+import { GetCarStationQuery, GetStationsQuery } from "./impl/mobility/mobility-gql/stations.graphql-gen";
 import {
   DeparturesQuery,
   DeparturesQueryVariables
@@ -153,4 +153,8 @@ export interface IMobilityService {
   getStations(
     query: StationsQuery
   ): Promise<Result<GetStationsQuery, APIError>>;
+
+  getCarStation(
+    query: CarStationQuery
+  ): Promise<Result<GetCarStationQuery, APIError>>;
 }

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -184,6 +184,8 @@ export type StationsQuery = Pick<
   'lat' | 'lon' | 'range' | 'operators' | 'availableFormFactors'
 >;
 
+export type CarStationQuery = { ids: string[] }
+
 export type ServiceJourneyMapInfoData = {
   mapLegs: MapLeg[];
   start?: Coordinates;

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -2,7 +2,7 @@ import { Location, QueryMode } from "@entur/sdk";
 import { boomify } from "@hapi/boom";
 import { FetchError } from "node-fetch";
 import { Mode, PointsOnLink, TransportSubmode } from "../graphql/journey/journeyplanner-types_v3";
-import * as Mobility from "../graphql/mobility/mobility-types_v2";
+import { FormFactor } from "../graphql/mobility/mobility-types_v2";
 import { CursoredQuery } from "./cursored";
 import { GetServiceJourneyVehicleQuery } from "./impl/vehicles/vehicles-gql/vehicles.graphql-gen";
 import * as Types from "../graphql/vehicles/vehicles-types_v1";
@@ -172,17 +172,23 @@ export type ServiceJourneyVehicles = Array<{
   serviceJourney?: { id: string };
 }>;
 
-export type VehicleQuery = { id: string } & Pick<Mobility.QueryVehiclesArgs, 'lat' | 'lon' | 'range' | 'formFactors'>
+export type VehicleQuery = {
+  ids: string | string[]
+};
 
-export type VehiclesQuery = Pick<
-  Mobility.QueryVehiclesArgs,
-  'lat' | 'lon' | 'range' | 'operators' | 'formFactors'
->;
+export type VehiclesQuery = {
+  lat: number,
+  lon: number,
+  range: number,
+  formFactors?: FormFactor | FormFactor[]
+};
 
-export type StationsQuery = Pick<
-  Mobility.QueryStationsArgs,
-  'lat' | 'lon' | 'range' | 'operators' | 'availableFormFactors'
->;
+export type StationsQuery = {
+  lat: number,
+  lon: number,
+  range: number,
+  availableFormFactors?: FormFactor | FormFactor[]
+}
 
 export type CarStationQuery = { ids: string[] }
 export type BikeStationQuery = { ids: string[] }

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -185,6 +185,7 @@ export type StationsQuery = Pick<
 >;
 
 export type CarStationQuery = { ids: string[] }
+export type BikeStationQuery = { ids: string[] }
 
 export type ServiceJourneyMapInfoData = {
   mapLegs: MapLeg[];


### PR DESCRIPTION
Entur has introduced a new `ids` parameter to their `stations` and `vehicles` queries. This pr uses this new option to fetch a single scooter or station. 