### PR TITLE
feat: Disable the Apollo Client cache

### DIFF
--- a/src/graphql/graphql-client.ts
+++ b/src/graphql/graphql-client.ts
@@ -1,5 +1,5 @@
 /* eslint no-console: 0 */
-import {InMemoryCache, NormalizedCacheObject} from '@apollo/client/cache';
+import {InMemoryCache} from '@apollo/client/cache';
 import {
   ApolloClient,
   DefaultOptions,
@@ -48,7 +48,9 @@ const urlVehiclesWss = ENTUR_WEBSOCKET_BASEURL
   : 'wss://api.entur.io/realtime/v1/vehicles/subscriptions';
 
 function createClient(url: string) {
-  const cache = new InMemoryCache();
+  // The possibleTypes is empty to disable the in-memory cache
+  const cache = new InMemoryCache({possibleTypes: {}});
+
   return function (headers: Request<ReqRefDefaults>) {
     const httpLink = new HttpLink({
       uri: url,
@@ -149,5 +151,3 @@ export const journeyPlannerClient = createClient(urlJourneyPlanner);
 export const mobilityClient = createClient(urlMobility);
 export const vehiclesClient = createClient(urlVehicles);
 export const vehiclesSubscriptionClient = createWebSocketClient(urlVehiclesWss);
-
-export type GraphQLClient = ApolloClient<NormalizedCacheObject>;

--- a/src/service/impl/departures-grouped/departure-favorites.ts
+++ b/src/service/impl/departures-grouped/departure-favorites.ts
@@ -4,7 +4,6 @@ import {journeyPlannerClient} from '../../../graphql/graphql-client';
 import {CursoredData, generateCursorData} from '../../cursored';
 import {DepartureFavoritesQuery, FavoriteDeparture} from '../../types';
 import {APIError} from '../../../utils/api-error';
-import {populateRealtimeCacheIfNotThere} from '../realtime/departure-time';
 import {
   GroupsByIdDocument,
   GroupsByIdQuery,
@@ -31,22 +30,6 @@ export async function getDepartureFavorites(
     filterByLineIds: favorites?.map((f) => f.lineId),
     includeCancelledTrips: options.includeCancelledTrips,
   };
-
-  const quayIds = union(favorites?.map((f) => f.quayId)).filter(
-    Boolean,
-  ) as string[];
-  const lineIds = union(favorites?.map((f) => f.lineId));
-  // Fire and forget population of cache. Not critial if it fails.
-  populateRealtimeCacheIfNotThere(
-    {
-      limit: 100,
-      startTime: options.startTime,
-      limitPerLine: options.limitPerLine,
-      quayIds,
-      lineIds,
-    },
-    headers,
-  );
 
   const result = await journeyPlannerClient(headers).query<
     GroupsByIdQuery,

--- a/src/service/impl/departures-grouped/departure-group.ts
+++ b/src/service/impl/departures-grouped/departure-group.ts
@@ -42,9 +42,6 @@ export async function getDeparturesGroupedNearest(
       variables: {
         stopIds: favorites.map((f) => f.stopId),
       },
-      // With fetch policy set to `cache-first`, apollo client will return data
-      // from the cache, or fetch new data and populate the cache.
-      fetchPolicy: 'cache-first',
     });
 
     if (quayIdsResult.errors) {

--- a/src/service/impl/departures/index.ts
+++ b/src/service/impl/departures/index.ts
@@ -22,7 +22,6 @@ import {
   filterFavoriteDepartures,
 } from './utils/favorites';
 import * as Boom from '@hapi/boom';
-import {populateRealtimeCacheIfNotThere} from '../realtime/departure-time';
 import {
   DeparturesDocument,
   DeparturesQuery,
@@ -63,19 +62,6 @@ export default (): IDeparturesService => {
               limitPerLine,
               numberOfDepartures,
             };
-
-        // Fire and forget population of cache. Not critial if it fails.
-        populateRealtimeCacheIfNotThere(
-          {
-            quayIds,
-            startTime,
-            lineIds,
-            limit: limit.numberOfDepartures,
-            limitPerLine: limit.limitPerLine,
-            timeRange,
-          },
-          headers,
-        );
 
         const result = await journeyPlannerClient(headers).query<
           DeparturesQuery,
@@ -209,22 +195,6 @@ export default (): IDeparturesService => {
             ...limit,
           },
         });
-
-        const quayIds = result.data.stopPlace?.quays?.map((q) => q.id);
-        if (quayIds) {
-          // Fire and forget population of cache. Not critial if it fails.
-          populateRealtimeCacheIfNotThere(
-            {
-              quayIds,
-              startTime,
-              lineIds,
-              limit: limit.numberOfDepartures,
-              limitPerLine: limit.limitPerLine,
-              timeRange,
-            },
-            headers,
-          );
-        }
 
         if (result.errors) {
           return Result.err(new APIError(result.errors));

--- a/src/service/impl/realtime/__tests__/sanitize-realtime-query.test.ts
+++ b/src/service/impl/realtime/__tests__/sanitize-realtime-query.test.ts
@@ -1,0 +1,38 @@
+import {sanitizeRealtimeQuery} from '../sanitize-realtime-query';
+import type {DepartureRealtimeQuery} from '../../../types';
+import {addHours, addMinutes} from 'date-fns';
+
+const createQuery = (startTime: Date): DepartureRealtimeQuery => ({
+  quayIds: [],
+  limit: 10,
+  startTime,
+});
+
+describe('sanitizeRealtimeQuery', () => {
+  it('When start time is now the sanitized start time should be unchanged and time range should be 30 minutes', () => {
+    const startTime = new Date();
+    const sanitized = sanitizeRealtimeQuery(createQuery(startTime));
+    expect(sanitized?.startTime.getTime()).toBeCloseTo(startTime.getTime(), 5);
+    expect(sanitized?.timeRange).toBeCloseTo(1800, 1);
+  });
+
+  it('When start time is in the past the sanitized start time should be now and time range should be 30 minutes', () => {
+    const startTime = addHours(new Date(), -2);
+    const sanitized = sanitizeRealtimeQuery(createQuery(startTime));
+    expect(sanitized?.startTime.getTime()).toBeCloseTo(new Date().getTime(), 5);
+    expect(sanitized?.timeRange).toBeCloseTo(1800, 1);
+  });
+
+  it('When start time is 15 minutes in the future the sanitized start time should be unchanged and time range should be 15 minutes', () => {
+    const startTime = addMinutes(new Date(), 15);
+    const sanitized = sanitizeRealtimeQuery(createQuery(startTime));
+    expect(sanitized?.startTime.getTime()).toBeCloseTo(startTime.getTime(), 5);
+    expect(sanitized?.timeRange).toBeCloseTo(900, 1);
+  });
+
+  it('When start time is 45 minutes in the future the sanitized query should be undefined', () => {
+    const startTime = addMinutes(new Date(), 45);
+    const sanitized = sanitizeRealtimeQuery(createQuery(startTime));
+    expect(sanitized).toBeUndefined();
+  });
+});

--- a/src/service/impl/realtime/__tests__/sanitize-realtime-query.test.ts
+++ b/src/service/impl/realtime/__tests__/sanitize-realtime-query.test.ts
@@ -12,22 +12,34 @@ describe('sanitizeRealtimeQuery', () => {
   it('When start time is now the sanitized start time should be unchanged and time range should be 30 minutes', () => {
     const startTime = new Date();
     const sanitized = sanitizeRealtimeQuery(createQuery(startTime));
-    expect(sanitized?.startTime.getTime()).toBeCloseTo(startTime.getTime(), 5);
-    expect(sanitized?.timeRange).toBeCloseTo(1800, 1);
+
+    expect(sanitized?.timeRange).toBeDefined();
+    expect(
+      diff(sanitized!.startTime.getTime(), startTime.getTime()),
+    ).toBeLessThan(5);
+    expect(diff(sanitized!.timeRange, 1800)).toBeLessThanOrEqual(1);
   });
 
   it('When start time is in the past the sanitized start time should be now and time range should be 30 minutes', () => {
     const startTime = addHours(new Date(), -2);
     const sanitized = sanitizeRealtimeQuery(createQuery(startTime));
-    expect(sanitized?.startTime.getTime()).toBeCloseTo(new Date().getTime(), 5);
-    expect(sanitized?.timeRange).toBeCloseTo(1800, 1);
+
+    expect(sanitized?.timeRange).toBeDefined();
+    expect(
+      diff(sanitized!.startTime.getTime(), new Date().getTime()),
+    ).toBeLessThan(5);
+    expect(diff(sanitized!.timeRange, 1800)).toBeLessThanOrEqual(1);
   });
 
   it('When start time is 15 minutes in the future the sanitized start time should be unchanged and time range should be 15 minutes', () => {
     const startTime = addMinutes(new Date(), 15);
     const sanitized = sanitizeRealtimeQuery(createQuery(startTime));
-    expect(sanitized?.startTime.getTime()).toBeCloseTo(startTime.getTime(), 5);
-    expect(sanitized?.timeRange).toBeCloseTo(900, 1);
+
+    expect(sanitized?.timeRange).toBeDefined();
+    expect(
+      diff(sanitized!.startTime.getTime(), startTime.getTime()),
+    ).toBeLessThan(5);
+    expect(diff(sanitized!.timeRange, 900)).toBeLessThanOrEqual(1);
   });
 
   it('When start time is 45 minutes in the future the sanitized query should be undefined', () => {
@@ -36,3 +48,5 @@ describe('sanitizeRealtimeQuery', () => {
     expect(sanitized).toBeUndefined();
   });
 });
+
+const diff = (v1: number, v2: number) => Math.abs(v1 - v2);

--- a/src/service/impl/realtime/departure-time.ts
+++ b/src/service/impl/realtime/departure-time.ts
@@ -1,73 +1,16 @@
-import {journeyPlannerClient} from '../../../graphql/graphql-client';
-import {
-  DepartureRealtimeData,
-  DepartureRealtimeQuery,
-  DeparturesRealtimeData,
-} from '../../types';
+import {DepartureRealtimeData, DeparturesRealtimeData} from '../../types';
 import {
   EstimatedCallFragment,
-  GetDepartureRealtimeDocument,
   GetDepartureRealtimeQuery,
-  GetDepartureRealtimeQueryVariables,
 } from './journey-gql/departure-time.graphql-gen';
-import {ReqRefDefaults, Request} from '@hapi/hapi';
-
-export const createVariables = (
-  query: DepartureRealtimeQuery,
-): GetDepartureRealtimeQueryVariables => ({
-  ...query,
-  timeRange: query.timeRange ?? 86400,
-});
-
-/**
- * Trigger realtime fetch to populate cache for the query, reducing the amount
- * of data for the initial realtime query. Can be fire-and-forget, as it's not
- * critical if the cache is empty.
- *
- * To get a cache hit, `inputQuery` needs to match the query for the subsequent
- * realtime request.
- */
-export async function populateRealtimeCacheIfNotThere(
-  inputQuery: DepartureRealtimeQuery,
-  headers: Request<ReqRefDefaults>,
-) {
-  try {
-    const variables = createVariables(inputQuery);
-    const previousResult = getPreviousExpectedFromCache(variables, headers);
-
-    if (previousResult) return;
-
-    await journeyPlannerClient(headers).query<
-      GetDepartureRealtimeQuery,
-      GetDepartureRealtimeQueryVariables
-    >({
-      query: GetDepartureRealtimeDocument,
-      variables,
-      // With fetch policy set to `cache-first`, apollo client will return data
-      // from the cache, or fetch new data and populate the cache.
-      fetchPolicy: 'cache-first',
-    });
-  } catch (e) {}
-}
-
-type PreviousDepartureTimeLookupService = {
-  [serviceJourneyId: string]: {time: string; realtime: boolean};
-};
-type PreviousDepartureTimeLookup = {
-  [quayId: string]: PreviousDepartureTimeLookupService;
-};
 
 export function mapToDepartureRealtime(
   input: GetDepartureRealtimeQuery,
-  previousResultLookup?: PreviousDepartureTimeLookup,
 ): DeparturesRealtimeData {
   let obj: DeparturesRealtimeData = {};
   for (let quay of input.quays) {
     if (!quay) continue;
-    const departures = mapDeparture(
-      quay.estimatedCalls,
-      previousResultLookup?.[quay.id],
-    );
+    const departures = mapDeparture(quay.estimatedCalls);
 
     // Don't include if the result is empty. Save data and easier to see if there are updates.
     if (!Object.keys(departures).length) {
@@ -82,23 +25,10 @@ export function mapToDepartureRealtime(
   return obj;
 }
 
-function mapDeparture(
-  input: EstimatedCallFragment[],
-  previousResultLookup?: PreviousDepartureTimeLookupService,
-) {
+function mapDeparture(input: EstimatedCallFragment[]) {
   let obj: DepartureRealtimeData['departures'] = {};
   for (let departure of input) {
     const serviceJourneyId = departure.serviceJourney!.id;
-    const previousData = previousResultLookup?.[serviceJourneyId];
-
-    // Only include if new time is different than previous time.
-    // This is to reduce unneccesary data
-    if (
-      previousData?.time === departure.expectedDepartureTime &&
-      previousData?.realtime === departure.realtime
-    ) {
-      continue;
-    }
 
     obj[serviceJourneyId] = {
       serviceJourneyId,
@@ -110,41 +40,4 @@ function mapDeparture(
     };
   }
   return obj;
-}
-
-export function getPreviousExpectedFromCache(
-  variables: GetDepartureRealtimeQueryVariables,
-  headers: Request<ReqRefDefaults>,
-) {
-  try {
-    const result = journeyPlannerClient(headers).readQuery<
-      GetDepartureRealtimeQuery,
-      GetDepartureRealtimeQueryVariables
-    >({
-      query: GetDepartureRealtimeDocument,
-      variables,
-    });
-    if (!result) return undefined;
-
-    return mapToPreviousResultsHash(result);
-  } catch (e) {
-    // Nothing in the cache.
-    return undefined;
-  }
-}
-
-function mapToPreviousResultsHash(input: GetDepartureRealtimeQuery) {
-  let previousExpectedDepartureTimeLookup: PreviousDepartureTimeLookup = {};
-  for (let quay of input.quays) {
-    const quayId = quay.id;
-    previousExpectedDepartureTimeLookup[quayId] = {};
-    for (let departure of quay.estimatedCalls) {
-      const serviceJourneyId = departure.serviceJourney!.id;
-      previousExpectedDepartureTimeLookup[quayId][serviceJourneyId] = {
-        time: departure.expectedDepartureTime,
-        realtime: departure.realtime ?? false,
-      };
-    }
-  }
-  return previousExpectedDepartureTimeLookup;
 }

--- a/src/service/impl/realtime/sanitize-realtime-query.ts
+++ b/src/service/impl/realtime/sanitize-realtime-query.ts
@@ -1,0 +1,24 @@
+import type {DepartureRealtimeQuery} from '../../types';
+import type {GetDepartureRealtimeQueryVariables} from './journey-gql/departure-time.graphql-gen';
+import {addMinutes, differenceInSeconds, isAfter} from 'date-fns';
+
+const REALTIME_MINUTES = 30;
+
+/**
+ * Sanitize the input query to get the correct time range for the realtime
+ * updates, since we should only fetch updates which are between now and 30
+ * minutes in the feature.
+ *
+ * Undefined is returned if the input start time is more than 30 minutes in the
+ * future, which signals that no realtime updates should be fetched.
+ */
+export const sanitizeRealtimeQuery = (
+  query: DepartureRealtimeQuery,
+): GetDepartureRealtimeQueryVariables | undefined => {
+  const now = new Date();
+  const startTime = isAfter(query.startTime, now) ? query.startTime : now;
+  const realtimeWindowEnd = addMinutes(now, REALTIME_MINUTES);
+  const timeRange = differenceInSeconds(realtimeWindowEnd, startTime);
+
+  return timeRange > 0 ? {...query, startTime, timeRange} : undefined;
+};

--- a/src/service/impl/service-journey/service-journey.ts
+++ b/src/service/impl/service-journey/service-journey.ts
@@ -24,7 +24,6 @@ export async function getMapInfoWithFromQuay(
   >({
     query: MapInfoWithFromQuayV2Document,
     variables,
-    fetchPolicy: 'cache-first',
   });
   return result;
 }
@@ -46,7 +45,6 @@ export async function getMapInfoWithFromAndToQuay(
   >({
     query: MapInfoWithFromAndToQuayV2Document,
     variables,
-    fetchPolicy: 'cache-first',
   });
   return result;
 }


### PR DESCRIPTION
The theory is that the Apollo Client cache is the reason why we are
seeing a large memory usage in prod. Also the client doesn't make as
much sense when we have multiple BFF instances running in prod.

The main usage for the Apollo Client cache was to cache the previous
result for realtime updates, so only calls that were actually
updated could be returned. This is now changed to only return
updates for calls up to 30 minutes in the future, and no usage of
cache.

Here are some results of testing the realtime endpoint with old and new BFF where the new BFF does not use Apollo client cache, but instead restrict realtime updates to the next 30 minutes. 

The test was done around 10:30 AM a normal weekday.

| Case | Old BFF | New BFF |
| --- | --- | --- |
| Departures screen: P1 with date now | ~9 updates | ~20 updates |
| Front page: Multiple favorites | ~7 updates | ~15 updates | 

In summary it seems that the new BFF returns around double the updates, but luckily still fairly low numbers so it shouldn't be a too high increase for the user with regards to mobile data usage.
