### PR TITLE
chore: make range a required field for stations and vehicles

### DIFF
--- a/src/api/mobility/schema.ts
+++ b/src/api/mobility/schema.ts
@@ -31,7 +31,7 @@ export const getVehiclesRequest_v2 = {
   query: Joi.object<VehiclesQuery_v2>({
     lat: Joi.number().required(),
     lon: Joi.number().required(),
-    range: Joi.number().optional(),
+    range: Joi.number().required(),
     includeBicycles: Joi.boolean().required(),
     bicycleOperators: Joi.array().items(Joi.string()).optional().single(),
     includeScooters: Joi.boolean().required(),
@@ -63,7 +63,7 @@ export const getStationsRequest_v2 = {
   query: Joi.object<StationsQuery_v2>({
     lat: Joi.number().required(),
     lon: Joi.number().required(),
-    range: Joi.number().optional(),
+    range: Joi.number().required(),
     includeBicycles: Joi.boolean().required(),
     bicycleOperators: Joi.array().items(Joi.string()).optional().single(),
     includeCars: Joi.boolean().required(),


### PR DESCRIPTION
Currently, not providing `range` to the stations or vehicles endpoints gives a 500 server error. Making the field required in the schema gives a more precise error message:

```
{
	"statusCode": 400,
	"error": "Bad Request",
	"message": "\"range\" is required",
	"validation": {
		"source": "query",
		"keys": [
			"range"
		]
	}
}
```

### Acceptance criteria

- [ ] These requests work as expected
	- /bff/v2/mobility/stations_v2?lat=63.4279&lon=10.3888&includeBicycles=true&includeCars=true&range=1000
	- /bff/v2/mobility/vehicles_v2?lat=63.4279&lon=10.3888&includeScooters=true&includeBicycles=true&range=1000
- [ ] These requests gives a 400 error
	- /bff/v2/mobility/stations_v2?lat=63.4279&lon=10.3888&includeBicycles=true&includeCars=true
	- /bff/v2/mobility/vehicles_v2?lat=63.4279&lon=10.3888&includeScooters=true&includeBicycles=true