### PR TITLE
test: api test changes and improvements

### DIFF
--- a/test/src/scenario.ts
+++ b/test/src/scenario.ts
@@ -3,16 +3,16 @@ import {
   departuresScenarioPerformance,
   serviceJourneyScenario,
   tripsScenario,
-  mobilityScenario
+  mobilityScenario,
 } from './v2/v2Scenario';
-import { getNextFriday } from './utils/utils';
+import {getNextFriday} from './utils/utils';
 import {
   departuresScenarioV1,
   geocoderScenarioV1,
   journeyScenarioV1,
-  serviceJourneyScenarioV1
+  serviceJourneyScenarioV1,
 } from './v1/v1Scenario';
-import { stationByIdScenario } from './v2/mobility/scenario';
+import {stationByIdScenario} from './v2/mobility/scenario';
 
 //Scenarios
 export const scn = (usecase: string): void => {

--- a/test/src/utils/utils.ts
+++ b/test/src/utils/utils.ts
@@ -2,12 +2,12 @@
 Utility functions
  */
 
-import { RefinedResponse, ResponseType } from 'k6/http';
-import { JSONArray, JSONObject } from 'k6';
+import {RefinedResponse, ResponseType} from 'k6/http';
+import {JSONArray, JSONObject} from 'k6';
 
 export const randomNumber = (
   max: number,
-  zeroPaddings: boolean = false
+  zeroPaddings: boolean = false,
 ): string => {
   let rand = Math.floor(Math.random() * max);
   if (rand === max) {
@@ -29,14 +29,14 @@ export const randomNumber = (
 
 export const useNoDecimals = (
   floatValue: number,
-  noDecimals: number
+  noDecimals: number,
 ): number => {
   return Math.floor(floatValue * 10 ** noDecimals) / 10 ** noDecimals;
 };
 
 export const randomNumberInclusiveInInterval = (
   min: number,
-  max: number
+  max: number,
 ): number => {
   let rand = Math.floor(Math.random() * (max - min));
   rand = rand + min;
@@ -51,7 +51,7 @@ export const isEqual = (array1: any[], array2: any[]): boolean => {
 // Check if an array with times are sorted ASC
 export const timeArrayIsSorted = (
   timeArray: string[],
-  sorting: string = 'ASC'
+  sorting: string = 'ASC',
 ): boolean => {
   let currDate = '1900-01-01T00:00:00+02:00';
   switch (sorting) {
@@ -81,7 +81,7 @@ export const timeArrayIsSorted = (
 // Check that alle dates are after/equal to given time
 export const departsAfterExpectedStartTime = (
   expStartTimes: string[],
-  startTime: string
+  startTime: string,
 ): boolean => {
   for (let expTime of expStartTimes) {
     if (Date.parse(startTime) > Date.parse(expTime as string)) {
@@ -94,7 +94,7 @@ export const departsAfterExpectedStartTime = (
 // Check that alle dates are after/equal to given time
 export const arrivesBeforeExpectedEndTime = (
   expEndTimes: string[],
-  startTime: string
+  startTime: string,
 ): boolean => {
   for (let expTime of expEndTimes) {
     if (Date.parse(startTime) < Date.parse(expTime as string)) {
@@ -121,10 +121,26 @@ export const getCurrentTime = (extraHours: number = 0): string => {
   return today.toISOString();
 };
 
+// Checks if two dates are equal with an allowed margin (sec)
+export const timeIsEqual = (
+  time1: string,
+  time2: string,
+  allowedSecMargin: number = 0,
+): boolean => {
+  const allowedMillisMargin = allowedSecMargin * 1000;
+  const time1D = new Date(time1);
+  const time2D = new Date(time2);
+
+  return !(
+    time1D.getTime() - time2D.getTime() > allowedMillisMargin ||
+    time2D.getTime() - time1D.getTime() > allowedMillisMargin
+  );
+};
+
 // Utility function to get the json response with correct casting
 export const jCheck = (
   response: RefinedResponse<ResponseType>,
-  jsonSelector: string
+  jsonSelector: string,
 ): null | boolean | number | string | JSONArray | JSONObject => {
   const jsonResult = response.json(jsonSelector);
   const jsonResultType = typeof jsonResult;

--- a/test/src/v1/geocoder/geocoder.ts
+++ b/test/src/v1/geocoder/geocoder.ts
@@ -1,19 +1,19 @@
 import http from 'k6/http';
-import { conf, ExpectsType, metrics } from '../../config/configuration';
-import { bffHeadersGet } from '../../utils/headers';
+import {conf, ExpectsType, metrics} from '../../config/configuration';
+import {bffHeadersGet} from '../../utils/headers';
 import {
   GeocoderFeatureResponseType,
   GeocoderReverseResponseType,
-  geocoderTestDataType
+  geocoderTestDataType,
 } from '../types';
 
 export function geocoderFeatures(
   testData: geocoderTestDataType,
-  limit: number = 10
+  limit: number = 10,
 ) {
   for (let test of testData.scenarios) {
     const requestName = `v1_geocoderFeatures_${testData.scenarios.indexOf(
-      test
+      test,
     )}`;
     const latitude = test.query.latitude;
     const longitude = test.query.longitude;
@@ -21,12 +21,12 @@ export function geocoderFeatures(
     const url = `${conf.host()}/bff/v1/geocoder/features?lat=${latitude}&limit=${limit}&lon=${longitude}&query=${searchString}`;
 
     const res = http.get(url, {
-      tags: { name: requestName },
-      headers: bffHeadersGet
+      tags: {name: requestName},
+      headers: bffHeadersGet,
     });
 
     const expects: ExpectsType = [
-      { check: 'should have status 200', expect: res.status === 200 }
+      {check: 'should have status 200', expect: res.status === 200},
     ];
 
     try {
@@ -38,22 +38,23 @@ export function geocoderFeatures(
           {
             check: `should include "${expResult.id}"`,
             expect: json
-              .map(feature => feature.properties.id)
-              .includes(expResult.id)
+              .map((feature) => feature.properties.id)
+              .includes(expResult.id),
           },
           {
             check: `should have correct name for "${expResult.id}"`,
             expect:
-              json.filter(feature => feature.properties.id === expResult.id)[0]
-                .properties.name === expResult.name
+              json.filter(
+                (feature) => feature.properties.id === expResult.id,
+              )[0].properties.name === expResult.name,
           },
           {
             check: `should include category "${expResult.category}" for "${expResult.id}"`,
             expect: json
-              .filter(feature => feature.properties.id === expResult.id)[0]
+              .filter((feature) => feature.properties.id === expResult.id)[0]
               .properties.category.flat()
-              .includes(expResult.category)
-          }
+              .includes(expResult.category),
+          },
         );
       }
 
@@ -61,7 +62,7 @@ export function geocoderFeatures(
       if (test.moreResults) {
         expects.push({
           check: `should have more hits than ${test.expectedResults.length}`,
-          expect: json.length > test.expectedResults.length
+          expect: json.length > test.expectedResults.length,
         });
       }
 
@@ -69,7 +70,7 @@ export function geocoderFeatures(
         [res.request.url],
         res.timings.duration,
         requestName,
-        expects
+        expects,
       );
     } catch (exp) {
       //throw exp
@@ -80,33 +81,30 @@ export function geocoderFeatures(
         [
           {
             check: `${exp}`,
-            expect: false
-          }
-        ]
+            expect: false,
+          },
+        ],
       );
     }
   }
 }
 
-export function geocoderReverse(
-  testData: geocoderTestDataType,
-  radius: number = 1000
-) {
+export function geocoderReverse(testData: geocoderTestDataType) {
   for (let test of testData.scenarios) {
     const requestName = `v1_geocoderReverse_${testData.scenarios.indexOf(
-      test
+      test,
     )}`;
     const latitude = test.query.latitude;
     const longitude = test.query.longitude;
-    const url = `${conf.host()}/bff/v1/geocoder/reverse?lat=${latitude}&lon=${longitude}&radius=${radius}`;
+    const url = `${conf.host()}/bff/v1/geocoder/reverse?lat=${latitude}&lon=${longitude}`;
 
     const res = http.get(url, {
-      tags: { name: requestName },
-      headers: bffHeadersGet
+      tags: {name: requestName},
+      headers: bffHeadersGet,
     });
 
     const expects: ExpectsType = [
-      { check: 'should have status 200', expect: res.status === 200 }
+      {check: 'should have status 200', expect: res.status === 200},
     ];
 
     try {
@@ -118,22 +116,23 @@ export function geocoderReverse(
           {
             check: `should include "${expResult.id}"`,
             expect: json
-              .map(feature => feature.properties.id)
-              .includes(expResult.id)
+              .map((feature) => feature.properties.id)
+              .includes(expResult.id),
           },
           {
             check: `should have correct name for "${expResult.id}"`,
             expect:
-              json.filter(feature => feature.properties.id === expResult.id)[0]
-                .properties.name === expResult.name
+              json.filter(
+                (feature) => feature.properties.id === expResult.id,
+              )[0].properties.name === expResult.name,
           },
           {
             check: `should include category "${expResult.category}" for "${expResult.id}"`,
             expect: json
-              .filter(feature => feature.properties.id === expResult.id)[0]
+              .filter((feature) => feature.properties.id === expResult.id)[0]
               .properties.category.flat()
-              .includes(expResult.category)
-          }
+              .includes(expResult.category),
+          },
         );
       }
 
@@ -141,7 +140,7 @@ export function geocoderReverse(
       if (test.moreResults) {
         expects.push({
           check: `should have more hits than ${test.expectedResults.length}`,
-          expect: json.length > test.expectedResults.length
+          expect: json.length > test.expectedResults.length,
         });
       }
 
@@ -149,7 +148,7 @@ export function geocoderReverse(
         [res.request.url],
         res.timings.duration,
         requestName,
-        expects
+        expects,
       );
     } catch (exp) {
       //throw exp
@@ -160,9 +159,9 @@ export function geocoderReverse(
         [
           {
             check: `${exp}`,
-            expect: false
-          }
-        ]
+            expect: false,
+          },
+        ],
       );
     }
   }

--- a/test/src/v2/testData/testData.ts
+++ b/test/src/v2/testData/testData.ts
@@ -3,9 +3,9 @@ import {
   serviceJourneyTestDataType,
   stopsDetailsTestDataType,
   stopsNearestTestDataType,
-  tripsTestDataType
+  tripsTestDataType,
 } from '../types';
-import { filteredTripsTestDataType } from '../types/testData';
+import {filteredTripsTestDataType} from '../types/testData';
 
 export const stopsNearestTestData: stopsNearestTestDataType = {
   scenarios: [
@@ -13,30 +13,30 @@ export const stopsNearestTestData: stopsNearestTestDataType = {
       query: {
         lon: '10.314600011575415',
         lat: '63.287662848427736',
-        distance: 400
+        distance: 400,
       },
       expectedResult: {
-        stopPlaces: ['NSR:StopPlace:42912']
-      }
+        stopPlaces: ['NSR:StopPlace:42912'],
+      },
     },
     {
       query: {
         lon: '10.314600011575415',
         lat: '63.287662848427736',
-        distance: 500
+        distance: 500,
       },
       expectedResult: {
-        stopPlaces: ['NSR:StopPlace:42912', 'NSR:StopPlace:41942']
-      }
-    }
-  ]
+        stopPlaces: ['NSR:StopPlace:42912', 'NSR:StopPlace:41942'],
+      },
+    },
+  ],
 };
 
 export const stopsDetailsTestData: stopsDetailsTestDataType = {
   scenarios: [
     {
       query: {
-        stopPlaceIds: ['NSR:StopPlace:42912']
+        stopPlaceIds: ['NSR:StopPlace:42912'],
       },
       expectedResults: [
         {
@@ -47,21 +47,21 @@ export const stopsDetailsTestData: stopsDetailsTestDataType = {
               id: 'NSR:Quay:73575',
               name: 'Loddgårdstrøa',
               publicCode: null,
-              description: null
+              description: null,
             },
             {
               id: 'NSR:Quay:73576',
               name: 'Loddgårdstrøa',
               publicCode: null,
-              description: null
-            }
-          ]
-        }
-      ]
+              description: null,
+            },
+          ],
+        },
+      ],
     },
     {
       query: {
-        stopPlaceIds: ['NSR:StopPlace:42912', 'NSR:StopPlace:41613']
+        stopPlaceIds: ['NSR:StopPlace:42912', 'NSR:StopPlace:41613'],
       },
       expectedResults: [
         {
@@ -72,15 +72,15 @@ export const stopsDetailsTestData: stopsDetailsTestDataType = {
               id: 'NSR:Quay:73575',
               name: 'Loddgårdstrøa',
               publicCode: null,
-              description: null
+              description: null,
             },
             {
               id: 'NSR:Quay:73576',
               name: 'Loddgårdstrøa',
               publicCode: null,
-              description: null
-            }
-          ]
+              description: null,
+            },
+          ],
         },
         {
           stopPlaceId: 'NSR:StopPlace:41613',
@@ -90,43 +90,29 @@ export const stopsDetailsTestData: stopsDetailsTestDataType = {
               id: 'NSR:Quay:71181',
               name: 'Prinsens gate',
               publicCode: 'P2',
-              description: 'ved AtB Kundesenter'
+              description: 'ved AtB Kundesenter',
             },
             {
               id: 'NSR:Quay:71184',
               name: 'Prinsens gate',
               publicCode: 'P1',
-              description: 'ved Bunnpris'
+              description: 'ved Bunnpris',
             },
             {
               id: 'NSR:Quay:107493',
               name: 'Prinsens gate',
               publicCode: 'P3',
-              description: null
-            }
-          ]
-        }
-      ]
-    }
-  ]
+              description: null,
+            },
+          ],
+        },
+      ],
+    },
+  ],
 };
 
 export const departureFavoritesTestData: departureFavoritesTestDataType = {
   scenarios: [
-    {
-      favorites: [
-        {
-          lineId: 'ATB:Line:2_2',
-          quayId: 'NSR:Quay:73152',
-          quayName: 'Ladeveien',
-          stopId: 'NSR:StopPlace:42686',
-          lineNumber: '2',
-          lineName: 'Strindheim via Lade',
-          lineTransportationMode: 'bus',
-          lineTransportationSubMode: 'localBus'
-        }
-      ]
-    },
     {
       favorites: [
         {
@@ -137,9 +123,9 @@ export const departureFavoritesTestData: departureFavoritesTestDataType = {
           lineNumber: '82',
           lineName: 'Hesttrøa',
           lineTransportationMode: 'bus',
-          lineTransportationSubMode: 'localBus'
-        }
-      ]
+          lineTransportationSubMode: 'localBus',
+        },
+      ],
     },
     {
       favorites: [
@@ -152,7 +138,7 @@ export const departureFavoritesTestData: departureFavoritesTestDataType = {
           lineName: 'Hesttrøa',
           lineTransportationMode: 'bus',
           lineTransportationSubMode: 'localBus',
-          quayPublicCode: ''
+          quayPublicCode: '',
         },
         {
           lineId: 'ATB:Line:2_82',
@@ -163,11 +149,11 @@ export const departureFavoritesTestData: departureFavoritesTestDataType = {
           lineName: 'Melhus',
           lineTransportationMode: 'bus',
           lineTransportationSubMode: 'localBus',
-          quayPublicCode: ''
-        }
-      ]
-    }
-  ]
+          quayPublicCode: '',
+        },
+      ],
+    },
+  ],
 };
 
 // Search from a service journey's start to end
