### PR TITLE
feat: temporary flag to include ferry submode in stop places query

### DIFF
--- a/src/service/impl/stop-places/index.ts
+++ b/src/service/impl/stop-places/index.ts
@@ -28,6 +28,19 @@ import {
 export default (): IStopPlacesService => {
   return {
     async getStopPlacesByMode(query, headers) {
+      /**
+       * Temporary flag to include ferry submode in the stop places query
+       * so that we have an backward compatible way to show ferry stop places
+       * when buying express boat tickets in the Svipper app.
+       * This flag should be removed once we have enough users on app
+       * version > v1.56
+       */
+      if (
+        (!headers.appVersion || headers.appVersion <= '1.55') &&
+        process.env.INCLUDE_CAR_FERRY_SUBMODE_STOP_PLACES_QUERY === 'true'
+      ) {
+        query.transportSubmodes?.push(TransportSubmode.LocalCarFerry);
+      }
       const result = await journeyPlannerClient(headers).query<
         GetStopPlacesByModeQuery,
         GetStopPlacesByModeQueryVariables


### PR DESCRIPTION
This PR introduces a temporary flag to include the ferry submode in the stop places query. This change ensures backward compatibility for showing ferry stop places when buying express boat tickets in the Svipper app. This should be removed once we have enough users on the app version including the permanent solution: https://github.com/AtB-AS/mittatb-app/pull/4704. 

### Acceptance criteria
- [ ] Stop places for lines with transport sub mode `localCarFerry` are included in the result when the env-variable `INCLUDE_CAR_FERRY_SUBMODE_STOP_PLACES_QUERY` is set to true

Part of closing https://github.com/AtB-AS/kundevendt/issues/18966