### PR TITLE
refactor: add types to Joi schemas

### DIFF
--- a/src/api/departures-grouped/schema.ts
+++ b/src/api/departures-grouped/schema.ts
@@ -1,8 +1,14 @@
 import Joi from 'joi';
-import {DepartureGroupsQuery} from '../../service/types';
+import {
+  DepartureFavoritesPayload,
+  DepartureFavoritesQuery,
+  DepartureGroupsPayload,
+  DepartureGroupsQuery,
+  FavoriteDeparture,
+} from '../../service/types';
 
 export const getDeparturesCursoredRequest = {
-  payload: Joi.object({
+  payload: Joi.object<DepartureGroupsPayload>({
     location: Joi.alt([
       Joi.object({
         layer: 'venue',
@@ -21,7 +27,7 @@ export const getDeparturesCursoredRequest = {
     favorites: Joi.array()
       .single()
       .items(
-        Joi.object({
+        Joi.object<FavoriteDeparture>({
           stopId: Joi.string().required(),
           lineName: Joi.string(),
           lineId: Joi.string().required(),
@@ -40,11 +46,11 @@ export const getDeparturesCursoredRequest = {
 };
 
 export const getDepartureFavoritesCursoredRequest = {
-  payload: Joi.object({
+  payload: Joi.object<DepartureFavoritesPayload>({
     favorites: Joi.array()
       .single()
       .items(
-        Joi.object({
+        Joi.object<FavoriteDeparture>({
           stopId: Joi.string().required(),
           lineName: Joi.string(),
           lineId: Joi.string().required(),
@@ -54,7 +60,7 @@ export const getDepartureFavoritesCursoredRequest = {
           .required(),
       ),
   }),
-  query: Joi.object({
+  query: Joi.object<DepartureFavoritesQuery>({
     limitPerLine: Joi.number().default(5),
     startTime: Joi.date().default(() => new Date()),
     includeCancelledTrips: Joi.boolean(),

--- a/src/api/departures/schema.ts
+++ b/src/api/departures/schema.ts
@@ -1,7 +1,16 @@
 import Joi from 'joi';
+import {DeparturesQueryVariables} from '../../service/impl/departures/journey-gql/departures.graphql-gen';
+import {StopPlaceQuayDeparturesQueryVariables} from '../../service/impl/departures/journey-gql/stop-departures.graphql-gen';
+import {StopsDetailsQueryVariables} from '../../service/impl/departures/journey-gql/stops-details.graphql-gen';
+import {NearestStopPlacesQueryVariables} from '../../service/impl/departures/journey-gql/stops-nearest.graphql-gen';
+import {
+  DeparturesPayload,
+  FavoriteDeparture,
+  QuayDeparturesQueryVariables,
+} from '../../service/types';
 
 export const getStopsNearestRequest = {
-  query: Joi.object({
+  query: Joi.object<NearestStopPlacesQueryVariables>({
     latitude: Joi.number().required(),
     longitude: Joi.number().required(),
     distance: Joi.number().default(1000),
@@ -11,13 +20,13 @@ export const getStopsNearestRequest = {
 };
 
 export const getStopsDetailsRequest = {
-  query: Joi.object({
+  query: Joi.object<StopsDetailsQueryVariables>({
     ids: Joi.array().items(Joi.string()).required().single(),
   }),
 };
 
 export const getStopDeparturesRequest = {
-  query: Joi.object({
+  query: Joi.object<StopPlaceQuayDeparturesQueryVariables>({
     id: Joi.string().required(),
     numberOfDepartures: Joi.number().default(5),
     startTime: Joi.string(),
@@ -27,11 +36,11 @@ export const getStopDeparturesRequest = {
 };
 
 export const postStopDeparturesRequest = {
-  payload: Joi.object({
+  payload: Joi.object<DeparturesPayload>({
     favorites: Joi.array()
       .single()
       .items(
-        Joi.object({
+        Joi.object<FavoriteDeparture>({
           stopId: Joi.string().required(),
           lineName: Joi.string(),
           lineId: Joi.string().required(),
@@ -39,7 +48,7 @@ export const postStopDeparturesRequest = {
         }).options({stripUnknown: true}),
       ),
   }),
-  query: Joi.object({
+  query: Joi.object<StopPlaceQuayDeparturesQueryVariables>({
     id: Joi.string().required(),
     numberOfDepartures: Joi.number().default(5),
     startTime: Joi.string(),
@@ -49,11 +58,11 @@ export const postStopDeparturesRequest = {
 };
 
 export const postDeparturesRequest = {
-  payload: Joi.object({
+  payload: Joi.object<DeparturesPayload>({
     favorites: Joi.array()
       .single()
       .items(
-        Joi.object({
+        Joi.object<FavoriteDeparture>({
           stopId: Joi.string().required(),
           lineName: Joi.string(),
           lineId: Joi.string().required(),
@@ -61,7 +70,7 @@ export const postDeparturesRequest = {
         }).options({stripUnknown: true}),
       ),
   }),
-  query: Joi.object({
+  query: Joi.object<DeparturesQueryVariables>({
     ids: Joi.array().single().items(Joi.string()).required(),
     numberOfDepartures: Joi.number().default(1000),
     startTime: Joi.string(),
@@ -71,21 +80,21 @@ export const postDeparturesRequest = {
 };
 
 export const getQuayDeparturesRequest = {
-  query: Joi.object({
+  query: Joi.object<QuayDeparturesQueryVariables>({
     id: Joi.string().required(),
     numberOfDepartures: Joi.number().default(10),
     startTime: Joi.string(),
     timeRange: Joi.number().default(86400),
-    numberOfDeparturesPerLineAndDestinationDisplay: Joi.number(),
+    limitPerLine: Joi.number(),
   }),
 };
 
 export const postQuayDeparturesRequest = {
-  payload: Joi.object({
+  payload: Joi.object<DeparturesPayload>({
     favorites: Joi.array()
       .single()
       .items(
-        Joi.object({
+        Joi.object<FavoriteDeparture>({
           stopId: Joi.string().required(),
           lineName: Joi.string(),
           lineId: Joi.string().required(),
@@ -93,19 +102,11 @@ export const postQuayDeparturesRequest = {
         }).options({stripUnknown: true}),
       ),
   }),
-  query: Joi.object({
+  query: Joi.object<QuayDeparturesQueryVariables>({
     id: Joi.string().required(),
     numberOfDepartures: Joi.number().default(1000),
     startTime: Joi.string(),
     timeRange: Joi.number().default(86400),
     limitPerLine: Joi.number(),
-  }),
-};
-
-export const getDepartureRealtime = {
-  query: Joi.object({
-    quayIds: Joi.array().items(Joi.string()).default([]).single(),
-    startTime: Joi.date(),
-    limit: Joi.number().default(5),
   }),
 };

--- a/src/api/enrollment/schema.ts
+++ b/src/api/enrollment/schema.ts
@@ -1,7 +1,8 @@
 import Joi from 'joi';
+import {EnrollmentQuery} from '../../service/types';
 
 export const postEnrollmentGroupRequest = {
-  query: Joi.object({
+  query: Joi.object<EnrollmentQuery>({
     inviteKey: Joi.string().required(),
   }),
 };

--- a/src/api/geocoder/schema.ts
+++ b/src/api/geocoder/schema.ts
@@ -1,6 +1,7 @@
 import Joi from 'joi';
+import {FeaturesQuery, ReverseFeaturesQuery} from '../../service/types';
 
-export const getFeaturesRequest = Joi.object({
+export const getFeaturesRequest = Joi.object<FeaturesQuery>({
   query: Joi.string().required(),
   lon: Joi.number(),
   lat: Joi.number(),
@@ -11,7 +12,7 @@ export const getFeaturesRequest = Joi.object({
 }).and('lat', 'lon');
 
 export const getFeaturesReverseRequest = {
-  query: Joi.object({
+  query: Joi.object<ReverseFeaturesQuery>({
     lat: Joi.number().required(),
     lon: Joi.number().required(),
     layers: Joi.array().items(Joi.alt('address', 'venue')).single(),

--- a/src/api/mobility/index.ts
+++ b/src/api/mobility/index.ts
@@ -12,6 +12,7 @@ import {
   getStationsRequest,
   getVehicleRequest,
   getCarStationRequest,
+  getBikeStationRequest,
 } from './schema';
 
 export default (server: Hapi.Server) => (service: IMobilityService) => {
@@ -78,7 +79,7 @@ export default (server: Hapi.Server) => (service: IMobilityService) => {
     path: '/bff/v2/mobility/station/bike',
     options: {
       tags: ['api', 'mobility', 'station', 'bike'],
-      validate: getCarStationRequest,
+      validate: getBikeStationRequest,
       description: 'Get details about a single bike station',
     },
     handler: async (request, h) => {

--- a/src/api/mobility/schema.ts
+++ b/src/api/mobility/schema.ts
@@ -1,8 +1,15 @@
 import Joi from 'joi';
 import {FormFactor} from '../../graphql/mobility/mobility-types_v2';
+import {
+  BikeStationQuery,
+  CarStationQuery,
+  StationsQuery,
+  VehicleQuery,
+  VehiclesQuery,
+} from '../../service/types';
 
 export const getVehiclesRequest = {
-  query: Joi.object({
+  query: Joi.object<VehiclesQuery>({
     formFactors: Joi.array()
       .items(Joi.string())
       .optional()
@@ -15,13 +22,13 @@ export const getVehiclesRequest = {
   }),
 };
 export const getVehicleRequest = {
-  query: Joi.object({
+  query: Joi.object<VehicleQuery>({
     ids: Joi.array().items(Joi.string()).required().single(),
   }),
 };
 
 export const getStationsRequest = {
-  query: Joi.object({
+  query: Joi.object<StationsQuery>({
     availableFormFactors: Joi.array()
       .items(Joi.string())
       .optional()
@@ -34,7 +41,12 @@ export const getStationsRequest = {
   }),
 };
 export const getCarStationRequest = {
-  query: Joi.object({
+  query: Joi.object<CarStationQuery>({
+    ids: Joi.array().items(Joi.string()).required().single(),
+  }),
+};
+export const getBikeStationRequest = {
+  query: Joi.object<BikeStationQuery>({
     ids: Joi.array().items(Joi.string()).required().single(),
   }),
 };

--- a/src/api/quays/schema.ts
+++ b/src/api/quays/schema.ts
@@ -1,7 +1,8 @@
 import Joi from 'joi';
+import {QuaysCoordinatesPayload} from '../../service/types';
 
 export const getQuaysCoordinatesRequest = {
-  payload: Joi.object({
+  payload: Joi.object<QuaysCoordinatesPayload>({
     ids: Joi.array()
       .single()
       .items(Joi.string().options({stripUnknown: true}).required()),

--- a/src/api/realtime/schema.ts
+++ b/src/api/realtime/schema.ts
@@ -1,7 +1,8 @@
 import Joi from 'joi';
+import {DepartureRealtimeQuery} from '../../service/types';
 
 export const getDepartureRealtime = {
-  query: Joi.object({
+  query: Joi.object<DepartureRealtimeQuery>({
     quayIds: Joi.array().items(Joi.string()).default([]).single(),
     startTime: Joi.date(),
     limit: Joi.number().default(5),

--- a/src/api/servicejourney/schema.ts
+++ b/src/api/servicejourney/schema.ts
@@ -1,10 +1,15 @@
 import Joi from 'joi';
+import {
+  DeparturesForServiceJourneyQuery,
+  ServiceJourneyMapInfoQuery,
+  ServiceJourneyWithEstimatedCallsQuery,
+} from '../../service/types';
 
 export const getServiceJourneyMapDataRequest = {
   params: Joi.object({
     id: Joi.string().required(),
   }).required(),
-  query: Joi.object({
+  query: Joi.object<ServiceJourneyMapInfoQuery>({
     fromQuayId: Joi.string(),
     toQuayId: Joi.string(),
   }),
@@ -14,7 +19,7 @@ export const getDeparturesForServiceJourneyRequestV2 = {
   params: Joi.object({
     id: Joi.string().required(),
   }).required(),
-  query: Joi.object({
+  query: Joi.object<DeparturesForServiceJourneyQuery>({
     date: Joi.date(),
   }),
 };
@@ -23,7 +28,7 @@ export const getServiceJourneyWithEstimatedCallsV2 = {
   params: Joi.object({
     id: Joi.string().required(),
   }).required(),
-  query: Joi.object({
+  query: Joi.object<ServiceJourneyWithEstimatedCallsQuery>({
     date: Joi.date(),
   }),
 };

--- a/src/api/trips/schema.ts
+++ b/src/api/trips/schema.ts
@@ -1,8 +1,12 @@
 import Joi from 'joi';
+import {Location, Modes} from '../../graphql/journey/journeyplanner-types_v3';
+import {TripsQueryVariables} from '../../service/impl/trips/journey-gql/trip.graphql-gen';
+import {TripPatternsQuery} from '../../service/types';
+import {CompressedSingleTripQuery} from '../../types/trips';
 
 export const postTripsRequest = {
-  payload: Joi.object({
-    from: Joi.object({
+  payload: Joi.object<TripsQueryVariables>({
+    from: Joi.object<Location>({
       place: Joi.string().optional(),
       name: Joi.string().default('UNKNOWN'),
       coordinates: Joi.object({
@@ -10,7 +14,7 @@ export const postTripsRequest = {
         longitude: Joi.number(),
       }),
     }).required(),
-    to: Joi.object({
+    to: Joi.object<Location>({
       place: Joi.string().optional(),
       name: Joi.string().default('UNKNOWN'),
       coordinates: Joi.object({
@@ -25,7 +29,7 @@ export const postTripsRequest = {
     waitReluctance: Joi.number(),
     walkReluctance: Joi.number(),
     walkSpeed: Joi.number(),
-    modes: Joi.object({
+    modes: Joi.object<Modes>({
       accessMode: Joi.string(),
       directMode: Joi.string(),
       egressMode: Joi.string(),
@@ -40,7 +44,7 @@ export const postTripsRequest = {
 };
 
 export const postEncodedSingleTripRequest = {
-  payload: Joi.object({
+  payload: Joi.object<CompressedSingleTripQuery>({
     compressedQuery: Joi.string().required(),
   }).required(),
 };
@@ -71,7 +75,7 @@ export const postSingleTripRequest = {
 };
 
 export const postJourneyRequest = {
-  payload: Joi.object({
+  payload: Joi.object<TripPatternsQuery>({
     from: Joi.object({
       place: Joi.string().optional(),
       name: Joi.string().default('UNKNOWN'),

--- a/src/api/trips/schema.ts
+++ b/src/api/trips/schema.ts
@@ -2,7 +2,10 @@ import Joi from 'joi';
 import {Location, Modes} from '../../graphql/journey/journeyplanner-types_v3';
 import {TripsQueryVariables} from '../../service/impl/trips/journey-gql/trip.graphql-gen';
 import {TripPatternsQuery} from '../../service/types';
-import {CompressedSingleTripQuery} from '../../types/trips';
+import {
+  CompressedSingleTripQuery,
+  TripsQueryWithJourneyIds,
+} from '../../types/trips';
 
 export const postTripsRequest = {
   payload: Joi.object<TripsQueryVariables>({
@@ -50,9 +53,9 @@ export const postEncodedSingleTripRequest = {
 };
 
 export const postSingleTripRequest = {
-  payload: Joi.object({
+  payload: Joi.object<TripsQueryWithJourneyIds>({
     query: Joi.object({
-      from: Joi.object({
+      from: Joi.object<Location>({
         place: Joi.string().optional(),
         name: Joi.string().default('UNKNOWN'),
         coordinates: Joi.object({
@@ -60,7 +63,7 @@ export const postSingleTripRequest = {
           longitude: Joi.number(),
         }),
       }).required(),
-      to: Joi.object({
+      to: Joi.object<Location>({
         place: Joi.string().optional(),
         name: Joi.string().default('UNKNOWN'),
         coordinates: Joi.object({
@@ -76,7 +79,7 @@ export const postSingleTripRequest = {
 
 export const postJourneyRequest = {
   payload: Joi.object<TripPatternsQuery>({
-    from: Joi.object({
+    from: Joi.object<Location>({
       place: Joi.string().optional(),
       name: Joi.string().default('UNKNOWN'),
       coordinates: Joi.object({
@@ -84,7 +87,7 @@ export const postJourneyRequest = {
         longitude: Joi.number(),
       }),
     }).required(),
-    to: Joi.object({
+    to: Joi.object<Location>({
       place: Joi.string().optional(),
       name: Joi.string().default('UNKNOWN'),
       coordinates: Joi.object({

--- a/src/api/vehicles/schema.ts
+++ b/src/api/vehicles/schema.ts
@@ -1,7 +1,8 @@
 import Joi from 'joi';
+import {ServiceJourneyVehicleQueryVariables} from '../../service/types';
 
 export const getVehiclesRequest = {
-  query: Joi.object({
+  query: Joi.object<ServiceJourneyVehicleQueryVariables>({
     serviceJourneyIds: Joi.array().items(Joi.string()).default([]).single(),
   }),
 };

--- a/src/api/vipps-login/schema.ts
+++ b/src/api/vipps-login/schema.ts
@@ -1,7 +1,8 @@
 import Joi from 'joi';
+import {VippsCustomTokenRequest} from '../../service/types';
 
 export const postVippsLoginRequest = {
-  payload: Joi.object({
+  payload: Joi.object<VippsCustomTokenRequest>({
     authorizationCode: Joi.string().required(),
     state: Joi.string().required(),
     nonce: Joi.string().required(),

--- a/src/service/impl/departures-grouped/departure-favorites.ts
+++ b/src/service/impl/departures-grouped/departure-favorites.ts
@@ -2,7 +2,7 @@ import {Result} from '@badrap/result';
 import union from 'lodash.union';
 import {journeyPlannerClient} from '../../../graphql/graphql-client';
 import {CursoredData, generateCursorData} from '../../cursored';
-import {DepartureGroupsQuery, FavoriteDeparture} from '../../types';
+import {DepartureFavoritesQuery, FavoriteDeparture} from '../../types';
 import {APIError} from '../../../utils/api-error';
 import {populateRealtimeCacheIfNotThere} from '../realtime/departure-time';
 import {
@@ -16,7 +16,7 @@ import {ReqRefDefaults, Request} from '@hapi/hapi';
 export type DepartureFavoritesMetadata = CursoredData<StopPlaceGroup[]>;
 
 export async function getDepartureFavorites(
-  options: DepartureGroupsQuery,
+  options: DepartureFavoritesQuery,
   headers: Request<ReqRefDefaults>,
   favorites?: FavoriteDeparture[],
 ): Promise<Result<DepartureFavoritesMetadata, APIError>> {

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -68,6 +68,7 @@ export type DepartureFavoritesPayload = {
 export type DepartureFavoritesQuery = CursoredQuery<{
   startTime: Date;
   limitPerLine: number;
+  includeCancelledTrips: boolean;
 }>;
 
 export type DepartureRealtimeQuery = {
@@ -101,6 +102,7 @@ export interface TripPatternsQuery {
   to: Location;
   searchDate?: Date;
   arriveBy: boolean;
+  minimumTransferTime?: number;
   limit: number;
   maxTransferWalkDistance: number; // Meters. Defaults to 2000 in Entur
   maxPreTransitWalkDistance: number; // Meters. Defaults to alot in Entur
@@ -176,6 +178,7 @@ export type VehiclesQuery = {
   lon: number;
   range: number;
   formFactors?: FormFactor | FormFactor[];
+  operators?: string[];
 };
 
 export type StationsQuery = {
@@ -183,6 +186,7 @@ export type StationsQuery = {
   lon: number;
   range: number;
   availableFormFactors?: FormFactor | FormFactor[];
+  operators?: string[];
 };
 
 export type CarStationQuery = {ids: string[]};


### PR DESCRIPTION
After https://github.com/AtB-AS/atb-bff/pull/278, I noticed some small bugs with Joi validation schemas that would be much easier to spot if typescript types were used when setting up validation.

There was some inconsistencies that I have tried to fix without causing functional changes. I've added some comments to those places below.

## Acceptance criteria

Shouldn't be any functional changes, but could be a good idea to test these endpoints after merge: 

- `/bff/v2/mobility/stations`
- `/bff/v2/mobility/vehicles`
- `/bff/v2/departures/departures` (Through add favorite flow, and departures v2 filtered on favorites)
- `/bff/v1/journey/trip` (Only versions below v1.18 of the app)