@@ -179,23 +165,23 @@ export const serviceJourneyTestData: serviceJourneyTestDataType = {
           name: 'Melhus skysstasjon',
           coordinates: {
             latitude: 63.284753,
-            longitude: 10.277964
+            longitude: 10.277964,
           },
-          place: 'NSR:StopPlace:42547'
+          place: 'NSR:StopPlace:42547',
         },
         from: {
           name: 'Hesttrøa',
           coordinates: {
             latitude: 63.294611,
-            longitude: 10.332289
+            longitude: 10.332289,
           },
-          place: 'NSR:StopPlace:41699'
+          place: 'NSR:StopPlace:41699',
         },
         when: '',
-        arriveBy: false
-      }
-    }
-  ]
+        arriveBy: false,
+      },
+    },
+  ],
 };
 
 export const filteredTripsTestData: filteredTripsTestDataType = {
@@ -203,17 +189,17 @@ export const filteredTripsTestData: filteredTripsTestDataType = {
     name: 'Trondheim lufthavn',
     coordinates: {
       latitude: 63.454052,
-      longitude: 10.917269
+      longitude: 10.917269,
     },
-    place: 'NSR:StopPlace:44286'
+    place: 'NSR:StopPlace:44286',
   },
   from: {
     name: 'Trondheim S',
     coordinates: {
       latitude: 63.436107,
-      longitude: 10.40108
+      longitude: 10.40108,
     },
-    place: 'NSR:StopPlace:41742'
+    place: 'NSR:StopPlace:41742',
   },
   when: '',
   arriveBy: false,
@@ -221,8 +207,8 @@ export const filteredTripsTestData: filteredTripsTestDataType = {
     accessMode: 'foot',
     directMode: 'foot',
     egressMode: 'foot',
-    transportModes: []
-  }
+    transportModes: [],
+  },
 };
 
 export const tripsTestData: tripsTestDataType = {
@@ -233,29 +219,29 @@ export const tripsTestData: tripsTestDataType = {
           name: 'Studentersamfundet',
           coordinates: {
             latitude: 63.422568,
-            longitude: 10.394852
+            longitude: 10.394852,
           },
-          place: 'NSR:StopPlace:42660'
+          place: 'NSR:StopPlace:42660',
         },
         from: {
           name: 'Prinsens gate',
           coordinates: {
             latitude: 63.431034,
-            longitude: 10.392007
+            longitude: 10.392007,
           },
-          place: 'NSR:StopPlace:41613'
+          place: 'NSR:StopPlace:41613',
         },
         when: '',
-        arriveBy: false
+        arriveBy: false,
       },
       expectedResult: {
         legModes: [
-          { pattern: 0, modes: ['foot'] },
-          { pattern: 1, modes: ['bus'] },
-          { pattern: 2, modes: ['bus'] }
+          {pattern: 0, modes: ['foot']},
+          {pattern: 1, modes: ['bus']},
+          {pattern: 2, modes: ['bus']},
         ],
-        minimumTripPatterns: 4
-      }
+        minimumTripPatterns: 4,
+      },
     },
     {
       query: {
@@ -263,27 +249,27 @@ export const tripsTestData: tripsTestDataType = {
           name: 'Eddaparken',
           coordinates: {
             latitude: 63.422287048884975,
-            longitude: 10.394009646391378
-          }
+            longitude: 10.394009646391378,
+          },
         },
         from: {
           name: 'Trondheim Torg',
           coordinates: {
             latitude: 63.42987338669995,
-            longitude: 10.393239260988398
-          }
+            longitude: 10.393239260988398,
+          },
         },
         when: '',
