### PR TITLE
fix: Updates after Nivel api changes

### DIFF
--- a/src/service/impl/mobility/index.ts
+++ b/src/service/impl/mobility/index.ts
@@ -198,11 +198,7 @@ export default (): IMobilityService => ({
       if (result.error) {
         return Result.err(new APIError(`Invalid response. ${result.error}`));
       }
-      const retVal: ViolationsReportingInitQueryResult = {
-        ...result.value,
-        violations: result.value.violations.filter((v) => v.selectable),
-      };
-      return Result.ok(retVal);
+      return Result.ok(result.value);
     } catch (error) {
       return Result.err(new APIError(error));
     }

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -259,10 +259,8 @@ export type ViolationsReportingProvider = {
   };
 };
 export type ParkingViolationType = {
-  id: number;
   code: string;
   icon: string;
-  selectable: boolean;
 };
 export type ViolationsReportingInitQueryResult = {
   providers: ViolationsReportingProvider[];


### PR DESCRIPTION
Nivel have changed their API and removed a few properties. The violations that previously had `selectable: false` are no longer sent