### PR TITLE
feat: add capacity to station query

### DIFF
--- a/src/service/impl/fragments/mobility-gql/stations.graphql
+++ b/src/service/impl/fragments/mobility-gql/stations.graphql
@@ -10,6 +10,7 @@ fragment stationBasic on Station {
     id
     lat
     lon
+    capacity
     vehicleTypesAvailable {
         ...vehicleTypeAvailabilityBasic
     }

--- a/src/service/impl/fragments/mobility-gql/stations.graphql-gen.ts
+++ b/src/service/impl/fragments/mobility-gql/stations.graphql-gen.ts
@@ -6,7 +6,7 @@ import gql from 'graphql-tag';
 import { TranslatedStringFragmentDoc, PricingPlanFragmentDoc, SystemFragmentDoc, RentalUrisFragmentDoc } from './shared.graphql-gen';
 export type VehicleTypeAvailabilityBasicFragment = { count: number, vehicleType: { formFactor: Types.FormFactor } };
 
-export type StationBasicFragment = { id: string, lat: number, lon: number, vehicleTypesAvailable?: Array<VehicleTypeAvailabilityBasicFragment> };
+export type StationBasicFragment = { id: string, lat: number, lon: number, capacity?: number, vehicleTypesAvailable?: Array<VehicleTypeAvailabilityBasicFragment> };
 
 export type BikeStationFragment = (
   { numDocksAvailable?: number, name: TranslatedStringFragment, pricingPlans: Array<PricingPlanFragment>, system: SystemFragment, rentalUris?: RentalUrisFragment }
@@ -35,6 +35,7 @@ export const StationBasicFragmentDoc = gql`
   id
   lat
   lon
+  capacity
   vehicleTypesAvailable {
     ...vehicleTypeAvailabilityBasic
   }


### PR DESCRIPTION
Related to https://github.com/AtB-AS/kundevendt/issues/15241

Right now we don't have any information about station capacity, we need it to display the information to the user as shown in the screenshot below.

- The number 3 is the total available cars.
- The number 4 is the total station capacity.

Please let me know if I missed anything!

![image](https://github.com/AtB-AS/atb-bff/assets/1777333/147ed9f0-1b11-42d8-95e0-54c7871e5220)