-        arriveBy: false
+        arriveBy: false,
       },
       expectedResult: {
         legModes: [
-          { pattern: 0, modes: ['foot'] },
-          { pattern: 1, modes: ['foot', 'bus', 'foot'] },
-          { pattern: 2, modes: ['foot', 'bus', 'foot'] }
+          {pattern: 0, modes: ['foot']},
+          {pattern: 1, modes: ['foot', 'bus', 'foot']},
+          {pattern: 2, modes: ['foot', 'bus', 'foot']},
         ],
-        minimumTripPatterns: 4
-      }
+        minimumTripPatterns: 4,
+      },
     },
     {
       query: {
@@ -291,23 +277,23 @@ export const tripsTestData: tripsTestDataType = {
           name: 'Skansen',
           coordinates: {
             latitude: 63.43060811850891,
-            longitude: 10.376745476594767
-          }
+            longitude: 10.376745476594767,
+          },
         },
         to: {
           name: 'Melhus',
           coordinates: {
             latitude: 63.284594,
-            longitude: 10.27745
-          }
+            longitude: 10.27745,
+          },
         },
         when: '',
-        arriveBy: false
+        arriveBy: false,
       },
       expectedResult: {
         legModes: null,
-        minimumTripPatterns: 2
-      }
-    }
-  ]
+        minimumTripPatterns: 2,
+      },
+    },
+  ],
 };

