### PR TITLE
test: get vehicles by id

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: tor/test-vehicles-by-id
+          ref: main
 
       - name: Install k6
         run: |

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: main
+          ref: tor/test-vehicles-by-id
 
       - name: Install k6
         run: |

--- a/test/src/v2/mobility/scenario.ts
+++ b/test/src/v2/mobility/scenario.ts
@@ -1,15 +1,29 @@
 import { vehicle, vehicles } from './vehicles';
-import { VehicleInfoType } from '../types/mobility';
+import { StationInfoType, VehicleInfoType } from '../types/mobility';
+import { station, stations } from './stations';
 
 // Get vehicles and ask for a specific vehicle
 export function vehicleByIdScenario(): void {
   let vehicleInfo: VehicleInfoType = vehicles(200);
   if (vehicleInfo !== undefined) {
-    vehicle(vehicleInfo, 100);
+    vehicle(vehicleInfo);
   }
 
   vehicleInfo = vehicles(300);
   if (vehicleInfo !== undefined) {
-    vehicle(vehicleInfo, 100);
+    vehicle(vehicleInfo);
+  }
+}
+
+// Get vehicles and ask for a specific vehicle
+export function stationByIdScenario(): void {
+  let stationInfo: StationInfoType = stations(250);
+  if (stationInfo !== undefined) {
+    station(stationInfo);
+  }
+
+  stationInfo = stations(400);
+  if (stationInfo !== undefined) {
+    station(stationInfo);
   }
 }

--- a/test/src/v2/mobility/stations.ts
+++ b/test/src/v2/mobility/stations.ts
@@ -6,18 +6,22 @@ import {
   Station
 } from '../../../../src/graphql/mobility/mobility-types_v2';
 import { randomNumber } from '../../utils/utils';
+import { StationInfoType } from '../types/mobility';
 
