### PR TITLE
fix: allow undefined via to match with empty via

### DIFF
--- a/src/service/impl/departures/utils/favorites.ts
+++ b/src/service/impl/departures/utils/favorites.ts
@@ -107,8 +107,10 @@ function destinationDisplaysAreEqual(
 ) {
   const frontTextIsEqual =
     destinationDisplay1?.frontText === destinationDisplay2?.frontText;
-  const viaLengthIsEqual =
-    destinationDisplay1?.via?.length === destinationDisplay2?.via?.length;
+  // fallback to empty array to allow undefined via to match with empty via
+  const via1 = destinationDisplay1?.via || [];
+  const via2 = destinationDisplay1?.via || [];
+  const viaLengthIsEqual = via1.length === via2.length;
   if (!frontTextIsEqual || !viaLengthIsEqual) {
     return false;
   }


### PR DESCRIPTION
Resolves https://github.com/AtB-AS/kundevendt/issues/2732

Keep destinationDisplaysAreEqual in sync with the one in the app.