--- a/test/src/v2/trips/trips.ts
+++ b/test/src/v2/trips/trips.ts
@@ -1,27 +1,28 @@
 import http from 'k6/http';
-import { conf, ExpectsType, metrics } from '../../config/configuration';
-import { bffHeadersPost } from '../../utils/headers';
+import {conf, ExpectsType, metrics} from '../../config/configuration';
+import {bffHeadersPost} from '../../utils/headers';
 import {
   arrivesBeforeExpectedEndTime,
   departsAfterExpectedStartTime,
   isEqual,
-  timeArrayIsSorted
+  timeArrayIsSorted,
+  timeIsEqual,
 } from '../../utils/utils';
 import {
   singleTripsTestDataType,
   TripPatternWithCompressedQuery,
-  tripsTestDataType
+  tripsTestDataType,
 } from '../types';
-import { TripsQuery } from '../../../../src/service/impl/trips/journey-gql/trip.graphql-gen';
-import { transportModesType } from '../types/trips';
-import { filteredTripsTestDataType } from '../types/testData';
-import { filteredTripsTestData } from '../testData/testData';
+import {TripsQuery} from '../../../../src/service/impl/trips/journey-gql/trip.graphql-gen';
+import {transportModesType} from '../types/trips';
+import {filteredTripsTestDataType} from '../types/testData';
+import {filteredTripsTestData} from '../testData/testData';
 
 // Travel search request
 export function trips(
   testData: tripsTestDataType,
   searchDate: string,
-  arriveBy: boolean = false
+  arriveBy: boolean = false,
 ): void {
   const searchTime = `${searchDate}T07:00:00.000Z`;
   for (let test of testData.scenarios) {
@@ -35,12 +36,12 @@ export function trips(
     test.query.arriveBy = arriveBy;
 
     const res = http.post(url, JSON.stringify(test.query), {
-      tags: { name: requestName },
-      headers: bffHeadersPost
+      tags: {name: requestName},
+      headers: bffHeadersPost,
     });
 
     const expects: ExpectsType = [
-      { check: 'should have status 200', expect: res.status === 200 }
+      {check: 'should have status 200', expect: res.status === 200},
     ];
 
     try {
@@ -51,17 +52,17 @@ export function trips(
         expects.push({
           check: 'should have expected end times before requested time',
           expect: arrivesBeforeExpectedEndTime(
-            json.trip.tripPatterns.map(pattern => pattern.expectedEndTime),
-            searchTime
-          )
+            json.trip.tripPatterns.map((pattern) => pattern.expectedEndTime),
+            searchTime,
+          ),
         });
       } else {
         expects.push({
           check: 'should have expected start times after requested time',
           expect: departsAfterExpectedStartTime(
-            json.trip.tripPatterns.map(pattern => pattern.expectedStartTime),
-            searchTime
-          )
+            json.trip.tripPatterns.map((pattern) => pattern.expectedStartTime),
+            searchTime,
+          ),
         });
       }
 
@@ -112,17 +113,17 @@ export function trips(
       expects.push(
         {
           check: 'should have correct from place',
-          expect: fromPlaces.filter(e => e !== expFromPlace).length === 0
+          expect: fromPlaces.filter((e) => e !== expFromPlace).length === 0,
         },
         {
           check: 'should have correct to place',
-          expect: toPlaces.filter(e => e !== expToPlace).length === 0
+          expect: toPlaces.filter((e) => e !== expToPlace).length === 0,
         },
-        { check: 'should have connected legs', expect: legsAreConnected },
+        {check: 'should have connected legs', expect: legsAreConnected},
         {
           check: 'should have correct aggregated walk distance on legs',
-          expect: walkDistanceIsCorrect
-        }
+          expect: walkDistanceIsCorrect,
+        },
       );
 
       // Assert correct leg modes (for any given)
@@ -130,11 +131,11 @@ export function trips(
         for (let expModes of test.expectedResult.legModes) {
           const responseLegModes = json.trip.tripPatterns[
             expModes.pattern
-          ].legs.map(leg => leg.mode);
+          ].legs.map((leg) => leg.mode);
           //console.log(`** ${testData.scenarios.indexOf(test)} ** ${expModes.pattern} ** ${responseLegModes} - ${expModes.modes}`)
           expects.push({
             check: `should have correct leg modes for trip pattern ${expModes.pattern}`,
-            expect: isEqual(responseLegModes, expModes.modes)
+            expect: isEqual(responseLegModes, expModes.modes),
           });
         }
       }
@@ -144,14 +145,14 @@ export function trips(
         check: `should have minimum number of trip patterns ${test.expectedResult.minimumTripPatterns}`,
         expect:
           json.trip.tripPatterns.length >=
-          test.expectedResult.minimumTripPatterns
+          test.expectedResult.minimumTripPatterns,
       });
 
       metrics.checkForFailures(
         [res.request.url],
         res.timings.duration,
         requestName,
-        expects
+        expects,
       );
     } catch (exp) {
       metrics.checkForFailures(
@@ -161,9 +162,9 @@ export function trips(
         [
           {
             check: `${exp}`,
-            expect: false
-          }
-        ]
+            expect: false,
+          },
+        ],
       );
     }
   }
