### PR TITLE
feat: add aimedDepartureTime to realtime response

### DIFF
--- a/src/service/impl/realtime/departure-time.ts
+++ b/src/service/impl/realtime/departure-time.ts
@@ -105,6 +105,7 @@ function mapDeparture(
       timeData: {
         realtime: departure.realtime ?? false,
         expectedDepartureTime: departure.expectedDepartureTime,
+        aimedDepartureTime: departure.aimedDepartureTime,
       },
     };
   }

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -127,6 +127,7 @@ export type RealtimeData = {
   timeData: {
     realtime: boolean;
     expectedDepartureTime: string;
+    aimedDepartureTime: string;
   };
 };
 


### PR DESCRIPTION
Send aimedDepartureTime as part of the real-time response so that the app can differentiate different departures with the same `serviceJourneyId`. See https://github.com/AtB-AS/mittatb-app/pull/3699 for how it is used in the app. 

Part of solving https://github.com/AtB-AS/kundevendt/issues/4277