### PR TITLE
feat: Add app version checker plugin

### DIFF
--- a/src/plugins/__tests__/app-version-checker-plugin.test.ts
+++ b/src/plugins/__tests__/app-version-checker-plugin.test.ts
@@ -24,62 +24,73 @@ describe('appVersionCheckerPlugin', () => {
 
   it('should reject requests where app version is too low', async () => {
     process.env.MIN_APP_VERSION = '2.25';
-    let response = await doRequest(server, '1.1');
+    let response = await doRequest(server, '1.1', 'installId');
     expect(response.statusCode).toBe(426);
 
-    response = await doRequest(server, '0.5');
+    response = await doRequest(server, '0.5', 'installId');
     expect(response.statusCode).toBe(426);
 
-    response = await doRequest(server, '1.99');
+    response = await doRequest(server, '1.99', 'installId');
     expect(response.statusCode).toBe(426);
 
-    response = await doRequest(server, '2.0');
+    response = await doRequest(server, '2.0', 'installId');
     expect(response.statusCode).toBe(426);
 
-    response = await doRequest(server, '2.24.9');
+    response = await doRequest(server, '2.24.9', 'installId');
     expect(response.statusCode).toBe(426);
   });
 
   it('should allow requests where app version is higher or equal to the min app version', async () => {
     process.env.MIN_APP_VERSION = '2.25';
 
-    let response = await doRequest(server, '3.0');
+    let response = await doRequest(server, '3.0', 'installId');
     expect(response.statusCode).toBe(200);
 
-    response = await doRequest(server, '2.99');
+    response = await doRequest(server, '2.99', 'installId');
     expect(response.statusCode).toBe(200);
 
-    response = await doRequest(server, '2.26');
+    response = await doRequest(server, '2.26', 'installId');
     expect(response.statusCode).toBe(200);
 
-    response = await doRequest(server, '2.25.1');
+    response = await doRequest(server, '2.25.1', 'installId');
     expect(response.statusCode).toBe(200);
 
-    response = await doRequest(server, '2.25');
+    response = await doRequest(server, '2.25', 'installId');
     expect(response.statusCode).toBe(200);
   });
 
-  it('should allow requests if no client app version', async () => {
+  it('should allow requests if no client app version and no install id', async () => {
     process.env.MIN_APP_VERSION = '2.25';
 
-    let response = await doRequest(server, undefined);
+    let response = await doRequest(server, undefined, undefined);
     expect(response.statusCode).toBe(200);
+  });
+
+  it('should reject requests if no client app version and an install id', async () => {
+    process.env.MIN_APP_VERSION = '2.25';
+
+    let response = await doRequest(server, undefined, 'installId');
+    expect(response.statusCode).toBe(426);
   });
 
   it('should allow requests if no min app version', async () => {
     process.env.MIN_APP_VERSION = undefined;
 
-    let response = await doRequest(server, '3.0');
+    let response = await doRequest(server, '3.0', 'installId');
     expect(response.statusCode).toBe(200);
 
-    response = await doRequest(server, '0.1');
+    response = await doRequest(server, '0.1', 'installId');
     expect(response.statusCode).toBe(200);
   });
 });
 
-const doRequest = (server: Hapi.Server, appVersion: string | undefined) =>
+const doRequest = (
+  server: Hapi.Server,
+  appVersion: string | undefined,
+  installId: string | undefined,
+) =>
   server.inject({
     method: 'GET',
-    headers: {'atb-app-version': appVersion},
+    headers: {'atb-app-version': appVersion, 'atb-install-id': installId},
     url: '/',
   });

--- a/src/plugins/__tests__/app-version-checker-plugin.test.ts
+++ b/src/plugins/__tests__/app-version-checker-plugin.test.ts
@@ -41,19 +41,19 @@ describe('appVersionCheckerPlugin', () => {
   it('should reject requests where app version is too low', async () => {
     process.env.MIN_APP_VERSION = '2.25';
     let response = await doRequest({appVersion: '1.1'});
-    expect(response.statusCode).toBe(426);
+    expect(response.statusCode).toBe(406);
 
     response = await doRequest({appVersion: '0.5'});
-    expect(response.statusCode).toBe(426);
+    expect(response.statusCode).toBe(406);
 
     response = await doRequest({appVersion: '1.99'});
-    expect(response.statusCode).toBe(426);
+    expect(response.statusCode).toBe(406);
 
     response = await doRequest({appVersion: '2.0'});
-    expect(response.statusCode).toBe(426);
+    expect(response.statusCode).toBe(406);
 
     response = await doRequest({appVersion: '2.24.9'});
-    expect(response.statusCode).toBe(426);
+    expect(response.statusCode).toBe(406);
   });
 
   it('should allow requests where app version is higher or equal to the min app version', async () => {
@@ -83,7 +83,7 @@ describe('appVersionCheckerPlugin', () => {
     process.env.MIN_APP_VERSION = '2.25';
 
     let response = await doRequest({});
-    expect(response.statusCode).toBe(426);
+    expect(response.statusCode).toBe(406);
   });
 
   it('should allow requests if no min app version', async () => {

--- a/src/plugins/__tests__/app-version-checker-plugin.test.ts
+++ b/src/plugins/__tests__/app-version-checker-plugin.test.ts
@@ -5,10 +5,26 @@ import atbHeaders from '../atb-headers';
 describe('appVersionCheckerPlugin', () => {
   let server: Hapi.Server;
 
+  const doRequest = ({
+    appVersion,
+    webshopVersion,
+  }: {
+    appVersion?: string;
+    webshopVersion?: string;
+  }) =>
+    server.inject({
+      method: 'GET',
+      headers: {
+        'atb-app-version': appVersion,
+        'atb-webshop-version': webshopVersion,
+      },
+      url: '/',
+    });
+
   beforeAll(async () => {
     server = Hapi.server();
     await server.register(atbHeaders);
-    await server.register({plugin: appVersionCheckerPlugin});
+    await server.register(appVersionCheckerPlugin);
 
     // Sample route to test against
     server.route({
@@ -24,73 +40,59 @@ describe('appVersionCheckerPlugin', () => {
 
   it('should reject requests where app version is too low', async () => {
     process.env.MIN_APP_VERSION = '2.25';
-    let response = await doRequest(server, '1.1', 'installId');
+    let response = await doRequest({appVersion: '1.1'});
     expect(response.statusCode).toBe(426);
 
-    response = await doRequest(server, '0.5', 'installId');
+    response = await doRequest({appVersion: '0.5'});
     expect(response.statusCode).toBe(426);
 
-    response = await doRequest(server, '1.99', 'installId');
+    response = await doRequest({appVersion: '1.99'});
     expect(response.statusCode).toBe(426);
 
-    response = await doRequest(server, '2.0', 'installId');
+    response = await doRequest({appVersion: '2.0'});
     expect(response.statusCode).toBe(426);
 
-    response = await doRequest(server, '2.24.9', 'installId');
+    response = await doRequest({appVersion: '2.24.9'});
     expect(response.statusCode).toBe(426);
   });
 
   it('should allow requests where app version is higher or equal to the min app version', async () => {
     process.env.MIN_APP_VERSION = '2.25';
 
-    let response = await doRequest(server, '3.0', 'installId');
+    let response = await doRequest({appVersion: '3.0'});
     expect(response.statusCode).toBe(200);
 
-    response = await doRequest(server, '2.99', 'installId');
+    response = await doRequest({appVersion: '2.26'});
     expect(response.statusCode).toBe(200);
 
-    response = await doRequest(server, '2.26', 'installId');
+    response = await doRequest({appVersion: '2.25.1'});
     expect(response.statusCode).toBe(200);
 
-    response = await doRequest(server, '2.25.1', 'installId');
-    expect(response.statusCode).toBe(200);
-
-    response = await doRequest(server, '2.25', 'installId');
+    response = await doRequest({appVersion: '2.25'});
     expect(response.statusCode).toBe(200);
   });
 
-  it('should allow requests if no client app version and no install id', async () => {
+  it('should allow requests if no client app version and there is a webshop version', async () => {
     process.env.MIN_APP_VERSION = '2.25';
 
-    let response = await doRequest(server, undefined, undefined);
+    let response = await doRequest({webshopVersion: '2.0'});
     expect(response.statusCode).toBe(200);
   });
 
-  it('should reject requests if no client app version and an install id', async () => {
+  it('should reject requests if no client app version and no webshop version', async () => {
     process.env.MIN_APP_VERSION = '2.25';
 
-    let response = await doRequest(server, undefined, 'installId');
+    let response = await doRequest({});
     expect(response.statusCode).toBe(426);
   });
 
   it('should allow requests if no min app version', async () => {
     process.env.MIN_APP_VERSION = undefined;
 
-    let response = await doRequest(server, '3.0', 'installId');
+    let response = await doRequest({appVersion: '3.0'});
     expect(response.statusCode).toBe(200);
 
-    response = await doRequest(server, '0.1', 'installId');
+    response = await doRequest({appVersion: '0.1'});
     expect(response.statusCode).toBe(200);
   });
 });
-
-const doRequest = (
-  server: Hapi.Server,
-  appVersion: string | undefined,
-  installId: string | undefined,
-) =>
-  server.inject({
-    method: 'GET',
-    headers: {'atb-app-version': appVersion, 'atb-install-id': installId},
-    url: '/',
-  });

--- a/src/plugins/__tests__/app-version-checker-plugin.test.ts
+++ b/src/plugins/__tests__/app-version-checker-plugin.test.ts
@@ -1,0 +1,85 @@
+import Hapi from '@hapi/hapi';
+import appVersionCheckerPlugin from '../app-version-checker-plugin';
+import atbHeaders from '../atb-headers';
+
+describe('appVersionCheckerPlugin', () => {
+  let server: Hapi.Server;
+
+  beforeAll(async () => {
+    server = Hapi.server();
+    await server.register(atbHeaders);
+    await server.register({plugin: appVersionCheckerPlugin});
+
+    // Sample route to test against
+    server.route({
+      method: 'GET',
+      path: '/',
+      handler: (_, h) => h.response().code(200),
+    });
+  });
+
+  afterAll(async () => {
+    await server.stop();
+  });
+
+  it('should reject requests where app version is too low', async () => {
+    process.env.MIN_APP_VERSION = '2.25';
+    let response = await doRequest(server, '1.1');
+    expect(response.statusCode).toBe(426);
+
+    response = await doRequest(server, '0.5');
+    expect(response.statusCode).toBe(426);
+
+    response = await doRequest(server, '1.99');
+    expect(response.statusCode).toBe(426);
+
+    response = await doRequest(server, '2.0');
+    expect(response.statusCode).toBe(426);
+
+    response = await doRequest(server, '2.24.9');
+    expect(response.statusCode).toBe(426);
+  });
+
+  it('should allow requests where app version is higher or equal to the min app version', async () => {
+    process.env.MIN_APP_VERSION = '2.25';
+
+    let response = await doRequest(server, '3.0');
+    expect(response.statusCode).toBe(200);
+
+    response = await doRequest(server, '2.99');
+    expect(response.statusCode).toBe(200);
+
+    response = await doRequest(server, '2.26');
+    expect(response.statusCode).toBe(200);
+
+    response = await doRequest(server, '2.25.1');
+    expect(response.statusCode).toBe(200);
+
+    response = await doRequest(server, '2.25');
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('should allow requests if no client app version', async () => {
+    process.env.MIN_APP_VERSION = '2.25';
+
+    let response = await doRequest(server, undefined);
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('should allow requests if no min app version', async () => {
+    process.env.MIN_APP_VERSION = undefined;
+
+    let response = await doRequest(server, '3.0');
+    expect(response.statusCode).toBe(200);
+
+    response = await doRequest(server, '0.1');
+    expect(response.statusCode).toBe(200);
+  });
+});
+
+const doRequest = (server: Hapi.Server, appVersion: string | undefined) =>
+  server.inject({
+    method: 'GET',
+    headers: {'atb-app-version': appVersion},
+    url: '/',
+  });

--- a/src/plugins/app-version-checker-plugin.ts
+++ b/src/plugins/app-version-checker-plugin.ts
@@ -1,0 +1,33 @@
+import Hapi from '@hapi/hapi';
+import {compareVersion} from '../utils/compare-version';
+
+interface Options {}
+
+const plugin: Hapi.Plugin<Options> = {
+  dependencies: 'atb-headers',
+  name: 'app-version-checker-plugin',
+  register: (server) => {
+    server.ext('onPreHandler', (request, h) => {
+      const minAppVersion = process.env.MIN_APP_VERSION;
+      if (isAppVersionTooLow(request.appVersion, minAppVersion)) {
+        return h
+          .response({error: `Required client app version: ${minAppVersion}`})
+          .code(426)
+          .takeover();
+      }
+
+      return h.continue;
+    });
+  },
+};
+
+const isAppVersionTooLow = (
+  appVersion: string | undefined,
+  minAppVersion: string | undefined,
+): boolean => {
+  if (!appVersion) return false;
+  if (!minAppVersion) return false;
+  return compareVersion(minAppVersion, appVersion) > 0;
+};
+
+export default plugin;

--- a/src/plugins/app-version-checker-plugin.ts
+++ b/src/plugins/app-version-checker-plugin.ts
@@ -12,7 +12,7 @@ const plugin: Hapi.Plugin<Options> = {
       if (isAppVersionTooLow(request, minAppVersion)) {
         return h
           .response({error: `Required client app version: ${minAppVersion}`})
-          .code(426)
+          .code(406)
           .takeover();
       }
 

--- a/src/plugins/app-version-checker-plugin.ts
+++ b/src/plugins/app-version-checker-plugin.ts
@@ -9,7 +9,7 @@ const plugin: Hapi.Plugin<Options> = {
   register: (server) => {
     server.ext('onPreHandler', (request, h) => {
       const minAppVersion = process.env.MIN_APP_VERSION;
-      if (isAppVersionTooLow(request.appVersion, minAppVersion)) {
+      if (isAppVersionTooLow(request, minAppVersion)) {
         return h
           .response({error: `Required client app version: ${minAppVersion}`})
           .code(426)
@@ -22,12 +22,14 @@ const plugin: Hapi.Plugin<Options> = {
 };
 
 const isAppVersionTooLow = (
-  appVersion: string | undefined,
+  request: Hapi.Request,
   minAppVersion: string | undefined,
 ): boolean => {
-  if (!appVersion) return false;
+  const isRequestFromApp = !!request.installId;
+  if (!isRequestFromApp) return false;
   if (!minAppVersion) return false;
-  return compareVersion(minAppVersion, appVersion) > 0;
+  if (!request.appVersion) return true;
+  return compareVersion(minAppVersion, request.appVersion) > 0;
 };
 
 export default plugin;

--- a/src/plugins/app-version-checker-plugin.ts
+++ b/src/plugins/app-version-checker-plugin.ts
@@ -25,8 +25,8 @@ const isAppVersionTooLow = (
   request: Hapi.Request,
   minAppVersion: string | undefined,
 ): boolean => {
-  const isRequestFromApp = !!request.installId;
-  if (!isRequestFromApp) return false;
+  const isRequestFromWebshop = !!request.webshopVersion;
+  if (isRequestFromWebshop) return false;
   if (!minAppVersion) return false;
   if (!request.appVersion) return true;
   return compareVersion(minAppVersion, request.appVersion) > 0;

--- a/src/plugins/atb-headers.ts
+++ b/src/plugins/atb-headers.ts
@@ -12,6 +12,8 @@ const plugin: Hapi.Plugin<Options> = {
       request.headers['atb-request-id'];
     const appVersion = (request: Hapi.Request) =>
       request.headers['atb-app-version'];
+    const webshopVersion = (request: Hapi.Request) =>
+      request.headers['atb-webshop-version'];
     const correlationId = (request: Hapi.Request) =>
       request.headers['atb-correlation-id'] || uuid();
     const customerAccountId = (request: Hapi.Request) =>
@@ -19,6 +21,7 @@ const plugin: Hapi.Plugin<Options> = {
     server.decorate('request', 'installId', installId, {apply: true});
     server.decorate('request', 'requestId', requestId, {apply: true});
     server.decorate('request', 'appVersion', appVersion, {apply: true});
+    server.decorate('request', 'webshopVersion', webshopVersion, {apply: true});
     server.decorate('request', 'correlationId', correlationId, {apply: true});
     server.decorate('request', 'customerAccountId', customerAccountId, {
       apply: true,

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import hapiApiVersion from 'hapi-api-version';
 
 import logFmtPlugin from './plugins/logfmt';
 import atbHeaders from './plugins/atb-headers';
+import appVersionCheckerPlugin from './plugins/app-version-checker-plugin';
 import url from 'url';
 import Redis from '@hapi/catbox-redis';
 import Memory from '@hapi/catbox-memory';
@@ -57,9 +58,8 @@ export const createServer = (opts: ServerOptions) => {
 };
 
 export const initializePlugins = async (server: hapi.Server) => {
-  await server.register({
-    plugin: atbHeaders,
-  });
+  await server.register({plugin: atbHeaders});
+  await server.register({plugin: appVersionCheckerPlugin});
   await server.register({
     plugin: logFmtPlugin,
     options: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -71,6 +71,7 @@ export const initializePlugins = async (server: hapi.Server) => {
         url: url.format(request.url, {search: false}),
         requestId: request.requestId,
         installId: request.installId,
+        webshopVersion: request.webshopVersion,
         appVersion: request.appVersion,
         correlationId: request.correlationId,
         customerAccountId: request.customerAccountId,

--- a/src/types/atb-headers.d.ts
+++ b/src/types/atb-headers.d.ts
@@ -6,6 +6,7 @@ declare module '@hapi/hapi' {
     installId?: string;
     requestId?: string;
     appVersion?: string;
+    webshopVersion?: string;
     correlationId?: string;
     customerAccountId?: string;
   }

--- a/src/utils/__tests__/compare-version.test.ts
+++ b/src/utils/__tests__/compare-version.test.ts
@@ -1,0 +1,44 @@
+import {compareVersion} from '../compare-version';
+
+describe('Function compareVersion', () => {
+  const versions: [string, string, number][] = [
+    // first version is greater
+    ['1.2', '1.1', 1],
+    ['1.1.1', '1.1', 1],
+    ['1.100.1', '1.1', 1],
+    ['1.3.0', '1.2.3', 1],
+    ['2.0.3', '1.2.0', 1],
+    ['2.1', '1.1.1', 1],
+    ['2.3.1', '2.1.2', 1],
+    ['2.1.1', '2.0.2', 1],
+    ['2.0.0', '1.2.3', 1],
+    ['2.1', '1.1', 1],
+    // second version is greater
+    ['1.4', '1.31', -1],
+    ['1.4.1', '1.31.1', -1],
+    ['1.1', '1.1.1', -1],
+    ['1.1', '2.1', -1],
+    ['1.2.3', '1.2.4', -1],
+    ['1.2.0', '1.2.1', -1],
+    ['1.2.3', '2.0.0', -1],
+    // same version
+    ['1.2', '1.2.0', 0],
+    ['1.2.0', '1.2', 0],
+    ['1.1', '1.1', 0],
+    ['1', '1', 0],
+    // empty strings
+    ['', '1.0.0', NaN],
+    ['1.2.0', '', NaN],
+    ['', '', NaN],
+    // edge cases
+    ['0.0.0', '0.0.0', 0],
+    ['0.0.0', '0.0.1', -1],
+    ['0.0.1', '0.0.0', 1],
+  ];
+
+  versions.forEach(([versionA, versionB, expected]) => {
+    it(`correctly compares ${versionA} and ${versionB}`, () => {
+      expect(compareVersion(versionA, versionB)).toBe(expected);
+    });
+  });
+});

--- a/src/utils/compare-version.ts
+++ b/src/utils/compare-version.ts
@@ -1,0 +1,30 @@
+/**
+ * Compares two app version strings in major.minor.patch format. Will return 1
+ * if first argument is greater, 0 if they are equal and -1 if the second
+ * argument is greater. If some of the strings are empty, NaN will be returned.
+ */
+export function compareVersion(versionA: string, versionB: string) {
+  if (!versionA || !versionB) return NaN;
+
+  const maxLength = Math.max(versionA.length, versionB.length);
+
+  const splitAndNormalize = (version: string) => {
+    const parts = version.split('.').map(Number);
+    // Normalize to 3 parts by adding zeros if necessary
+    while (parts.length < maxLength) {
+      parts.push(0);
+    }
+    return parts;
+  };
+
+  const vA = splitAndNormalize(versionA);
+  const vB = splitAndNormalize(versionB);
+
+  // Compare each component
+  for (let i = 0; i < maxLength; i++) {
+    if (vA[i] > vB[i]) return 1; // versionA is greater
+    if (vA[i] < vB[i]) return -1; // versionB is greater
+  }
+
+  return 0; // versions are equal
+}

--- a/src/utils/log-response.ts
+++ b/src/utils/log-response.ts
@@ -61,6 +61,7 @@ export const logResponse = ({
     code: statusCode,
     requestId: requestHeaders['requestId'],
     installId: requestHeaders['installId'],
+    webshopVersion: requestHeaders['webshopVersion'],
     appVersion: requestHeaders['appVersion'],
     customerAccountId: customerAccountId,
     rateLimitUsed: rateLimitUsed,


### PR DESCRIPTION
If a MIN_APP_VERSION env variable is set, then all incoming requests
with app version in http header (atb-app-version) lower than the
minimum is rejected with status code 426 Upgrade Required.
