### PR TITLE
feat: allow requests with no appVersion header

### DIFF
--- a/src/plugins/__tests__/app-version-checker-plugin.test.ts
+++ b/src/plugins/__tests__/app-version-checker-plugin.test.ts
@@ -88,11 +88,11 @@ describe('appVersionCheckerPlugin', () => {
     expect(response.statusCode).toBe(200);
   });
 
-  it('should reject requests if no client app version and no webshop version', async () => {
+  it('should allow requests if no client app version and no webshop version', async () => {
     process.env.MIN_APP_VERSION = '2.25';
 
     let response = await doRequest({});
-    expect(response.statusCode).toBe(406);
+    expect(response.statusCode).toBe(200);
   });
 
   it('should allow requests if no min app version', async () => {
@@ -105,10 +105,10 @@ describe('appVersionCheckerPlugin', () => {
     expect(response.statusCode).toBe(200);
   });
 
-  it('should not reject on health endpoint even if no client app version and no webshop version', async () => {
+  it('should not reject on health endpoint even if app version is below min app version', async () => {
     process.env.MIN_APP_VERSION = '2.25';
 
-    let response = await doRequest({url: '/health'});
+    let response = await doRequest({url: '/health', appVersion: '1.1'});
     expect(response.statusCode).toBe(200);
   });
 });

--- a/src/plugins/app-version-checker-plugin.ts
+++ b/src/plugins/app-version-checker-plugin.ts
@@ -31,7 +31,7 @@ const isAppVersionTooLow = (
   const isRequestFromWebshop = !!request.webshopVersion;
   if (isRequestFromWebshop) return false;
   if (!minAppVersion) return false;
-  if (!request.appVersion) return true;
+  if (!request.appVersion) return false;
   return compareVersion(minAppVersion, request.appVersion) > 0;
 };
 


### PR DESCRIPTION
Allows requests with no app version to prevent the widget from breaking. Also allows requests from app versions <1.24, (since they don't set the appVersion header) but since it's such a low amount of users, it's better than breaking the widget.

ref. https://mittatb.slack.com/archives/C0116FMPX4Y/p1732006029514839
