### PR TITLE
test: less results in summer

### DIFF
--- a/test/src/v2/testData/testData.ts
+++ b/test/src/v2/testData/testData.ts
@@ -292,7 +292,7 @@ export const tripsTestData: tripsTestDataType = {
       },
       expectedResult: {
         legModes: null,
-        minimumTripPatterns: 2,
+        minimumTripPatterns: 1,
       },
     },
   ],


### PR DESCRIPTION
On the test cases, there is only one /trip request and due to summer schedules there are less results than before. A quick fix is to lower the requested number of trip patterns for one specific test scenario: Skansen (place) -> Melhus (place).