### PR TITLE
fix: Update logic for finding corresponding point on link

### DIFF
--- a/src/service/impl/service-journey/utils.ts
+++ b/src/service/impl/service-journey/utils.ts
@@ -1,6 +1,5 @@
 import polyline from '@mapbox/polyline';
 import haversineDistance from 'haversine-distance';
-import { PointsOnLink } from '../../../graphql/journey/journeyplanner-types_v3';
 import { Coordinates, MapLeg, ServiceJourneyMapInfoData } from '../../types';
 import {
   MapInfoWithFromAndToQuayV2Query,
@@ -23,84 +22,55 @@ export function mapToMapLegs(
     ? [data.toQuay.latitude ?? 0, data.toQuay.longitude ?? 0]
     : undefined;
 
-  const coordinates: PolylinePair[] = polyline.decode(
+  const pointsCoords: PolylinePair[] = polyline.decode(
     data.serviceJourney?.pointsOnLink?.points ?? ''
   );
-  const defaultValue = {
-    start: polypairToCoordinates(coordinates[0]),
-    stop: polypairToCoordinates(coordinates[coordinates.length - 1]),
 
-    mapLegs: [
-      {
-        ...baseItem,
-        faded: false,
-        pointsOnLink: data.serviceJourney?.pointsOnLink as PointsOnLink
-      } as MapLeg
-    ]
-  };
+  const mainStartIndex = fromQuayCoordinates
+    ? findIndex(pointsCoords, fromQuayCoordinates)
+    : 0;
+  const mainEndIndex = toQuayCoordinates
+    ? findIndex(pointsCoords, toQuayCoordinates)
+    : pointsCoords.length - 1;
 
-  if (!fromQuayCoordinates && !toQuayCoordinates) {
-    return defaultValue;
-  }
+  const beforeLegCoords = pointsCoords.slice(0, mainStartIndex + 1);
+  const mainLegCoords = pointsCoords.slice(mainStartIndex, mainEndIndex + 1);
+  const afterLegCoords = pointsCoords.slice(mainEndIndex);
 
-  const splitIndexTo = findIndex(coordinates, toQuayCoordinates);
-  const splitIndexFrom = findIndex(coordinates, fromQuayCoordinates);
+  const toMapLeg = (item: PolylinePair[], faded: boolean): MapLeg =>
+    ({
+      ...baseItem,
+      faded,
+      pointsOnLink: {
+        length: item.length,
+        points: polyline.encode(item)
+      }
+    } as MapLeg);
 
-  if (splitIndexFrom < 0 && splitIndexTo < 0) {
-    return defaultValue;
-  }
-  const isNoneOrFirst = splitIndexFrom < 1;
-  const isNoneOrLast =
-    splitIndexTo < 0 || splitIndexTo >= coordinates.length - 1;
-
-  // before should also include quay.
-  const before = isNoneOrFirst ? [] : coordinates.slice(0, splitIndexFrom + 1);
-  const mainLeg = coordinates.slice(
-    isNoneOrFirst ? 0 : splitIndexFrom,
-    isNoneOrLast ? coordinates.length : splitIndexTo + 1
-  );
-  const after = isNoneOrLast ? [] : coordinates.slice(splitIndexTo);
-
-  const itemIfDefined = (
-    item: PolylinePair[],
-    faded: boolean
-  ): MapLeg | undefined =>
-    item.length
-      ? ({
-          ...baseItem,
-          faded,
-          pointsOnLink: {
-            length: item.length,
-            points: polyline.encode(item)
-          }
-        } as MapLeg)
-      : undefined;
   const mapLegs: MapLeg[] = [
-    itemIfDefined(before, true),
-    itemIfDefined(mainLeg, false),
-    itemIfDefined(after, true)
-  ].filter(Boolean) as MapLeg[];
+    toMapLeg(beforeLegCoords, true),
+    toMapLeg(mainLegCoords, false),
+    toMapLeg(afterLegCoords, true)
+  ].filter(leg => (leg.pointsOnLink.length || 0) > 1);
 
   return {
-    ...defaultValue,
+    start: polypairToCoordinates(pointsCoords[0]),
+    stop: polypairToCoordinates(pointsCoords[pointsCoords.length - 1]),
     mapLegs
   };
 }
 
 function findIndex<T>(
   array: Array<PolylinePair>,
-  quayCoords?: PolylinePair
+  quayCoords: PolylinePair
 ): number {
-  if (!quayCoords) return -1;
-  let closestIndex = -1;
-  let closestDistance = 100;
-  array.forEach((t, index) => {
-    if (haversineDistance(t, quayCoords) < closestDistance) {
-      closestIndex = index;
-      closestDistance = haversineDistance(t, quayCoords);
-    }
-  });
-  return closestIndex;
+  return array.reduce(
+    (closest, t, index) => {
+      const distance = haversineDistance(t, quayCoords);
+      return distance < closest.distance ? { index, distance } : closest;
+    },
+    { index: -1, distance: 100 }
+  ).index;
 }
 
 function polypairToCoordinates(

--- a/src/service/impl/service-journey/utils.ts
+++ b/src/service/impl/service-journey/utils.ts
@@ -9,7 +9,7 @@ import {
 
 type PolylinePair = [lat: number, lng: number];
 
-const COORDINATE_DISTANCE_THRESHOLD_IN_METERS = 3;
+const COORDINATE_DISTANCE_THRESHOLD_IN_METERS = 20;
 
 export function mapToMapLegs(
   data: MapInfoWithFromQuayV2Query & MapInfoWithFromAndToQuayV2Query

--- a/src/service/impl/service-journey/utils.ts
+++ b/src/service/impl/service-journey/utils.ts
@@ -92,7 +92,7 @@ function findIndex<T>(
   quayCoords?: PolylinePair
 ): number {
   if (!quayCoords) return -1;
-  let closestIndex = 0;
+  let closestIndex = -1;
   let closestDistance = 100;
   array.forEach((t, index) => {
     if (haversineDistance(t, quayCoords) < closestDistance) {

--- a/src/service/impl/service-journey/utils.ts
+++ b/src/service/impl/service-journey/utils.ts
@@ -59,15 +59,17 @@ export function mapToMapLegs(
   if (splitIndexFrom < 0 && splitIndexTo < 0) {
     return defaultValue;
   }
+  const isNoneOrFirst = splitIndexFrom < 1;
+  const isNoneOrLast =
+    splitIndexTo < 0 || splitIndexTo >= coordinates.length - 1;
 
   // before should also include quay.
-  const before =
-    splitIndexFrom < 0 ? [] : coordinates.slice(0, splitIndexFrom + 1);
+  const before = isNoneOrFirst ? [] : coordinates.slice(0, splitIndexFrom + 1);
   const mainLeg = coordinates.slice(
-    splitIndexFrom < 0 ? 0 : splitIndexFrom,
-    splitIndexTo < 0 ? coordinates.length : splitIndexTo + 1
+    isNoneOrFirst ? 0 : splitIndexFrom,
+    isNoneOrLast ? coordinates.length : splitIndexTo + 1
   );
-  const after = splitIndexTo < 0 ? [] : coordinates.slice(splitIndexTo);
+  const after = isNoneOrLast ? [] : coordinates.slice(splitIndexTo);
 
   const itemIfDefined = (
     item: PolylinePair[],


### PR DESCRIPTION
Change logic regarding COORDINATE_DISTANCE_THRESHOLD_IN_METERS, as it seems to be too short to find the nearest point on link in several cases, and then returns default, which is full color for the whole line:
<details>
<summary>Screenshot</summary>

![Simulator Screen Shot - iPhone 14 Pro Max - 2023-05-25 at 14 02 48](https://github.com/AtB-AS/atb-bff/assets/85479566/7bc2d2f9-76e6-4c1b-aa06-8486b5913878)
</details>

With changing the logic to find the nearest point on link for the quay, it seems to fix most/all cases, and does not appear to break places:
<details>
<summary>Screenshot</summary>

![Simulator Screen Shot - iPhone 14 Pro Max - 2023-05-25 at 14 02 11](https://github.com/AtB-AS/atb-bff/assets/85479566/81c62ba5-d655-4d10-a9ae-c0c978bc707f)
</details>

Also add handling for from index and to index being first and last index, respectively.


Related to https://github.com/AtB-AS/kundevendt/issues/3689