-export function stations(range: number = 250) {
+export function stations(range: number = 250): StationInfoType | undefined {
   const requestName = `v2_stations_${range}`;
+  const formFactor = 'BICYCLE';
   // coordinates around Trondheim city center
   const lat = `63.4304571134${randomNumber(1000, true)}`;
   const lon = `10.39810091257${randomNumber(1000, true)}`;
-  const url = `${conf.host()}/bff/v2/mobility/stations?availableFormFactors=BICYCLE&lat=${lat}&lon=${lon}&range=${range}`;
+  const url = `${conf.host()}/bff/v2/mobility/stations?availableFormFactors=${formFactor}&lat=${lat}&lon=${lon}&range=${range}`;
 
   const res = http.get(url, {
     tags: { name: requestName },
     headers: bffHeadersGet
   });
+
+  let returnStation: StationInfoType = undefined;
 
   try {
     const json = res.json() as Query;
@@ -29,45 +33,121 @@ export function stations(range: number = 250) {
     ];
 
     if (numberOfStations != 0) {
+      // Station to return - returning the first
+      returnStation = {
+        id: stations[0].id,
+        count: stations[0].vehicleTypesAvailable![0].count,
+        formFactor: stations[0].vehicleTypesAvailable![0].vehicleType.formFactor
+      };
       expects.push(
         {
-          check: 'capacity is >= 0',
-          expect:
-            stations.filter(s => s.capacity! >= 0).length === numberOfStations
+          check: 'stations have id',
+          expect: stations.filter(s => s!.id).length === numberOfStations
         },
         {
-          check: 'number of bikes and docks available equals capacity',
-          expect:
-            stations.filter(
-              s => s.numBikesAvailable + s.numDocksAvailable! <= s.capacity!
-            ).length === numberOfStations
+          check: 'stations have latitude',
+          expect: stations.filter(s => s!.lat).length === numberOfStations
         },
         {
-          check: 'vehicles have a price per minute',
+          check: 'stations have longitude',
+          expect: stations.filter(s => s!.lon).length === numberOfStations
+        },
+        {
+          check: 'number of bikes is >= 0',
           expect:
-            stations.filter(s => s.pricingPlans[0].perMinPricing?.length! > 0)
+            stations.filter(s => s.vehicleTypesAvailable![0].count >= 0)
               .length === numberOfStations
-        },
-        {
-          check: 'an app link to the operator exists',
-          expect:
-            stations.filter(
-              s =>
-                s.system.rentalApps?.android?.storeUri?.length! > 0 &&
-                s.system.rentalApps?.ios?.storeUri?.length! > 0
-            ).length === numberOfStations
-        },
-        {
-          check: 'an url to the operator exists',
-          expect:
-            stations.filter(
-              s =>
-                s.rentalUris?.android?.length! > 0 &&
-                s.rentalUris?.ios?.length! > 0
-            ).length === numberOfStations
         }
       );
     }
+
+    metrics.checkForFailures(
+      [res.request.url],
+      res.timings.duration,
+      requestName,
+      expects
+    );
+
+    return returnStation;
+  } catch (exp) {
+    //throw exp
+    metrics.checkForFailures(
+      [res.request.url],
+      res.timings.duration,
+      requestName,
+      [
+        {
+          check: `${exp}`,
+          expect: false
+        }
+      ]
+    );
+
+    return returnStation;
+  }
+}
+
+// Get one station
+export function station(stationInfo: StationInfoType) {
+  const requestName = `v2_station`;
+  const url = `${conf.host()}/bff/v2/mobility/station/bike?ids=${
+    stationInfo!.id
+  }`;
+
+  const res = http.get(url, {
+    tags: { name: requestName },
+    headers: bffHeadersGet
+  });
+
+  try {
+    const json = res.json() as Query;
+    const stations = json.stations! as Station[];
+    const station = stations[0];
+
+    const expects: ExpectsType = [
+      { check: 'should have status 200', expect: res.status === 200 }
+    ];
+
+    expects.push(
+      {
+        check: 'should return only one station',
+        expect: stations.length === 1
+      },
+      {
+        check: 'station is is correct',
+        expect: station.id === stationInfo!.id
+      },
+      {
+        check: 'type of station is correct',
+        expect:
+          station.vehicleTypesAvailable![0].vehicleType.formFactor ===
+          stationInfo!.formFactor
+      },
+      {
+        check: 'number of available bikes is correct',
+        expect: station.vehicleTypesAvailable![0].count === stationInfo!.count
+      },
+      {
+        check: 'number of available docks is >= 0',
+        expect: station.numDocksAvailable! >= 0
+      },
+      {
+        check: 'vehicles have a price',
+        expect: station.pricingPlans[0].price >= 0
+      },
+      {
+        check: 'an app link to the operator exists',
+        expect:
+          station.system.rentalApps?.android?.storeUri?.length! > 0 &&
+          station.system.rentalApps?.ios?.storeUri?.length! > 0
+      },
+      {
+        check: 'an url to the operator exists',
+        expect:
+          station.rentalUris?.android?.length! > 0 &&
+          station.rentalUris?.ios?.length! > 0
+      }
+    );
 
     metrics.checkForFailures(
       [res.request.url],

--- a/test/src/v2/mobility/vehicles.ts
+++ b/test/src/v2/mobility/vehicles.ts
@@ -84,14 +84,11 @@ export function vehicles(range: number = 200): VehicleInfoType | undefined {
   }
 }
 
-export function vehicle(vehicleInfo: VehicleInfoType, range: number = 100) {
-  const requestName = `v2_vehicle_${range}`;
+// Get one vehicle
+export function vehicle(vehicleInfo: VehicleInfoType) {
+  const requestName = `v2_vehicle`;
   const formFactor = 'SCOOTER';
-  const url = `${conf.host()}/bff/v2/mobility/vehicle?id=${
-    vehicleInfo!.id
-  }&formFactors=${formFactor}&lat=${vehicleInfo!.lat}&lon=${
-    vehicleInfo!.lon
-  }&range=${range}`;
+  const url = `${conf.host()}/bff/v2/mobility/vehicle?ids=${vehicleInfo!.id}`;
 
   const res = http.get(url, {
     tags: { name: requestName },
@@ -100,12 +97,18 @@ export function vehicle(vehicleInfo: VehicleInfoType, range: number = 100) {
 
   try {
     const json = res.json() as Query;
-    const vehicle = json as Vehicle;
+    const vehicles = json.vehicles as Vehicle[];
+    const vehicle = vehicles[0];
 
     const expects: ExpectsType = [
       { check: 'should have status 200', expect: res.status === 200 }
     ];
+
     expects.push(
+      {
+        check: 'should return only one vehicle',
+        expect: vehicles.length === 1
+      },
       {
         check: 'vehicle id is correct',
         expect: vehicle.id === vehicleInfo!.id

--- a/test/src/v2/types/mobility.ts
+++ b/test/src/v2/types/mobility.ts
@@ -6,3 +6,11 @@ export type VehicleInfoType =
       currentFuelPercent: number;
     }
   | undefined;
+
+export type StationInfoType =
+  | {
+      id: string;
+      count: number;
+      formFactor: string;
+    }
+  | undefined;

--- a/test/src/v2/v2Scenario.ts
+++ b/test/src/v2/v2Scenario.ts
@@ -36,6 +36,7 @@ import {
   serviceJourneyCalls
 } from './servicejourney';
 import { stations, vehicleByIdScenario, vehicles } from './mobility';
+import { stationByIdScenario } from './mobility/scenario';
 
 //Scenario with std pattern
 export const departuresScenario = (searchDate: string): void => {
@@ -78,6 +79,7 @@ export const mobilityScenario = (): void => {
   stations(250);
 
   vehicleByIdScenario();
+  stationByIdScenario();
 };
 
 //Performance scenario with different patterns


### PR DESCRIPTION
Changed according to the mobility API: First get a list of el-scooters/bikes, and then get a single by id.

Note! Only testing one id in the list of ids. Will update this later.