### PR TITLE
feat: Use of VehicleStatus property on GraphQL

### DIFF
--- a/src/graphql/journey/journeyplanner-types_v3.ts
+++ b/src/graphql/journey/journeyplanner-types_v3.ts
@@ -368,9 +368,9 @@ export type Interchange = {
   ToServiceJourney?: Maybe<ServiceJourney>;
   fromServiceJourney?: Maybe<ServiceJourney>;
   guaranteed?: Maybe<Scalars['Boolean']>;
-  /** Maximum time after scheduled departure time the connecting transport is guarantied to wait for the delayed trip. [NOT RESPECTED DURING ROUTING, JUST PASSED THROUGH] */
+  /** Maximum time after scheduled departure time the connecting transport is guaranteed to wait for the delayed trip. [NOT RESPECTED DURING ROUTING, JUST PASSED THROUGH] */
   maximumWaitTime?: Maybe<Scalars['Int']>;
-  /** The transfer priority is used to decide where a transfer should happen, at the highest prioritized location. If the guarantied flag is set it take precedence priority. A guarantied ALLOWED transfer is preferred over a PREFERRED none-guarantied transfer. */
+  /** The transfer priority is used to decide where a transfer should happen, at the highest prioritized location. If the guaranteed flag is set it take precedence priority. A guaranteed ALLOWED transfer is preferred over a PREFERRED none-guaranteed transfer. */
   priority?: Maybe<InterchangePriority>;
   staySeated?: Maybe<Scalars['Boolean']>;
   toServiceJourney?: Maybe<ServiceJourney>;
@@ -607,6 +607,7 @@ export enum Mode {
   Monorail = 'monorail',
   Rail = 'rail',
   Scooter = 'scooter',
+  Taxi = 'taxi',
   Tram = 'tram',
   Trolleybus = 'trolleybus',
   Water = 'water'
@@ -1125,6 +1126,7 @@ export type QueryTypeTripArgs = {
   itineraryFilters?: InputMaybe<ItineraryFilters>;
   locale?: InputMaybe<Locale>;
   maxAccessEgressDurationForMode?: InputMaybe<Array<StreetModeDurationInput>>;
+  maxDirectDurationForMode?: InputMaybe<Array<StreetModeDurationInput>>;
   maximumAdditionalTransfers?: InputMaybe<Scalars['Int']>;
   maximumTransfers?: InputMaybe<Scalars['Int']>;
   modes?: InputMaybe<Modes>;
@@ -1235,8 +1237,6 @@ export enum RoutingErrorCode {
   OutsideBounds = 'outsideBounds',
   /** The date specified is outside the range of data currently loaded into the system */
   OutsideServicePeriod = 'outsideServicePeriod',
-  /** The routing request timed out. */
-  ProcessingTimeout = 'processingTimeout',
   /** An unknown error happened during the search. The details have been logged to the server logs */
   SystemError = 'systemError',
   /** The origin and destination are so close to each other, that walking is always better, but no direct mode was specified for the search */
@@ -1627,6 +1627,7 @@ export enum TransportMode {
   Metro = 'metro',
   Monorail = 'monorail',
   Rail = 'rail',
+  Taxi = 'taxi',
   Tram = 'tram',
   Trolleybus = 'trolleybus',
   Unknown = 'unknown',

--- a/src/graphql/vehicles/vehicles-types_v1.ts
+++ b/src/graphql/vehicles/vehicles-types_v1.ts
@@ -35,6 +35,16 @@ export type Location = {
   longitude: Scalars['Float'];
 };
 
+export enum OccupancyEnumeration {
+  FewSeatsAvailable = 'FEW_SEATS_AVAILABLE',
+  Full = 'FULL',
+  ManySeatsAvailable = 'MANY_SEATS_AVAILABLE',
+  NotAcceptingPassengers = 'NOT_ACCEPTING_PASSENGERS',
+  SeatsAvailable = 'SEATS_AVAILABLE',
+  StandingAvailable = 'STANDING_AVAILABLE',
+  Unknown = 'UNKNOWN'
+}
+
 export type Operator = {
   operatorRef: Scalars['String'];
 };
@@ -140,6 +150,15 @@ export enum VehicleModeEnumeration {
   Tram = 'TRAM'
 }
 
+export enum VehicleStatusEnumeration {
+  Assigned = 'ASSIGNED',
+  AtOrigin = 'AT_ORIGIN',
+  Cancelled = 'CANCELLED',
+  Completed = 'COMPLETED',
+  InProgress = 'IN_PROGRESS',
+  OffRoute = 'OFF_ROUTE'
+}
+
 export type VehicleUpdate = {
   bearing?: Maybe<Scalars['Float']>;
   codespace?: Maybe<Codespace>;
@@ -150,16 +169,21 @@ export type VehicleUpdate = {
   expirationEpochSecond?: Maybe<Scalars['Float']>;
   /** @deprecated Use 'bearing''. */
   heading?: Maybe<Scalars['Float']>;
+  /** Whether the vehicle is affected by traffic jams or other circumstances which may lead to further delays. If `null`, current status is unknown. */
+  inCongestion?: Maybe<Scalars['Boolean']>;
   lastUpdated?: Maybe<Scalars['DateTime']>;
   lastUpdatedEpochSecond?: Maybe<Scalars['Float']>;
   line?: Maybe<Line>;
   location?: Maybe<Location>;
   mode?: Maybe<VehicleModeEnumeration>;
   monitored?: Maybe<Scalars['Boolean']>;
+  occupancy?: Maybe<OccupancyEnumeration>;
   operator?: Maybe<Operator>;
   serviceJourney?: Maybe<ServiceJourney>;
   speed?: Maybe<Scalars['Float']>;
   vehicleId?: Maybe<Scalars['String']>;
   /** @deprecated Use 'vehicleId'. */
   vehicleRef?: Maybe<Scalars['String']>;
+  /** Reported status of the vehicle */
+  vehicleStatus?: Maybe<VehicleStatusEnumeration>;
 };

--- a/src/service/impl/vehicles/vehicles-gql/vehicles.graphql
+++ b/src/service/impl/vehicles/vehicles-gql/vehicles.graphql
@@ -10,5 +10,6 @@ query getServiceJourneyVehicle($serviceJourneyId: String!) {
     serviceJourney {
       id
     }
+    vehicleStatus
   }
 }

--- a/src/service/impl/vehicles/vehicles-gql/vehicles.graphql-gen.ts
+++ b/src/service/impl/vehicles/vehicles-gql/vehicles.graphql-gen.ts
@@ -7,7 +7,7 @@ export type GetServiceJourneyVehicleQueryVariables = Types.Exact<{
 }>;
 
 
-export type GetServiceJourneyVehicleQuery = { vehicles?: Array<{ lastUpdated?: any, bearing?: number, mode?: Types.VehicleModeEnumeration, location?: { latitude: number, longitude: number }, serviceJourney?: { id: string } }> };
+export type GetServiceJourneyVehicleQuery = { vehicles?: Array<{ lastUpdated?: any, bearing?: number, mode?: Types.VehicleModeEnumeration, vehicleStatus?: Types.VehicleStatusEnumeration, location?: { latitude: number, longitude: number }, serviceJourney?: { id: string } }> };
 
 
 export const GetServiceJourneyVehicleDocument = gql`
@@ -23,6 +23,7 @@ export const GetServiceJourneyVehicleDocument = gql`
     serviceJourney {
       id
     }
+    vehicleStatus
   }
 }
     `;


### PR DESCRIPTION
`Entur` recently added a new attribute to the GraphQL in order to know the end of a journey, this is useful for live position to know when it reached the end and show another option for `see live`

Closes: https://github.com/AtB-AS/kundevendt/issues/4214