### PR TITLE
feat: geofencing zones

### DIFF
--- a/src/api/mobility/index.ts
+++ b/src/api/mobility/index.ts
@@ -3,6 +3,7 @@ import {IMobilityService} from '../../service/interface';
 import {
   BikeStationQuery,
   CarStationQuery,
+  GeofencingZonesQuery,
   StationsQuery,
   StationsQuery_v2,
   VehicleQuery,
@@ -18,6 +19,7 @@ import {
   getVehicleRequest,
   getCarStationRequest,
   getBikeStationRequest,
+  getGeofencingZonesRequest,
   getVehiclesRequest_v2,
   getStationsRequest_v2,
   violationsReportingInitRequest,
@@ -125,6 +127,20 @@ export default (server: Hapi.Server) => (service: IMobilityService) => {
       const payload = request.query as unknown as BikeStationQuery;
 
       return (await service.getBikeStation(payload, h.request)).unwrap();
+    },
+  });
+
+  server.route({
+    method: 'GET',
+    path: '/bff/v2/mobility/geofencing-zones',
+    options: {
+      tags: ['api', 'mobility', 'parking zones'],
+      validate: getGeofencingZonesRequest,
+      description: 'Get geofencingZones for a transport operator in a city',
+    },
+    handler: async (request, h) => {
+      const payload = request.query as unknown as GeofencingZonesQuery;
+      return (await service.getGeofencingZones(payload, h.request)).unwrap();
     },
   });
 

