### PR TITLE
test: Change day of week in trip search

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -14,6 +14,7 @@
     "babel-loader": "9.1.2",
     "clean-webpack-plugin": "4.0.0",
     "copy-webpack-plugin": "11.0.0",
+    "prettier": "2.2.1",
     "typescript": "4.9.5",
     "webpack": "5.75.0",
     "webpack-cli": "5.0.1",

--- a/test/src/config/performanceConfig.json
+++ b/test/src/config/performanceConfig.json
@@ -4,11 +4,11 @@
   "stages": [
     {
       "duration": "20s",
-      "target": 20
+      "target": 60
     },
     {
       "duration": "10m",
-      "target": 20
+      "target": 60
     },
     {
       "duration": "20s",
@@ -18,8 +18,7 @@
   "thresholds": {
     "http_req_duration": ["avg < 2000", "p(95) < 5000"],
     "http_req_duration{name:getStatus}": ["avg > 0"],
-    "http_req_duration{name:getHealth}": ["avg > 0"],
-    "reqs_success_all": ["rate > 0.95"]
+    "http_req_duration{name:getHealth}": ["avg > 0"]
   },
   "junitCheckOutput": false
 }

--- a/test/src/config/performanceConfig.json
+++ b/test/src/config/performanceConfig.json
@@ -4,11 +4,11 @@
   "stages": [
     {
       "duration": "20s",
-      "target": 60
+      "target": 20
     },
     {
       "duration": "10m",
-      "target": 60
+      "target": 20
     },
     {
       "duration": "20s",
@@ -18,7 +18,8 @@
   "thresholds": {
     "http_req_duration": ["avg < 2000", "p(95) < 5000"],
     "http_req_duration{name:getStatus}": ["avg > 0"],
-    "http_req_duration{name:getHealth}": ["avg > 0"]
+    "http_req_duration{name:getHealth}": ["avg > 0"],
+    "reqs_success_all": ["rate > 0.95"]
   },
   "junitCheckOutput": false
 }

--- a/test/src/scenario.ts
+++ b/test/src/scenario.ts
@@ -5,7 +5,7 @@ import {
   tripsScenario,
   mobilityScenario,
 } from './v2/v2Scenario';
-import {getNextFriday} from './utils/utils';
+import {getDayNextWeek} from './utils/utils';
 import {
   departuresScenarioV1,
   geocoderScenarioV1,
@@ -28,7 +28,7 @@ export const scn = (usecase: string): void => {
 
 //Functional test
 const bff = (): void => {
-  const searchDate = getNextFriday();
+  const searchDate = getDayNextWeek(4);
   // V1
   departuresScenarioV1(searchDate);
   geocoderScenarioV1();
@@ -49,7 +49,7 @@ const test = (): void => {
 
 //Performance test
 const bffPerformanceTest = (): void => {
-  const searchDate = getNextFriday();
+  const searchDate = getDayNextWeek(4);
   if (__ITER === 0) {
     // Some initialization
   }

--- a/test/src/utils/utils.ts
+++ b/test/src/utils/utils.ts
@@ -104,10 +104,11 @@ export const arrivesBeforeExpectedEndTime = (
   return true;
 };
 
-// Return next Friday as a date - to be used in search
-export const getNextFriday = (): string => {
+// Return a day the following week as a date - to be used in search
+// E.g. weekday: 4 = Thursday
+export const getDayNextWeek = (weekday: number): string => {
   const today = new Date();
-  const increaseDays = 5 - today.getDay() + 7; // Friday = 5
+  const increaseDays = weekday - today.getDay() + 7;
   today.setDate(today.getDate() + increaseDays);
 
   return today.toISOString().split('T')[0];

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -2341,6 +2341,11 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+prettier@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+
 punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz"


### PR DESCRIPTION
Doing trip searches, a date is needed. This time, the chosen day fell on May 17th.

Not a fail proof solution, but change the weekday for doing trip searches. Pre: Friday, which now is May 17th. Change to Thursday.