@@ -173,7 +174,7 @@ export function trips(
 export function tripsWithCursor(
   testData: tripsTestDataType,
   searchDate: string,
-  arriveBy: boolean = false
+  arriveBy: boolean = false,
 ) {
   const test = testData.scenarios[0];
   const searchTime = `${searchDate}T07:00:00.000Z`;
@@ -187,12 +188,12 @@ export function tripsWithCursor(
   test.query.arriveBy = arriveBy;
 
   const res = http.post(url, JSON.stringify(test.query), {
-    tags: { name: requestName },
-    headers: bffHeadersPost
+    tags: {name: requestName},
+    headers: bffHeadersPost,
   });
 
   const expects: ExpectsType = [
-    { check: 'should have status 200', expect: res.status === 200 }
+    {check: 'should have status 200', expect: res.status === 200},
   ];
 
   try {
@@ -203,8 +204,8 @@ export function tripsWithCursor(
       ? json.trip.previousPageCursor
       : json.trip.nextPageCursor;
     const resNext = http.post(url, JSON.stringify(test.query), {
-      tags: { name: requestName },
-      headers: bffHeadersPost
+      tags: {name: requestName},
+      headers: bffHeadersPost,
     });
     // Remove cursor on object
     delete test.query.cursor;
@@ -212,7 +213,7 @@ export function tripsWithCursor(
 
     expects.push({
       check: 'should have status 200 on next cursor',
-      expect: resNext.status === 200
+      expect: resNext.status === 200,
     });
 
     // Assert returned time against expected times
@@ -222,18 +223,18 @@ export function tripsWithCursor(
           check:
             'should have expected end times before requested time on initial request',
           expect: arrivesBeforeExpectedEndTime(
-            json.trip.tripPatterns.map(pattern => pattern.expectedEndTime),
-            searchTime
-          )
+            json.trip.tripPatterns.map((pattern) => pattern.expectedEndTime),
+            searchTime,
+          ),
         },
         {
           check:
             'should have expected end times before requested time on next request',
           expect: arrivesBeforeExpectedEndTime(
-            json.trip.tripPatterns.map(pattern => pattern.expectedEndTime),
-            searchTime
-          )
-        }
+            json.trip.tripPatterns.map((pattern) => pattern.expectedEndTime),
+            searchTime,
+          ),
+        },
       );
     } else {
       expects.push(
@@ -241,41 +242,43 @@ export function tripsWithCursor(
           check:
             'should have expected start times after requested time on initial request',
           expect: departsAfterExpectedStartTime(
-            json.trip.tripPatterns.map(pattern => pattern.expectedStartTime),
-            searchTime
-          )
+            json.trip.tripPatterns.map((pattern) => pattern.expectedStartTime),
+            searchTime,
+          ),
         },
         {
           check:
             'should have expected start times after requested time on next request',
           expect: departsAfterExpectedStartTime(
-            json.trip.tripPatterns.map(pattern => pattern.expectedStartTime),
-            searchTime
-          )
-        }
+            json.trip.tripPatterns.map((pattern) => pattern.expectedStartTime),
+            searchTime,
+          ),
+        },
       );
     }
 
     // Assert sorted returned times on initial and next request
     if (test.query.arriveBy) {
       const expectedEndTimes = json.trip.tripPatterns
-        .map(pattern => pattern.expectedEndTime)
+        .map((pattern) => pattern.expectedEndTime)
         .concat(
-          jsonNext.trip.tripPatterns.map(pattern => pattern.expectedEndTime)
+          jsonNext.trip.tripPatterns.map((pattern) => pattern.expectedEndTime),
         );
       expects.push({
         check: 'should have sorted expected end times in DESC order',
-        expect: timeArrayIsSorted(expectedEndTimes, 'DESC')
+        expect: timeArrayIsSorted(expectedEndTimes, 'DESC'),
       });
     } else {
       const expectedStartTimes = json.trip.tripPatterns
-        .map(pattern => pattern.expectedStartTime)
+        .map((pattern) => pattern.expectedStartTime)
         .concat(
-          jsonNext.trip.tripPatterns.map(pattern => pattern.expectedStartTime)
+          jsonNext.trip.tripPatterns.map(
+            (pattern) => pattern.expectedStartTime,
+          ),
         );
       expects.push({
         check: 'should have sorted expected start times in ASC order',
-        expect: timeArrayIsSorted(expectedStartTimes, 'ASC')
+        expect: timeArrayIsSorted(expectedStartTimes, 'ASC'),
       });
     }
 
