### PR TITLE
fix: Increase max payload size for parking violation reports

### DIFF
--- a/src/api/mobility/index.ts
+++ b/src/api/mobility/index.ts
@@ -170,6 +170,7 @@ export default (server: Hapi.Server) => (service: IMobilityService) => {
       tags: ['api', 'mobility', 'violations', 'report'],
       validate: violationsReportRequest,
       description: 'Report a parking violation',
+      payload: {maxBytes: 10485760}, // Max upload size 10MB. Default 1MB
     },
     handler: async (request, h) => {
       const payload = request.payload as unknown as ViolationsReportQuery;


### PR DESCRIPTION
Found during testing of https://github.com/AtB-AS/kundevendt/issues/7908.

Images sent in parking violation reports are scaled down to around 1MB - sometimes under, sometimes over, depending on the image contents. The max limit could thus be set to something less than 10MB, but if image compression on the client fails on certain devices etc. the rather large limit will hopefully prevent errors due to an arbitrary limit at our end. Nivel accept these sizes.