### PR TITLE
fix: Polyline endpoint fail without cache

### DIFF
--- a/src/api/servicejourney/index.ts
+++ b/src/api/servicejourney/index.ts
@@ -52,10 +52,10 @@ export function serviceJourneyRoutes_v2(server: Hapi.Server) {
           },
         },
       },
-      handler: async (request) => {
+      handler: async (request, h) => {
         const {id} = request.params;
         const query = request.query as unknown as ServiceJourneyMapInfoQuery;
-        return server.methods.getServiceJourneyMapInfo_v2(id, query);
+        return server.methods.getServiceJourneyMapInfo_v2(id, query, h.request);
       },
     });
 
@@ -67,10 +67,10 @@ export function serviceJourneyRoutes_v2(server: Hapi.Server) {
         validate: getServiceJourneyMapDataRequest,
         description: 'Get departures for Service Journey',
       },
-      handler: async (request) => {
+      handler: async (request, h) => {
         const {id} = request.params;
         const query = request.query as unknown as ServiceJourneyMapInfoQuery;
-        return server.methods.getServiceJourneyMapInfo_v2(id, query);
+        return server.methods.getServiceJourneyMapInfo_v2(id, query, h.request);
       },
     });
 


### PR DESCRIPTION
### Background
Error "Cannot read properties of undefined (reading 'correlationId')" when using the polyline endpoint with no cache set.

```json
{
  "time": "2024-11-12T08:54:51.646Z",
  "method": "GET",
  "url": "http://atb-prod.api.mittatb.no/bff/v2/servicejourney/ATB:ServiceJourney:1_240229121417009_73/polyline",
  "requestId": "8bec0eb8-7250-4eba-8c07-5ae67846ddc8",
  "installId": "92f54197-0724-441c-83d2-1773a2779a16",
  "appVersion": "1.58",
  "correlationId": "57eaa696-13bd-4da4-a998-f5bb67d8040f",
  "message": "handle request",
  "fromQuayId": "NSR:Quay:102721",
  "error": "Cannot read properties of undefined (reading 'correlationId')",
  "code": "500",
  "severity": "ERROR",
  "duration": "2ms"
}
```

### Solution
The polyline server method has a third parameter
'headers: Request<ReqRefDefaults>', but this third parameter wasn't
provided when invoking the server method from the api endpoint. So
the third parameter was actually resolved to the cache config
which hapi behind the scenes provide as an extra parameter to the
server method invocation. When no cache was set, this parameter was
undefined, which would give an error later in the request handling
in the bff.

### Acceptance criteria
- [ ] Polyline (map lines) endpoint works even if no cache set (ttl set to `0`). Url `bff/v2/servicejourney/{id}/polyline`.
