### PR TITLE
fix: catch errors when creating Apollo subscriptions

### DIFF
--- a/src/api/vehicles/index.ts
+++ b/src/api/vehicles/index.ts
@@ -53,10 +53,18 @@ export default (server: Hapi.Server) => (service: IVehiclesService) => {
               return;
             }
 
-            ctx.client = service.createServiceJourneySubscription(
-              {serviceJourneyId},
-              ws,
-            );
+            try {
+              ctx.client = service.createServiceJourneySubscription(
+                {serviceJourneyId},
+                ws,
+              );
+            } catch (error) {
+              console.error(`WebSocket error: ${error}`);
+              if (ws.readyState == WebSocket.OPEN) {
+                ws.close(1011, 'Error when creating upstream subscription');
+              }
+              return;
+            }
           },
           disconnect: ({ctx}) => {
             if (ctx.client) {


### PR DESCRIPTION
![Screenshot 2024-01-18 at 15 08 34](https://github.com/AtB-AS/atb-bff/assets/1774972/8eee0810-084a-44f6-a319-1b460b97c016)

@Nisha1306 informed me about a crash in production caused by an Apollo Error during setup of a websocket subscription. I'm not able to recreate the exact problem locally (because the actual error seemed to be a temporary one at Enturs end), but throwing an arbitrary error during setup of vehiclesSubscriptionClient, caused the BFF to crash.

Putting the entirety of createServiceJourneySubscription in a try/catch prevents my locally fabricated crash from happening, and the assumption is that it would catch any upstream errors as well.

### Acceptance criteria

- [ ] Websockets / bus in map work as before
- [ ] The `/ws` instances of the BFF crashes less in production 🤞