### PR TITLE
fix: Use correct Nivel url for vehicle lookup

### DIFF
--- a/src/service/impl/mobility/index.ts
+++ b/src/service/impl/mobility/index.ts
@@ -215,7 +215,7 @@ export default (): IMobilityService => ({
     try {
       const urlParams = new URLSearchParams(query).toString();
       const response = await get<ViolationsReportingInitQueryResult>(
-        `/atb/init?${urlParams}`,
+        `/atb/vehicle?${urlParams}`,
         headers,
         {headers: {'x-api-key': nivelApiKey}},
         nivelBaseUrl,


### PR DESCRIPTION
Found during the development of https://github.com/AtB-AS/kundevendt/issues/7908