### PR TITLE
feat: add endpoint for looking the parent ID of a stop place

### DIFF
--- a/src/api/stop-places/index.ts
+++ b/src/api/stop-places/index.ts
@@ -45,7 +45,7 @@ export default (server: Hapi.Server) => (service: IStopPlacesService) => {
       tags: ['api', 'stop', 'parent'],
       validate: getStopPlaceParentRequest,
       description:
-        'Get stop place parent ID from a stop place ID, if the stop place ID is a parent, return itself',
+        'Get the parent ID of a stop place. If it has no parent, the provided stop ID will be returned instead',
     },
     handler: async (request, h) => {
       const query = request.query as unknown as StopPlaceParentQuery;

--- a/src/api/stop-places/index.ts
+++ b/src/api/stop-places/index.ts
@@ -2,10 +2,12 @@ import Hapi from '@hapi/hapi';
 import {IStopPlacesService} from '../../service/interface';
 import {
   getStopPlaceConnectionsRequest,
+  getStopPlaceParentRequest,
   getStopPlacesByModeRequest,
 } from './schema';
 import {
   StopPlaceConnectionsQuery,
+  StopPlaceParentQuery,
   StopPlacesByModeQuery,
 } from '../../service/types';
 
@@ -34,6 +36,20 @@ export default (server: Hapi.Server) => (service: IStopPlacesService) => {
     handler: async (request, h) => {
       const query = request.query as unknown as StopPlaceConnectionsQuery;
       return (await service.getStopPlaceConnections(query, h.request)).unwrap();
+    },
+  });
+  server.route({
+    method: 'GET',
+    path: '/bff/v2/stop-places/parent',
+    options: {
+      tags: ['api', 'stop', 'parent'],
+      validate: getStopPlaceParentRequest,
+      description:
+        'Get stop place parent ID from a stop place ID, if the stop place ID is a parent, return itself',
+    },
+    handler: async (request, h) => {
+      const query = request.query as unknown as StopPlaceParentQuery;
+      return (await service.getStopPlaceParent(query, h.request)).unwrap();
     },
   });
 };