@@ -302,19 +305,19 @@ export function tripsWithCursor(
     expects.push(
       {
         check: 'should have correct from place',
-        expect: fromPlaces.filter(e => e !== expFromPlace).length === 0
+        expect: fromPlaces.filter((e) => e !== expFromPlace).length === 0,
       },
       {
         check: 'should have correct to place',
-        expect: toPlaces.filter(e => e !== expToPlace).length === 0
-      }
+        expect: toPlaces.filter((e) => e !== expToPlace).length === 0,
+      },
     );
 
     metrics.checkForFailures(
       [res.request.url],
       res.timings.duration + resNext.timings.duration,
       requestName,
-      expects
+      expects,
     );
   } catch (exp) {
     metrics.checkForFailures(
@@ -324,9 +327,9 @@ export function tripsWithCursor(
       [
         {
           check: `${exp}`,
-          expect: false
-        }
-      ]
+          expect: false,
+        },
+      ],
     );
   }
 }
@@ -335,7 +338,7 @@ export function tripsWithCursor(
 export function filteredTrips(
   transportModes: transportModesType,
   searchDate: string,
-  filterRequestName?: string
+  filterRequestName?: string,
 ): void {
   const searchTime = `${searchDate}T07:00:00.000Z`;
   const requestName = filterRequestName
@@ -347,19 +350,19 @@ export function filteredTrips(
   request.when = searchTime;
   // Set filters
   request.modes.transportModes = transportModes;
-  const activeFiltersMode = transportModes.map(mode => mode.transportMode);
+  const activeFiltersMode = transportModes.map((mode) => mode.transportMode);
   activeFiltersMode.push('foot');
   const activeFiltersSubmode = transportModes.flatMap(
-    mode => mode.transportSubModes
+    (mode) => mode.transportSubModes,
   );
 
   const res = http.post(url, JSON.stringify(request), {
-    tags: { name: requestName },
-    headers: bffHeadersPost
+    tags: {name: requestName},
+    headers: bffHeadersPost,
   });
 
   const expects: ExpectsType = [
-    { check: 'should have status 200', expect: res.status === 200 }
+    {check: 'should have status 200', expect: res.status === 200},
   ];
 
   try {
@@ -369,9 +372,9 @@ export function filteredTrips(
     expects.push({
       check: 'should have expected start times after requested time',
       expect: departsAfterExpectedStartTime(
-        json.trip.tripPatterns.map(pattern => pattern.expectedStartTime),
-        searchTime
-      )
+        json.trip.tripPatterns.map((pattern) => pattern.expectedStartTime),
+        searchTime,
+      ),
     });
 
     // Assert correct start and stop
@@ -421,48 +424,48 @@ export function filteredTrips(
     expects.push(
       {
         check: 'should have correct from place',
-        expect: fromPlaces.filter(e => e !== expFromPlace).length === 0
+        expect: fromPlaces.filter((e) => e !== expFromPlace).length === 0,
       },
       {
         check: 'should have correct to place',
-        expect: toPlaces.filter(e => e !== expToPlace).length === 0
+        expect: toPlaces.filter((e) => e !== expToPlace).length === 0,
       },
-      { check: 'should have connected legs', expect: legsAreConnected },
+      {check: 'should have connected legs', expect: legsAreConnected},
       {
         check: 'should have correct aggregated walk distance on legs',
-        expect: walkDistanceIsCorrect
-      }
+        expect: walkDistanceIsCorrect,
+      },
     );
 
     // Assert returned transport modes on active filters
-    const responseModes = json.trip.tripPatterns.flatMap(pattern =>
-      pattern.legs.map(leg => leg.mode)
+    const responseModes = json.trip.tripPatterns.flatMap((pattern) =>
+      pattern.legs.map((leg) => leg.mode),
     ) as string[];
     expects.push({
       check: `should have correct transport modes from active filters`,
       expect:
-        responseModes.filter(mode => !activeFiltersMode.includes(mode))
-          .length === 0
+        responseModes.filter((mode) => !activeFiltersMode.includes(mode))
+          .length === 0,
     });
 
     // Assert returned transport submodes on active filters
     const responseSubmodes = cleanSubmodes(
-      json.trip.tripPatterns.flatMap(pattern =>
-        pattern.legs.map(leg => leg.line?.transportSubmode)
-      ) as string[]
+      json.trip.tripPatterns.flatMap((pattern) =>
+        pattern.legs.map((leg) => leg.line?.transportSubmode),
+      ) as string[],
     );
     expects.push({
       check: `should have correct transport submodes from active filters`,
       expect:
-        responseSubmodes.filter(mode => !activeFiltersSubmode.includes(mode))
-          .length === 0
+        responseSubmodes.filter((mode) => !activeFiltersSubmode.includes(mode))
+          .length === 0,
     });
 
     metrics.checkForFailures(
       [res.request.url],
       res.timings.duration,
       requestName,
-      expects
+      expects,
     );
   } catch (exp) {
     metrics.checkForFailures(
@@ -472,9 +475,9 @@ export function filteredTrips(
       [
         {
           check: `${exp}`,
-          expect: false
-        }
-      ]
+          expect: false,
+        },
+      ],
     );
   }
 }
@@ -498,7 +501,7 @@ const cleanSubmodes = (submodes: string[]): string[] => {
 export function singleTrip(
   testData: singleTripsTestDataType,
   searchDate: string,
-  arriveBy: boolean = false
+  arriveBy: boolean = false,
 ) {
   const requestName = 'v2_singleTrip';
   const searchTime = `${searchDate}T07:00:00.000Z`;
@@ -511,15 +514,15 @@ export function singleTrip(
   testData.query.arriveBy = arriveBy;
 
   const resTrips = http.post(urlTrips, JSON.stringify(testData.query), {
-    tags: { name: requestName },
-    headers: bffHeadersPost
+    tags: {name: requestName},
+    headers: bffHeadersPost,
   });
 
   const expects: ExpectsType = [
     {
       check: 'should have status 200 on /trips',
-      expect: resTrips.status === 200
-    }
+      expect: resTrips.status === 200,
+    },
   ];
 
   try {
@@ -538,51 +541,57 @@ export function singleTrip(
       const firstLegMode = jsonTripsSingle.legs[0].mode;
       if (!(noLegs === 1 && firstLegMode === 'foot')) {
         const comprQuery = jsonTripsSingle.compressedQuery;
-        const bodySingle = { compressedQuery: comprQuery };
+        const bodySingle = {compressedQuery: comprQuery};
 
         const resSingle = http.post(urlSingleTrip, JSON.stringify(bodySingle), {
-          tags: { name: requestName },
-          headers: bffHeadersPost
+          tags: {name: requestName},
+          headers: bffHeadersPost,
         });
         const jsonSingle = resSingle.json() as TripPatternWithCompressedQuery;
 
         // Note: The JSON-response is "randomly" ordered for each request. Pick out some test parameters.
         const tripsTest = [
-          jsonTripsSingle.legs[0].aimedStartTime,
           jsonTripsSingle.duration,
           jsonTripsSingle.walkDistance,
           jsonTripsSingle.legs.length,
-          jsonTripsSingle.compressedQuery
+          jsonTripsSingle.legs.map((leg) => leg.mode),
         ];
         const singleTest = [
-          jsonSingle.legs[0].aimedStartTime,
           jsonSingle.duration,
           jsonSingle.walkDistance,
           jsonSingle.legs.length,
-          jsonSingle.compressedQuery
+          jsonTripsSingle.legs.map((leg) => leg.mode),
         ];
         // Have been issues where trip search is not equal to its single trip. Log when it happens
         if (!isEqual(tripsTest, singleTest)) {
           console.log(
-            `*** ERROR tripsTest_${counter}: ${tripsTest.toString()}`
+            `*** ERROR tripsTest_${counter}: ${tripsTest.toString()}`,
           );
           console.log(
-            `*** ERROR singleTest_${counter}: ${singleTest.toString()}`
+            `*** ERROR singleTest_${counter}: ${singleTest.toString()}`,
           );
           console.log(
-            `*** Trip request body: ${JSON.stringify(testData.query)}`
+            `*** Trip request body: ${JSON.stringify(testData.query)}`,
           );
         }
 
         expects.push(
           {
             check: `should have status 200 on /singleTrip #${counter}`,
-            expect: resSingle.status === 200
+            expect: resSingle.status === 200,
           },
           {
             check: `single trip details should be equal to trips results details #${counter}`,
-            expect: isEqual(tripsTest, singleTest)
-          }
+            expect: isEqual(tripsTest, singleTest),
+          },
+          {
+            check: `single trip start time should be equal to trips results start time #${counter}`,
+            expect: timeIsEqual(
+              jsonTripsSingle.legs[0].aimedStartTime,
+              jsonSingle.legs[0].aimedStartTime,
+              120,
+            ),
+          },
         );
         noSingleTripsTested += 1;
       }
@@ -593,7 +602,7 @@ export function singleTrip(
       [urlSingleTrip],
       resTrips.timings.duration + singleTripDuration,
       requestName,
-      expects
+      expects,
     );
   } catch (exp) {
     metrics.checkForFailures(
@@ -603,9 +612,9 @@ export function singleTrip(
       [
         {
           check: `${exp}`,
-          expect: false
-        }
-      ]
+          expect: false,
+        },
+      ],
     );
   }
 }


### PR DESCRIPTION
Some improvements:
- Removed `&range` from geocoder reverse request
- Better retry-handling when cache should be hit for realtime requests
- Different asserts for single trips requests, e.g. approve a small difference in start time when the requested travel is in the future