### PR TITLE
feat: return lineName as well on EstimatedCalls for departures

### DIFF
--- a/src/api/departures/index.ts
+++ b/src/api/departures/index.ts
@@ -11,14 +11,12 @@ import {
   postDeparturesRequest,
 } from './schema';
 import {
-  DeparturesWithLineName,
   DeparturesPayload,
   QuayDeparturesQueryVariables,
 } from '../../service/types';
 import {NearestStopPlacesQueryVariables} from '../../service/impl/departures/journey-gql/stops-nearest.graphql-gen';
 import {StopsDetailsQueryVariables} from '../../service/impl/departures/journey-gql/stops-details.graphql-gen';
 import {DeparturesQueryVariables} from '../../service/impl/departures/journey-gql/departures.graphql-gen';
-import {mapToLegacyLineName} from '../../service/impl/departures/utils/converters';
 
 export default (server: Hapi.Server) => (service: IDeparturesService) => {
   server.route({
@@ -33,21 +31,7 @@ export default (server: Hapi.Server) => (service: IDeparturesService) => {
     handler: async (request, h) => {
       const query = request.query as unknown as DeparturesQueryVariables;
       const payload = request.payload as unknown as DeparturesPayload;
-      const departuresQueryData = (
-        await service.getDepartures(query, payload, h.request)
-      ).unwrap();
-
-      const departuresWithLineName: DeparturesWithLineName = {
-        ...departuresQueryData,
-        quays: departuresQueryData.quays.map((quay) => ({
-          ...quay,
-          estimatedCalls: quay.estimatedCalls.map((estimatedCall) => ({
-            ...estimatedCall,
-            lineName: mapToLegacyLineName(estimatedCall.destinationDisplay),
-          })),
-        })),
-      };
-      return departuresWithLineName;
+      return (await service.getDepartures(query, payload, h.request)).unwrap();
     },
   });
   server.route({

--- a/src/api/departures/index.ts
+++ b/src/api/departures/index.ts
@@ -11,12 +11,14 @@ import {
   postDeparturesRequest,
 } from './schema';
 import {
+  DeparturesWithLineName,
   DeparturesPayload,
   QuayDeparturesQueryVariables,
 } from '../../service/types';
 import {NearestStopPlacesQueryVariables} from '../../service/impl/departures/journey-gql/stops-nearest.graphql-gen';
 import {StopsDetailsQueryVariables} from '../../service/impl/departures/journey-gql/stops-details.graphql-gen';
 import {DeparturesQueryVariables} from '../../service/impl/departures/journey-gql/departures.graphql-gen';
+import {mapToLegacyLineName} from '../../service/impl/departures/utils/converters';
 
 export default (server: Hapi.Server) => (service: IDeparturesService) => {
   server.route({
@@ -31,7 +33,21 @@ export default (server: Hapi.Server) => (service: IDeparturesService) => {
     handler: async (request, h) => {
       const query = request.query as unknown as DeparturesQueryVariables;
       const payload = request.payload as unknown as DeparturesPayload;
-      return (await service.getDepartures(query, payload, h.request)).unwrap();
+      const departuresQueryData = (
+        await service.getDepartures(query, payload, h.request)
+      ).unwrap();
+
+      const departuresWithLineName: DeparturesWithLineName = {
+        ...departuresQueryData,
+        quays: departuresQueryData.quays.map((quay) => ({
+          ...quay,
+          estimatedCalls: quay.estimatedCalls.map((estimatedCall) => ({
+            ...estimatedCall,
+            lineName: mapToLegacyLineName(estimatedCall.destinationDisplay),
+          })),
+        })),
+      };
+      return departuresWithLineName;
     },
   });
   server.route({

--- a/src/service/interface.ts
+++ b/src/service/interface.ts
@@ -6,10 +6,7 @@ import WebSocket from 'ws';
 import {Subscription} from 'zen-observable-ts';
 import * as Trips from '../types/trips';
 import {DepartureGroupMetadata} from './impl/departures-grouped/departure-group';
-import {
-  DeparturesQuery,
-  DeparturesQueryVariables,
-} from './impl/departures/journey-gql/departures.graphql-gen';
+import {DeparturesQueryVariables} from './impl/departures/journey-gql/departures.graphql-gen';
 import {
   StopPlaceQuayDeparturesQuery,
   StopPlaceQuayDeparturesQueryVariables,
@@ -53,6 +50,7 @@ import {
   DeparturesForServiceJourneyQuery,
   DeparturesPayload,
   DeparturesRealtimeData,
+  DeparturesWithLineName,
   FeaturesQuery,
   QuaysCoordinatesPayload,
   ReverseFeaturesQuery,
@@ -158,7 +156,7 @@ export interface IDeparturesService {
     query: DeparturesQueryVariables,
     payload: DeparturesPayload,
     headers: Request<ReqRefDefaults>,
-  ): Promise<Result<DeparturesQuery, APIError>>;
+  ): Promise<Result<DeparturesWithLineName, APIError>>;
   getStopPlacesByPosition(
     query: NearestStopPlacesQueryVariables,
     headers: Request<ReqRefDefaults>,

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -10,6 +10,7 @@ import {FormFactor} from '../graphql/mobility/mobility-types_v2';
 import * as Types from '../graphql/vehicles/vehicles-types_v1';
 import {CursoredQuery} from './cursored';
 import {GetServiceJourneyVehicleQuery} from './impl/vehicles/vehicles-gql/vehicles.graphql-gen';
+import {DeparturesQuery} from './impl/departures/journey-gql/departures.graphql-gen';
 
 export interface Coordinates {
   latitude: number;
@@ -23,6 +24,16 @@ export type FavoriteDeparture = {
   destinationDisplay?: DestinationDisplay;
   lineId: string;
   quayId?: string;
+};
+
+type EstimatedCallWithLineName =
+  DeparturesQuery['quays'][0]['estimatedCalls'][0] & {
+    lineName?: string;
+  };
+export type DeparturesWithLineName = DeparturesQuery & {
+  quays: (DeparturesQuery['quays'][0] & {
+    estimatedCalls: EstimatedCallWithLineName[];
+  })[];
 };
 
 export type FeaturesQuery = {


### PR DESCRIPTION
To allow for locally stored favorite departures in the app to be migrated with regards to via format changes, include `lineName` along with `destinationDisplay` for the EstimatedCalls.

Resolves https://github.com/AtB-AS/kundevendt/issues/2732

Relevant app PR: https://github.com/AtB-AS/mittatb-app/pull/4056