--- a/src/api/mobility/schema.ts
+++ b/src/api/mobility/schema.ts
@@ -3,6 +3,7 @@ import {FormFactor} from '../../graphql/mobility/mobility-types_v2';
 import {
   BikeStationQuery,
   CarStationQuery,
+  GeofencingZonesQuery,
   StationsQuery,
   StationsQuery_v2,
   VehicleQuery,
@@ -79,6 +80,12 @@ export const getCarStationRequest = {
 export const getBikeStationRequest = {
   query: Joi.object<BikeStationQuery>({
     ids: Joi.array().items(Joi.string()).required().single(),
+  }),
+};
+
+export const getGeofencingZonesRequest = {
+  query: Joi.object<GeofencingZonesQuery>({
+    systemIds: Joi.array().items(Joi.string()).required().single(),
   }),
 };
 

--- a/src/graphql/journey/journeyplanner-types_v3.ts
+++ b/src/graphql/journey/journeyplanner-types_v3.ts
@@ -904,6 +904,8 @@ export type PtSituationElement = {
   summary: Array<MultilingualString>;
   /** Period this situation is in effect */
   validityPeriod?: Maybe<ValidityPeriod>;
+  /** Operator's version number for the situation element. */
+  version?: Maybe<Scalars['Int']['output']>;
   /** Timestamp when the situation element was updated. */
   versionedAtTime?: Maybe<Scalars['DateTime']['output']>;
 };
@@ -923,7 +925,7 @@ export type Quay = PlaceInterface & {
   estimatedCalls: Array<EstimatedCall>;
   /** Geometry for flexible area. */
   flexibleArea?: Maybe<Scalars['Coordinates']['output']>;
-  /** the Quays part of an flexible group. */
+  /** the Quays part of a flexible group. */
   flexibleGroup?: Maybe<Array<Maybe<Quay>>>;
   id: Scalars['ID']['output'];
   /** List of journey patterns servicing this quay */
@@ -1306,7 +1308,7 @@ export enum RelativeDirection {
  *
  */
 export type RelaxCostInput = {
-  /** The constant value to add to the limit. Must be a positive number. The value isequivalent to transit-cost-seconds. Integers is treated as seconds, but you may use the duration format. Example: '3665 = 'DT1h1m5s' = '1h1m5s'. */
+  /** The constant value to add to the limit. Must be a positive number. The value is equivalent to transit-cost-seconds. Integers are treated as seconds, but you may use the duration format. Example: '3665 = 'DT1h1m5s' = '1h1m5s'. */
   constant?: InputMaybe<Scalars['Cost']['input']>;
   /** The factor to multiply with the 'other cost'. Minimum value is 1.0. */
   ratio?: InputMaybe<Scalars['Float']['input']>;
@@ -1397,7 +1399,10 @@ export type RoutingParameters = {
   carDecelerationSpeed?: Maybe<Scalars['Float']['output']>;
   /** Time to park a car in a park and ride, w/o taking into account driving and walking cost. */
   carDropOffTime?: Maybe<Scalars['Int']['output']>;
-  /** Max car speed along streets, in meters per second */
+  /**
+   * Max car speed along streets, in meters per second
+   * @deprecated This parameter is no longer configurable.
+   */
   carSpeed?: Maybe<Scalars['Float']['output']>;
   /** @deprecated NOT IN USE IN OTP2. */
   compactLegsByReversedSearch?: Maybe<Scalars['Boolean']['output']>;

--- a/src/graphql/mobility/mobility-types_v2.ts
+++ b/src/graphql/mobility/mobility-types_v2.ts
@@ -52,6 +52,8 @@ export enum FormFactor {
 export type GeofencingZoneProperties = {
   end?: Maybe<Scalars['Int']['output']>;
   name?: Maybe<Scalars['String']['output']>;
+  /** MultiPolygon where the lists of coordinates are encoded as polyline strings using precision of 6 decimals (see http://code.google.com/apis/maps/documentation/polylinealgorithm.html). Meant to be used instead of geometry.coordinates to minimize the response payload size. */
+  polylineEncodedMultiPolygon?: Maybe<Array<Maybe<Array<Maybe<Scalars['String']['output']>>>>>;
   rules?: Maybe<Array<Maybe<GeofencingZoneRule>>>;
   start?: Maybe<Scalars['Int']['output']>;
 };
@@ -70,6 +72,7 @@ export type GeofencingZones = {
 };
 
 export type MultiPolygon = {
+  /** See properties.polylineEncodedMultiPolygon, and consider using that instead of coordinates */
   coordinates?: Maybe<Array<Maybe<Array<Maybe<Array<Maybe<Array<Maybe<Scalars['Float']['output']>>>>>>>>>;
   type?: Maybe<Scalars['String']['output']>;
 };

--- a/src/service/impl/mobility/index.ts
+++ b/src/service/impl/mobility/index.ts
@@ -46,6 +46,11 @@ import {
   violationsReportingInitQueryResultSchema,
   violationsVehicleLookupResultSchema,
 } from './schema';
+import {
+  GetGeofencingZonesDocument,
+  GetGeofencingZonesQuery,
+  GetGeofencingZonesQueryVariables,
+} from './mobility-gql/geofencing-zones.graphql-gen';
 
 const nivelBaseUrl = NIVEL_BASEURL || '';
 const nivelApiKey = NIVEL_API_KEY || '';
@@ -174,6 +179,24 @@ export default (): IMobilityService => ({
         GetBikeStationQueryVariables
       >({
         query: GetBikeStationDocument,
+        variables: query,
+      });
+      if (result.errors) {
+        return Result.err(new APIError(result.errors));
+      }
+      return Result.ok(result.data);
+    } catch (error) {
+      return Result.err(new APIError(error));
+    }
+  },
+
+  async getGeofencingZones(query, headers) {
+    try {
+      const result = await mobilityClient(headers).query<
+        GetGeofencingZonesQuery,
+        GetGeofencingZonesQueryVariables
+      >({
+        query: GetGeofencingZonesDocument,
         variables: query,
       });
       if (result.errors) {

--- a/src/service/impl/mobility/mobility-gql/geofencing-zones.graphql
+++ b/src/service/impl/mobility/mobility-gql/geofencing-zones.graphql
@@ -1,0 +1,29 @@
+
+query getGeofencingZones($systemIds: [ID]) { # why not [String!]?
+    geofencingZones(systemIds: $systemIds) {
+        systemId
+        geojson {
+            type
+            features {
+                type
+                geometry {
+                    type
+                    coordinates # todo: use polylineEncodedMultiPolygon instead
+                }
+                properties {
+                    name
+                    start
+                    end
+                    rules {
+                        vehicleTypeIds
+                        rideAllowed
+                        rideThroughAllowed
+                        maximumSpeedKph
+                        stationParking
+                    }
+                    #polylineEncodedMultiPolygon # todo: use this when mobility api ready
+                }
+            }
+        }
+    }
+}

--- a/src/service/impl/mobility/mobility-gql/geofencing-zones.graphql
+++ b/src/service/impl/mobility/mobility-gql/geofencing-zones.graphql
@@ -1,5 +1,5 @@
 
-query getGeofencingZones($systemIds: [ID]) { # why not [String!]?
+query getGeofencingZones($systemIds: [ID]) {
     geofencingZones(systemIds: $systemIds) {
         systemId
         geojson {

--- a/src/service/impl/mobility/mobility-gql/geofencing-zones.graphql
+++ b/src/service/impl/mobility/mobility-gql/geofencing-zones.graphql
@@ -8,7 +8,7 @@ query getGeofencingZones($systemIds: [ID]) { # why not [String!]?
                 type
                 geometry {
                     type
-                    coordinates # todo: use polylineEncodedMultiPolygon instead
+                    #coordinates #note: using polylineEncodedMultiPolygon instead
                 }
                 properties {
                     name
@@ -21,7 +21,7 @@ query getGeofencingZones($systemIds: [ID]) { # why not [String!]?
                         maximumSpeedKph
                         stationParking
                     }
-                    #polylineEncodedMultiPolygon # todo: use this when mobility api ready
+                    polylineEncodedMultiPolygon
                 }
             }
         }

--- a/src/service/impl/mobility/mobility-gql/geofencing-zones.graphql-gen.ts
+++ b/src/service/impl/mobility/mobility-gql/geofencing-zones.graphql-gen.ts
@@ -7,7 +7,7 @@ export type GetGeofencingZonesQueryVariables = Types.Exact<{
 }>;
 
 
-export type GetGeofencingZonesQuery = { geofencingZones?: Array<{ systemId?: string, geojson?: { type?: string, features?: Array<{ type?: string, geometry?: { type?: string, coordinates?: Array<Array<Array<Array<number>>>> }, properties?: { name?: string, start?: number, end?: number, rules?: Array<{ vehicleTypeIds?: Array<string>, rideAllowed: boolean, rideThroughAllowed: boolean, maximumSpeedKph?: number, stationParking?: boolean }> } }> } }> };
+export type GetGeofencingZonesQuery = { geofencingZones?: Array<{ systemId?: string, geojson?: { type?: string, features?: Array<{ type?: string, geometry?: { type?: string }, properties?: { name?: string, start?: number, end?: number, polylineEncodedMultiPolygon?: Array<Array<string>>, rules?: Array<{ vehicleTypeIds?: Array<string>, rideAllowed: boolean, rideThroughAllowed: boolean, maximumSpeedKph?: number, stationParking?: boolean }> } }> } }> };
 
 
 export const GetGeofencingZonesDocument = gql`
@@ -20,7 +20,6 @@ export const GetGeofencingZonesDocument = gql`
         type
         geometry {
           type
-          coordinates
         }
         properties {
           name
@@ -33,6 +32,7 @@ export const GetGeofencingZonesDocument = gql`
             maximumSpeedKph
             stationParking
           }
+          polylineEncodedMultiPolygon
         }
       }
     }

--- a/src/service/impl/mobility/mobility-gql/geofencing-zones.graphql-gen.ts
+++ b/src/service/impl/mobility/mobility-gql/geofencing-zones.graphql-gen.ts
@@ -1,0 +1,50 @@
+import * as Types from '../../../../graphql/mobility/mobility-types_v2';
+
+import { DocumentNode } from 'graphql';
+import gql from 'graphql-tag';
+export type GetGeofencingZonesQueryVariables = Types.Exact<{
+  systemIds?: Types.InputMaybe<Array<Types.InputMaybe<Types.Scalars['ID']['input']>> | Types.InputMaybe<Types.Scalars['ID']['input']>>;
+}>;
+
+
+export type GetGeofencingZonesQuery = { geofencingZones?: Array<{ systemId?: string, geojson?: { type?: string, features?: Array<{ type?: string, geometry?: { type?: string, coordinates?: Array<Array<Array<Array<number>>>> }, properties?: { name?: string, start?: number, end?: number, rules?: Array<{ vehicleTypeIds?: Array<string>, rideAllowed: boolean, rideThroughAllowed: boolean, maximumSpeedKph?: number, stationParking?: boolean }> } }> } }> };
+
+
+export const GetGeofencingZonesDocument = gql`
+    query getGeofencingZones($systemIds: [ID]) {
+  geofencingZones(systemIds: $systemIds) {
+    systemId
+    geojson {
+      type
+      features {
+        type
+        geometry {
+          type
+          coordinates
+        }
+        properties {
+          name
+          start
+          end
+          rules {
+            vehicleTypeIds
+            rideAllowed
+            rideThroughAllowed
+            maximumSpeedKph
+            stationParking
+          }
+        }
+      }
+    }
+  }
+}
+    `;
+export type Requester<C = {}> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R> | AsyncIterable<R>
+export function getSdk<C>(requester: Requester<C>) {
+  return {
+    getGeofencingZones(variables?: GetGeofencingZonesQueryVariables, options?: C): Promise<GetGeofencingZonesQuery> {
+      return requester<GetGeofencingZonesQuery, GetGeofencingZonesQueryVariables>(GetGeofencingZonesDocument, variables, options) as Promise<GetGeofencingZonesQuery>;
+    }
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/src/service/interface.ts
+++ b/src/service/interface.ts
@@ -29,6 +29,9 @@ import {
   GetStationsQuery,
 } from './impl/mobility/mobility-gql/stations.graphql-gen';
 import {
+  GetGeofencingZonesQuery
+} from './impl/mobility/mobility-gql/geofencing-zones.graphql-gen';
+import {
   GetVehicleQuery,
   GetVehicles_V2Query,
   GetVehiclesQuery,
@@ -40,6 +43,7 @@ import {
   TripsQueryVariables,
 } from './impl/trips/journey-gql/trip.graphql-gen';
 import {
+  GeofencingZonesQuery,
   BikeStationQuery,
   CarStationQuery,
   DepartureFavoritesPayload,
@@ -246,6 +250,10 @@ export interface IMobilityService {
     query: BikeStationQuery,
     headers: Request<ReqRefDefaults>,
   ): Promise<Result<GetBikeStationQuery, APIError>>;
+  getGeofencingZones(
+    query: GeofencingZonesQuery,
+    headers: Request<ReqRefDefaults>,
+  ): Promise<Result<GetGeofencingZonesQuery, APIError>>;
   initViolationsReporting(
     query: ViolationsReportingInitQuery,
     headers: Request<ReqRefDefaults>,

--- a/src/service/interface.ts
+++ b/src/service/interface.ts
@@ -28,9 +28,7 @@ import {
   GetStations_V2Query,
   GetStationsQuery,
 } from './impl/mobility/mobility-gql/stations.graphql-gen';
-import {
-  GetGeofencingZonesQuery
-} from './impl/mobility/mobility-gql/geofencing-zones.graphql-gen';
+import {GetGeofencingZonesQuery} from './impl/mobility/mobility-gql/geofencing-zones.graphql-gen';
 import {
   GetVehicleQuery,
   GetVehicles_V2Query,

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -247,6 +247,8 @@ export type StationsQuery_v2 = {
 export type CarStationQuery = {ids: string[]};
 export type BikeStationQuery = {ids: string[]};
 
+export type GeofencingZonesQuery = {systemIds: string[]};
+
 export type ServiceJourneyMapInfoData = {
   mapLegs: MapLeg[];
   start?: Coordinates;


### PR DESCRIPTION
In order to support geofencing zones, add a new end point for Enturs Mobility API with graphql.

Example use: `/bff/v2/mobility/geofencing-zones?systemIds=voitrondheim`

closes https://github.com/AtB-AS/kundevendt/issues/17614