### PR TITLE
fix: parse reverse geocoder layers as arrays

### DIFF
--- a/src/api/geocoder/schema.ts
+++ b/src/api/geocoder/schema.ts
@@ -4,12 +4,7 @@ export const getFeaturesRequest = Joi.object({
   query: Joi.string().required(),
   lon: Joi.number(),
   lat: Joi.number(),
-  layers: Joi.string().custom((val) => {
-    if (val && typeof val === 'string') {
-      return val.split(',');
-    }
-    return val;
-  }),
+  layers: Joi.array().items(Joi.string()).single(),
   multiModal: Joi.alt('parent', 'child', 'all').default('child'),
   tariff_zone_authorities: Joi.string(),
   'boundary.rect.min_lat': Joi.number(),
@@ -32,12 +27,7 @@ export const getFeaturesReverseRequest = {
   query: Joi.object({
     lat: Joi.number().required(),
     lon: Joi.number().required(),
-    layers: Joi.string().custom((val) => {
-      if (val && typeof val === 'string') {
-        return val.split(',');
-      }
-      return val;
-    }),
+    layers: Joi.array().items(Joi.string()).single(),
     radius: Joi.number(),
     limit: Joi.number(),
   }),


### PR DESCRIPTION
~Parses reverse geocoder `layers` field to accept a comma separated list of layers.~

Handles geocoder `layer` param as an arrays. This fixes a type inconsistency, where a string was expected to be an array.

Technically a breaking change, as using `layers=venue,address` isn't supported anymore. But this wasn't used, and didn't work properly anyway.

required for fixing https://github.com/AtB-AS/kundevendt/issues/2954

## Acceptance criteria

Reverse geocoder requests works as before in current and older versions of the app:

- [x] Loading departures in the map tab
- [x] Location search -> "Select in map"
- [x] Could also test navigating from trip details -> departures in old versions of the app, since this used the reverse geocoder previously. (That is, v1.26 and older. Before this change: https://github.com/AtB-AS/mittatb-app/pull/2993)
