### PR TITLE
fix: Make providerId optional in parking violations report

### DIFF
--- a/src/api/mobility/schema.ts
+++ b/src/api/mobility/schema.ts
@@ -96,7 +96,7 @@ export const violationsVehicleLookupRequest = {
 };
 export const violationsReportRequest = {
   payload: Joi.object<ViolationsReportQuery>({
-    providerId: Joi.number().required(),
+    providerId: Joi.number(),
     longitude: Joi.number().required(),
     latitude: Joi.number().required(),
     image: Joi.string(),


### PR DESCRIPTION
Necessary in order to add the option "Unknown provider". Nivel accepts undefined here.

Corresponding app pr: https://github.com/AtB-AS/mittatb-app/pull/3967