### PR TITLE
fix: make InMemoryCache persistent

### DIFF
--- a/src/graphql/graphql-client.ts
+++ b/src/graphql/graphql-client.ts
@@ -45,8 +45,8 @@ const urlVehiclesWss = ENTUR_WEBSOCKET_BASEURL
   : 'wss://api.entur.io/realtime/v1/vehicles/subscriptions';
 
 function createClient(url: string) {
+  const cache = new InMemoryCache();
   return function (headers: Request<ReqRefDefaults>) {
-    const cache = new InMemoryCache();
     const httpLink = new HttpLink({
       uri: url,
 


### PR DESCRIPTION
Looks like the InMemoryCache was reset on every API call, since it was created inside the returned ApolloClient function. 

This change makes InMemoryCache persist between API calls, and fixes caching for realtime requests as observed in https://github.com/AtB-AS/kundevendt/issues/4131

fixes https://github.com/AtB-AS/kundevendt/issues/4131
