### PR TITLE
fix: issue with missing unit for scale in geocoder

### DIFF
--- a/src/service/impl/geocoder.ts
+++ b/src/service/impl/geocoder.ts
@@ -29,7 +29,7 @@ export default (): IGeocoderService => {
               lon: params.lon,
             },
             weight: FOCUS_WEIGHT,
-            scale: 200,
+            scale: '200km',
             function: 'exp',
           },
         };

--- a/src/types/geocoder.d.ts
+++ b/src/types/geocoder.d.ts
@@ -276,5 +276,5 @@ export interface Focus {
    *
    * @defaultValue 2500
    */
-  scale?: number;
+  scale?: `${number}km`;
 }


### PR DESCRIPTION
See discussion https://mittatb.slack.com/archives/C02EEG7D8EL/p1696927561021349

Missing unit for focus causes focus point in geocoder not to work as expected. This enforces unit using types.


Fixes https://github.com/AtB-AS/kundevendt/issues/9263 