### PR TITLE
chore: use destinationDisplay to create key

### DIFF
--- a/src/service/impl/departures-grouped/utils/grouping.ts
+++ b/src/service/impl/departures-grouped/utils/grouping.ts
@@ -90,8 +90,12 @@ export type StopPlaceGroup = {
   quays: QuayGroup[];
 };
 
-function toKey(lineId?: string, frontText?: String) {
-  return [lineId ?? '', frontText ?? ''].join('-&-');
+function toKey(lineId?: string, destinationDisplay?: DestinationDisplay) {
+  return [
+    lineId ?? '',
+    destinationDisplay?.frontText ?? '',
+    destinationDisplay?.via?.join('-'),
+  ].join('-&-');
 }
 
 export default function mapQueryToGroups(
@@ -122,16 +126,10 @@ export default function mapQueryToGroups(
       quays?.map(function (quay) {
         const {times, estimatedCalls, ...quayInfo} = quay;
         const groups = groupBy(times, (item) =>
-          toKey(
-            item.serviceJourney?.line.id,
-            item.destinationDisplay?.frontText,
-          ),
+          toKey(item.serviceJourney?.line.id, item.destinationDisplay),
         );
         const lineInfoGroups = groupBy(estimatedCalls, (item) =>
-          toKey(
-            item.serviceJourney?.line.id,
-            item.destinationDisplay?.frontText,
-          ),
+          toKey(item.serviceJourney?.line.id, item.destinationDisplay),
         );
 
         let lines: QuayGroup['group'] = [];
@@ -142,7 +140,7 @@ export default function mapQueryToGroups(
             continue;
           }
 
-          // lineName is included here to support older clients
+          // lineName is included here to support older clients and used for migration purposes by the new app
           const lineInfo: DepartureLineInfo = {
             lineName: mapToLegacyLineName(lineInfoEntry.destinationDisplay),
             destinationDisplay: lineInfoEntry.destinationDisplay ?? {},

--- a/src/service/impl/departures-grouped/utils/grouping.ts
+++ b/src/service/impl/departures-grouped/utils/grouping.ts
@@ -140,7 +140,7 @@ export default function mapQueryToGroups(
             continue;
           }
 
-          // lineName is included here to support older clients and used for migration purposes by the new app
+          // lineName is included here to support older clients and used for migration purposes by app version >= 1.44
           const lineInfo: DepartureLineInfo = {
             lineName: mapToLegacyLineName(lineInfoEntry.destinationDisplay),
             destinationDisplay: lineInfoEntry.destinationDisplay ?? {},

--- a/src/service/impl/departures/utils/converters.ts
+++ b/src/service/impl/departures/utils/converters.ts
@@ -1,5 +1,12 @@
 import {DestinationDisplay} from '../../../../graphql/journey/journeyplanner-types_v3';
 
+/*
+  Important:
+
+  When more info is obtained about the conversion to the new format with a separate via array,
+  ensure that these functions map correctly.
+*/
+
 export function mapToLegacyLineName(
   destinationDisplay: DestinationDisplay | undefined,
 ): string {


### PR DESCRIPTION
Resolves https://github.com/AtB-AS/kundevendt/issues/2732

Replaces legacy usage of frontText in the toKey function
Also adds a couple of comments