### PR TITLE
fix: handle null parking violation provider image

### DIFF
--- a/src/service/impl/mobility/index.ts
+++ b/src/service/impl/mobility/index.ts
@@ -220,12 +220,18 @@ export default (): IMobilityService => ({
         {headers: {'x-api-key': nivelApiKey}},
         nivelBaseUrl,
       );
-      const result = violationsReportingInitQueryResultSchema.validate(
-        response,
-        {
-          stripUnknown: true,
-        },
-      );
+      const mapped = {
+        ...response,
+        providers: response.providers.map((provider) => ({
+          ...provider,
+          // The image field can in some cases be null, but the app expects it
+          // to be either set or undefined
+          image: provider.image ?? undefined,
+        })),
+      };
+      const result = violationsReportingInitQueryResultSchema.validate(mapped, {
+        stripUnknown: true,
+      });
       if (result.error) {
         return Result.err(new APIError(`Invalid response. ${result.error}`));
       }

--- a/src/service/impl/mobility/schema.ts
+++ b/src/service/impl/mobility/schema.ts
@@ -13,7 +13,7 @@ export const violationsReportingInitQueryResultSchema =
         image: Joi.object({
           type: Joi.string(),
           base64: Joi.string(),
-        }),
+        }).allow(null),
       }),
     ),
     violations: Joi.array().items(

--- a/src/service/impl/mobility/schema.ts
+++ b/src/service/impl/mobility/schema.ts
@@ -13,7 +13,7 @@ export const violationsReportingInitQueryResultSchema =
         image: Joi.object({
           type: Joi.string(),
           base64: Joi.string(),
-        }).allow(null),
+        }).optional(),
       }),
     ),
     violations: Joi.array().items(

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -272,7 +272,7 @@ export type ViolationsReportingProvider = {
   image: {
     type: string;
     base64: string;
-  };
+  } | null;
 };
 export type ParkingViolationType = {
   code: string;


### PR DESCRIPTION
The logo image we get from Nivel can sometimes be `null`, which previously lead to an error https://mittatb.slack.com/archives/C0116FMPX4Y/p1715346138109749

This maps the `null` value to `undefined`, which is an expected option in the app.