### PR TITLE
feat: add system id for vehicle

### DIFF
--- a/src/graphql/journey/journeyplanner-types_v3.ts
+++ b/src/graphql/journey/journeyplanner-types_v3.ts
@@ -904,6 +904,8 @@ export type PtSituationElement = {
   summary: Array<MultilingualString>;
   /** Period this situation is in effect */
   validityPeriod?: Maybe<ValidityPeriod>;
+  /** Operator's version number for the situation element. */
+  version?: Maybe<Scalars['Int']['output']>;
   /** Timestamp when the situation element was updated. */
   versionedAtTime?: Maybe<Scalars['DateTime']['output']>;
 };
@@ -923,7 +925,7 @@ export type Quay = PlaceInterface & {
   estimatedCalls: Array<EstimatedCall>;
   /** Geometry for flexible area. */
   flexibleArea?: Maybe<Scalars['Coordinates']['output']>;
-  /** the Quays part of an flexible group. */
+  /** the Quays part of a flexible group. */
   flexibleGroup?: Maybe<Array<Maybe<Quay>>>;
   id: Scalars['ID']['output'];
   /** List of journey patterns servicing this quay */
@@ -1306,7 +1308,7 @@ export enum RelativeDirection {
  *
  */
 export type RelaxCostInput = {
-  /** The constant value to add to the limit. Must be a positive number. The value isequivalent to transit-cost-seconds. Integers is treated as seconds, but you may use the duration format. Example: '3665 = 'DT1h1m5s' = '1h1m5s'. */
+  /** The constant value to add to the limit. Must be a positive number. The value is equivalent to transit-cost-seconds. Integers are treated as seconds, but you may use the duration format. Example: '3665 = 'DT1h1m5s' = '1h1m5s'. */
   constant?: InputMaybe<Scalars['Cost']['input']>;
   /** The factor to multiply with the 'other cost'. Minimum value is 1.0. */
   ratio?: InputMaybe<Scalars['Float']['input']>;
@@ -1397,7 +1399,10 @@ export type RoutingParameters = {
   carDecelerationSpeed?: Maybe<Scalars['Float']['output']>;
   /** Time to park a car in a park and ride, w/o taking into account driving and walking cost. */
   carDropOffTime?: Maybe<Scalars['Int']['output']>;
-  /** Max car speed along streets, in meters per second */
+  /**
+   * Max car speed along streets, in meters per second
+   * @deprecated This parameter is no longer configurable.
+   */
   carSpeed?: Maybe<Scalars['Float']['output']>;
   /** @deprecated NOT IN USE IN OTP2. */
   compactLegsByReversedSearch?: Maybe<Scalars['Boolean']['output']>;

--- a/src/service/impl/fragments/mobility-gql/shared.graphql
+++ b/src/service/impl/fragments/mobility-gql/shared.graphql
@@ -59,6 +59,7 @@ fragment brandAssets on BrandAssets {
 }
 
 fragment system on System {
+    id
     operator {
         ...operator
     }

--- a/src/service/impl/fragments/mobility-gql/shared.graphql-gen.ts
+++ b/src/service/impl/fragments/mobility-gql/shared.graphql-gen.ts
@@ -20,7 +20,7 @@ export type RentalAppsFragment = { android?: RentalAppFragment, ios?: RentalAppF
 
 export type BrandAssetsFragment = { brandImageUrl: string, brandImageUrlDark?: string, brandLastModified: string };
 
-export type SystemFragment = { operator: OperatorFragment, name: TranslatedStringFragment, brandAssets?: BrandAssetsFragment, rentalApps?: RentalAppsFragment };
+export type SystemFragment = { id: string, operator: OperatorFragment, name: TranslatedStringFragment, brandAssets?: BrandAssetsFragment, rentalApps?: RentalAppsFragment };
 
 export type VehicleTypeBasicFragment = { maxRangeMeters?: number, formFactor: Types.FormFactor };
 
@@ -100,6 +100,7 @@ export const RentalAppsFragmentDoc = gql`
     ${RentalAppFragmentDoc}`;
 export const SystemFragmentDoc = gql`
     fragment system on System {
+  id
   operator {
     ...operator
   }


### PR DESCRIPTION
To know which `systemId` to use for requesting geofencing zones, it must be included on the vehicle.

Note that for the future, it could be considered to also add this on `vehicleBasic`:
```gql
system {
   id
}
```
This would allow the app to know the `systemId` immediately onClick rather than after the `/vehicle` call, however would also add about 30% more data to the `/vehicles` response.

Resolves https://github.com/AtB-AS/kundevendt/issues/17614