--- a/src/api/stop-places/index.ts
+++ b/src/api/stop-places/index.ts
@@ -40,7 +40,7 @@ export default (server: Hapi.Server) => (service: IStopPlacesService) => {
   });
   server.route({
     method: 'GET',
-    path: '/bff/v2/stop-places/parent',
+    path: '/bff/v2/stop-places/parent-id',
     options: {
       tags: ['api', 'stop', 'parent'],
       validate: getStopPlaceParentRequest,

--- a/src/api/stop-places/schema.ts
+++ b/src/api/stop-places/schema.ts
@@ -1,6 +1,7 @@
 import Joi from 'joi';
 import {
   StopPlaceConnectionsQuery,
+  StopPlaceParentQuery,
   StopPlacesByModeQuery,
 } from '../../service/types';
 
@@ -18,5 +19,11 @@ export const getStopPlaceConnectionsRequest = {
     fromStopPlaceId: Joi.string().required(),
     transportModes: Joi.array().single().items(Joi.string()),
     transportSubmodes: Joi.array().single().items(Joi.string()),
+  }),
+};
+
+export const getStopPlaceParentRequest = {
+  query: Joi.object<StopPlaceParentQuery>({
+    fromStopPlaceId: Joi.string().required(),
   }),
 };

--- a/src/api/stop-places/schema.ts
+++ b/src/api/stop-places/schema.ts
@@ -24,6 +24,6 @@ export const getStopPlaceConnectionsRequest = {
 
 export const getStopPlaceParentRequest = {
   query: Joi.object<StopPlaceParentQuery>({
-    fromStopPlaceId: Joi.string().required(),
+    id: Joi.string().required(),
   }),
 };

--- a/src/service/impl/stop-places/index.ts
+++ b/src/service/impl/stop-places/index.ts
@@ -22,7 +22,7 @@ import {
 import {
   GetStopPlaceParentDocument,
   GetStopPlaceParentQuery,
-  GetStopPlaceParentQueryVariables
+  GetStopPlaceParentQueryVariables,
 } from './journey-gql/stop-place-parent.graphql-gen';
 
 export default (): IStopPlacesService => {

--- a/src/service/impl/stop-places/index.ts
+++ b/src/service/impl/stop-places/index.ts
@@ -19,7 +19,11 @@ import {
   TransportMode,
   TransportSubmode,
 } from '../../../graphql/journey/journeyplanner-types_v3';
-import { GetStopPlaceParentDocument, GetStopPlaceParentQuery, GetStopPlaceParentQueryVariables } from './journey-gql/stop-place-parent.graphql-gen';
+import {
+  GetStopPlaceParentDocument,
+  GetStopPlaceParentQuery,
+  GetStopPlaceParentQueryVariables
+} from './journey-gql/stop-place-parent.graphql-gen';
 
 export default (): IStopPlacesService => {
   return {

--- a/src/service/impl/stop-places/index.ts
+++ b/src/service/impl/stop-places/index.ts
@@ -111,18 +111,25 @@ export default (): IStopPlacesService => {
       >({
         query: GetStopPlaceParentDocument,
         variables: {
-          id: query.fromStopPlaceId,
+          id: query.id,
         },
       });
       if (result.errors) {
         return Result.err(new APIError(result.errors));
       }
       const parentStopPlaceId = result.data.stopPlace?.parent?.id;
+
+      // found parent stop ID
       if (parentStopPlaceId) {
         return Result.ok(parentStopPlaceId);
       }
 
-      return Result.ok(query.fromStopPlaceId);
+      // sent ID is parent stop place
+      if (result.data.stopPlace) {
+        return Result.ok(result.data.stopPlace?.id);
+      }
+
+      return Result.err(new Error('Invalid stop place ID'));
     },
   };
 };

--- a/src/service/impl/stop-places/index.ts
+++ b/src/service/impl/stop-places/index.ts
@@ -19,6 +19,7 @@ import {
   TransportMode,
   TransportSubmode,
 } from '../../../graphql/journey/journeyplanner-types_v3';
+import { GetStopPlaceParentDocument, GetStopPlaceParentQuery, GetStopPlaceParentQueryVariables } from './journey-gql/stop-place-parent.graphql-gen';
 
 export default (): IStopPlacesService => {
   return {
@@ -98,6 +99,26 @@ export default (): IStopPlacesService => {
       } catch (error) {
         return Result.err(new APIError(error));
       }
+    },
+    async getStopPlaceParent(query, headers) {
+      const result = await journeyPlannerClient(headers).query<
+        GetStopPlaceParentQuery,
+        GetStopPlaceParentQueryVariables
+      >({
+        query: GetStopPlaceParentDocument,
+        variables: {
+          id: query.fromStopPlaceId,
+        },
+      });
+      if (result.errors) {
+        return Result.err(new APIError(result.errors));
+      }
+      const parentStopPlaceId = result.data.stopPlace?.parent?.id;
+      if (parentStopPlaceId) {
+        return Result.ok(parentStopPlaceId);
+      }
+
+      return Result.ok(query.fromStopPlaceId);
     },
   };
 };

--- a/src/service/impl/stop-places/journey-gql/stop-place-parent.graphql
+++ b/src/service/impl/stop-places/journey-gql/stop-place-parent.graphql
@@ -1,0 +1,8 @@
+query getStopPlaceParent($id: String!) {
+  stopPlace(id: $id) {
+    id
+    parent {
+      id
+    }
+  }
+}

--- a/src/service/impl/stop-places/journey-gql/stop-place-parent.graphql-gen.ts
+++ b/src/service/impl/stop-places/journey-gql/stop-place-parent.graphql-gen.ts
@@ -1,0 +1,31 @@
+import * as Types from '../../../../graphql/journey/journeyplanner-types_v3';
+
+import { DocumentNode } from 'graphql';
+import gql from 'graphql-tag';
+export type GetStopPlaceParentQueryVariables = Types.Exact<{
+  id: Types.Scalars['String']['input'];
+}>;
+
+
+export type GetStopPlaceParentQuery = { stopPlace?: { id: string, parent?: { id: string } } };
+
+
+export const GetStopPlaceParentDocument = gql`
+    query getStopPlaceParent($id: String!) {
+  stopPlace(id: $id) {
+    id
+    parent {
+      id
+    }
+  }
+}
+    `;
+export type Requester<C = {}> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R> | AsyncIterable<R>
+export function getSdk<C>(requester: Requester<C>) {
+  return {
+    getStopPlaceParent(variables: GetStopPlaceParentQueryVariables, options?: C): Promise<GetStopPlaceParentQuery> {
+      return requester<GetStopPlaceParentQuery, GetStopPlaceParentQueryVariables>(GetStopPlaceParentDocument, variables, options) as Promise<GetStopPlaceParentQuery>;
+    }
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/src/service/interface.ts
+++ b/src/service/interface.ts
@@ -77,6 +77,7 @@ import {
   ViolationsReportQueryResult,
   ViolationsVehicleLookupQuery,
   ViolationsVehicleLookupQueryResult,
+  StopPlaceParentQuery,
 } from './types';
 import {APIError} from '../utils/api-error';
 import {Feature, Point} from 'geojson';
@@ -190,6 +191,10 @@ export interface IStopPlacesService {
     query: StopPlaceConnectionsQuery,
     headers: Request<ReqRefDefaults>,
   ): Promise<Result<StopPlaces, APIError>>;
+  getStopPlaceParent(
+    query: StopPlaceParentQuery,
+    headers: Request<ReqRefDefaults>,
+  ): Promise<Result<string, APIError>>;
 }
 
 export interface IEnrollmentService {

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -63,6 +63,10 @@ export interface StopPlaceConnectionsQuery {
   transportSubmodes?: TransportSubmode[];
 }
 
+export interface StopPlaceParentQuery {
+  fromStopPlaceId: string;
+}
+
 export type StopPlaces = Array<{
   name: string;
   id: string;

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -64,7 +64,7 @@ export interface StopPlaceConnectionsQuery {
 }
 
 export interface StopPlaceParentQuery {
-  fromStopPlaceId: string;
+  id: string;
 }
 
 export type StopPlaces = Array<{


### PR DESCRIPTION
part of https://github.com/AtB-AS/kundevendt/issues/18275

Adds an endpoint to look for parent stop place ID, we can then use the parent ID to look up the departure details in some stops, instead of using the current reverse geocoder API.

Endpoint : `/bff/v2/stop-places/parent`