### PR TITLE
feat: forward 429 network errors

### DIFF
--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -1,15 +1,17 @@
 import {Location, QueryMode} from '@entur/sdk';
 import {boomify} from '@hapi/boom';
-import {FetchError} from 'node-fetch';
+import {FetchError, Response} from 'node-fetch';
 import {
   Mode,
   PointsOnLink,
   TransportSubmode,
 } from '../graphql/journey/journeyplanner-types_v3';
 import {FormFactor} from '../graphql/mobility/mobility-types_v2';
+import * as Types from '../graphql/vehicles/vehicles-types_v1';
 import {CursoredQuery} from './cursored';
 import {GetServiceJourneyVehicleQuery} from './impl/vehicles/vehicles-gql/vehicles.graphql-gen';
-import * as Types from '../graphql/vehicles/vehicles-types_v1';
+
+const STATUS_CODES_TO_FORWARD = [429];
 
 export interface Coordinates {
   latitude: number;
@@ -229,9 +231,24 @@ export class APIError extends Error {
           this.statusCode = 503;
       }
     }
+    const networkErrorResponse = getNetworkErrorResponse(error);
+    if (
+      networkErrorResponse &&
+      STATUS_CODES_TO_FORWARD.includes(networkErrorResponse.status)
+    ) {
+      this.message = networkErrorResponse.statusText;
+      this.statusCode = networkErrorResponse.status;
+    }
+
     return boomify(this, {
       statusCode: this.statusCode,
       message: error.message,
     });
+  }
+}
+
+function getNetworkErrorResponse(error: any): Response | undefined {
+  if (error?.networkError?.response instanceof Response) {
+    return error.networkError.response;
   }
 }


### PR DESCRIPTION
BFF part of https://github.com/AtB-AS/mittatb-app/pull/3641

- Adds a `STATUS_CODES_TO_FORWARD` array with codes that we want to forward to the app. Right now just 429s, but since we probably want to handle more error cases in the future, I made it easily extendable.

I don't really think APIError should be part of types.ts, but I'm working on a refactor, that I'll make a new PR for.