### PR TITLE
chore: deprecate parent-id endpoint

### DIFF
--- a/src/api/stop-places/index.ts
+++ b/src/api/stop-places/index.ts
@@ -46,6 +46,11 @@ export default (server: Hapi.Server) => (service: IStopPlacesService) => {
       validate: getStopPlaceParentRequest,
       description:
         'Get the parent ID of a stop place. If it has no parent, the provided stop ID will be returned instead',
+      plugins: {
+        'hapi-swagger': {
+          deprecated: true,
+        },
+      },
     },
     handler: async (request, h) => {
       const query = request.query as unknown as StopPlaceParentQuery;


### PR DESCRIPTION
Following https://github.com/AtB-AS/mittatb-app/pull/4735, `/bff/v2/stop-places/parent-id` can be deprecated.