### PR TITLE
feat: forward 504 timeouts to clients

### DIFF
--- a/src/graphql/graphql-client.ts
+++ b/src/graphql/graphql-client.ts
@@ -8,7 +8,6 @@ import {
 } from '@apollo/client/core';
 import {WebSocketLink} from '@apollo/client/link/ws';
 import {onError} from '@apollo/client/link/error';
-import fetch, {RequestInit, RequestInfo, Response} from 'node-fetch';
 import {
   ENTUR_BASEURL,
   ENTUR_WEBSOCKET_BASEURL,
@@ -19,8 +18,7 @@ import {SubscriptionClient} from 'subscriptions-transport-ws';
 import {ReqRefDefaults, Request} from '@hapi/hapi';
 import {logResponse} from '../utils/log-response';
 import {Timer} from '../utils/timer';
-
-const REQUEST_TIMEOUT = 20_000;
+import {fetchWithTimeout} from '../utils/fetch-client';
 
 const defaultOptions: DefaultOptions = {
   watchQuery: {
@@ -48,24 +46,6 @@ const urlVehicles = ENTUR_BASEURL
 const urlVehiclesWss = ENTUR_WEBSOCKET_BASEURL
   ? `${ENTUR_WEBSOCKET_BASEURL}/realtime/v1/vehicles/subscriptions`
   : 'wss://api.entur.io/realtime/v1/vehicles/subscriptions';
-
-function fetchWithTimeout(
-  input: URL | RequestInfo,
-  init: RequestInit | undefined,
-): Promise<Response> {
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(
-      () => reject(new Error('TIMEOUT')),
-      REQUEST_TIMEOUT,
-    );
-    fetch(input, init)
-      .then(
-        (response) => resolve(response),
-        (error) => reject(error),
-      )
-      .finally(() => clearTimeout(timer));
-  });
-}
 
 function createClient(url: string) {
   const cache = new InMemoryCache();

--- a/src/utils/api-error.ts
+++ b/src/utils/api-error.ts
@@ -27,6 +27,10 @@ export class APIError extends Error {
       this.message = networkErrorResponse.statusText;
       this.statusCode = networkErrorResponse.status;
     }
+    if (error?.message === 'TIMEOUT') {
+      this.message = 'Upstream service timed out';
+      this.statusCode = 504;
+    }
 
     return boomify(this, {
       statusCode: this.statusCode,


### PR DESCRIPTION
1. Moves the `fetchWithTimeout` client to `fetch-client`
2. Uses fetchWithTimeout for non-graphql endpoints (geocoder / violations reporting)
3. Forwards 504 timeouts to clients

closes https://github.com/AtB-AS/kundevendt/issues/16023