### PR TITLE
feat: add vehicle id for mobility vehicles

### DIFF
--- a/src/service/impl/fragments/mobility-gql/stations.graphql
+++ b/src/service/impl/fragments/mobility-gql/stations.graphql
@@ -34,6 +34,7 @@ fragment bikeStation on Station {
 }
 
 fragment carVehicleType on VehicleType {
+    id
     formFactor
     propulsionType
     maxRangeMeters

--- a/src/service/impl/fragments/mobility-gql/stations.graphql-gen.ts
+++ b/src/service/impl/fragments/mobility-gql/stations.graphql-gen.ts
@@ -13,7 +13,7 @@ export type BikeStationFragment = (
   & StationBasicFragment
 );
 
-export type CarVehicleTypeFragment = { formFactor: Types.FormFactor, propulsionType: Types.PropulsionType, maxRangeMeters?: number, riderCapacity?: number, make?: string, model?: string, vehicleAccessories?: Array<Types.VehicleAccessory>, vehicleImage?: string, name?: TranslatedStringFragment };
+export type CarVehicleTypeFragment = { id: string, formFactor: Types.FormFactor, propulsionType: Types.PropulsionType, maxRangeMeters?: number, riderCapacity?: number, make?: string, model?: string, vehicleAccessories?: Array<Types.VehicleAccessory>, vehicleImage?: string, name?: TranslatedStringFragment };
 
 export type CarAvailabilityFragment = { count: number, vehicleType: CarVehicleTypeFragment };
 
@@ -65,6 +65,7 @@ ${SystemFragmentDoc}
 ${RentalUrisFragmentDoc}`;
 export const CarVehicleTypeFragmentDoc = gql`
     fragment carVehicleType on VehicleType {
+  id
   formFactor
   propulsionType
   maxRangeMeters


### PR DESCRIPTION
Related to PR : https://github.com/AtB-AS/mittatb-app/pull/4049

Currently we don't have any ID for vehicles returned by the stations, this is needed to ensure that we use correct `key` for the vehicle list in a car station. 