### PR TITLE
perf: prevent unnecessary mobility requests

### DIFF
--- a/src/service/impl/mobility/index.ts
+++ b/src/service/impl/mobility/index.ts
@@ -70,6 +70,10 @@ export default (): IMobilityService => ({
   },
 
   async getVehicles_v2(query, headers) {
+    // Prevent unnecessary calls to Entur when no vehicles are requested
+    if (!query.includeBicycles && !query.includeScooters) {
+      return Result.ok({});
+    }
     try {
       const result = await mobilityClient(headers).query<
         GetVehicles_V2Query,
@@ -124,6 +128,10 @@ export default (): IMobilityService => ({
   },
 
   async getStations_v2(query, headers) {
+    // Prevent unnecessary calls to Entur when no stations are requested
+    if (!query.includeBicycles && !query.includeCars) {
+      return Result.ok({});
+    }
     try {
       const result = await mobilityClient(headers).query<
         GetStations_V2Query,


### PR DESCRIPTION
fixes part of https://github.com/AtB-AS/kundevendt/issues/15210

Since there are a lot of requests to stations_v2 where no stations are asked for, I think it makes sense to add a guard that returns an empty result before sending a request to Entur. And to vehicles_v2 in case it also applies there.

The best solution is of course to not send those requests in the first place, which I will look at next, but that will only apply to new versions of the app, so hopefully this makes the BFF a bit more performant and less noisy towards Entur.