### PR TITLE
test: handle holidays in api tests

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -12,33 +12,34 @@ on:
         description: 'Specify URL to run tests against'
         required: true
         default: 'https://atb-staging.api.mittatb.no'
+      branch:
+        description: 'Run against a special branch'
+        required: true
+        default: 'main'
       waitSeconds:
         description: 'Seconds to wait before test run'
         required: true
-        default: '0'
+        default: '300'
 
 jobs:
   api-test:
     name: API-tests
     runs-on: ubuntu-latest
-    # As default, wait 0 sec for manual triggered and 300 sec for push (wait for new deploy)
-    steps:
-      - name: Set variables
-        env:
-          DEFAULT_URL: 'https://atb-staging.api.mittatb.no'
-          DEFAULT_WAIT_SECONDS: '300'
-        run: |
-          echo "INPUT_URL=${{ github.event.inputs.url || env.DEFAULT_URL }}" >> $GITHUB_ENV
-          echo "INPUT_WAIT_SECONDS=${{ github.event.inputs.waitSeconds || env.DEFAULT_WAIT_SECONDS }}" >> $GITHUB_ENV
+    env:
+      ENV_URL: ${{ github.event.inputs.url || 'https://atb-staging.api.mittatb.no' }}
+      ENV_BRANCH: ${{ github.event.inputs.branch || 'main' }}
+      ENV_WAIT_SECONDS: ${{ github.event.inputs.waitSeconds || '300' }}
 
+    steps:
+      # As default, wait 0 sec for manual triggered and 300 sec for push (wait for new deploy)
       - name: Sleep given seconds to wait for deploy
-        run: sleep ${{ env.INPUT_WAIT_SECONDS }}s
+        run: sleep ${{ env.ENV_WAIT_SECONDS }}s
         shell: bash
 
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ env.ENV_BRANCH }}
 
       - name: Install k6
         run: |
@@ -58,7 +59,7 @@ jobs:
           cd test && yarn webpack
 
       - name: Run API tests
-        run: ./k6 run test/dist/k6.js --env host=${{ env.INPUT_URL }} --env runFrom=root --log-output=stdout --log-format=raw | tee test/dist/results/junitLog.txt
+        run: ./k6 run test/dist/k6.js --env host=${{ env.ENV_URL }} --env runFrom=root --log-output=stdout --log-format=raw | tee test/dist/results/junitLog.txt
 
       - name: Create JUnit from checks
         run: python python-tools/apiCheckToJUnit/apiCheckToJUnit.py --file junitLog.txt --folder dist/results
@@ -76,5 +77,5 @@ jobs:
           retention-days: 5
 
       - name: Re-run API tests
-        run: ./k6 run test/dist/k6.js --env host=${{ env.INPUT_URL }} --env runFrom=root --env printJUnit=false --quiet
+        run: ./k6 run test/dist/k6.js --env host=${{ env.ENV_URL }} --env runFrom=root --env printJUnit=false --quiet
 

--- a/test/src/utils/utils.ts
+++ b/test/src/utils/utils.ts
@@ -104,6 +104,40 @@ export const arrivesBeforeExpectedEndTime = (
   return true;
 };
 
+// List of holidays, i.e. days with either routes as a Saturday or a Sunday
+const holidays = [
+  '2024-12-24',
+  '2024-12-25',
+  '2024-12-26',
+  '2024-12-27',
+  '2024-12-28',
+  '2024-12-29',
+  '2024-12-30',
+  '2024-12-31',
+  '2025-01-01',
+  '2025-04-16',
+  '2025-04-17',
+  '2025-04-18',
+  '2025-04-21',
+  '2025-05-01',
+  '2025-05-29',
+  '2025-06-09',
+  '2025-12-24',
+  '2025-12-25',
+  '2025-12-26',
+  '2025-12-27',
+  '2025-12-28',
+  '2025-12-29',
+  '2025-12-30',
+  '2025-12-31',
+  '2026-01-01',
+];
+
+// Check if a given date is a holiday (format YYYY-MM-DD)
+const isHoliday = (testDate: string): boolean => {
+  return holidays.includes(testDate);
+};
+
 // Return a day the following week as a date - to be used in search
 // E.g. weekday: 4 = Thursday
 export const getDayNextWeek = (weekday: number): string => {
@@ -111,6 +145,10 @@ export const getDayNextWeek = (weekday: number): string => {
   const increaseDays = weekday - today.getDay() + 7;
   today.setDate(today.getDate() + increaseDays);
 
+  // Check if date is holiday - IF: Increase with a week to get same week day
+  while (isHoliday(today.toISOString().split('T')[0])) {
+    today.setDate(today.getDate() + 7);
+  }
   return today.toISOString().split('T')[0];
 };
 

--- a/test/src/v2/departures/departures.ts
+++ b/test/src/v2/departures/departures.ts
@@ -15,7 +15,7 @@ export function departures(
 ) {
   const requestName = 'v2_departures';
   const quayIdParams = quayIds.join('&ids=');
-  const url = `${conf.host()}/bff/v2/departures/departures?ids=${quayIdParams}&numberOfDepartures=${limit}&startTime=${startDate}T00:00:00.000Z&timeRange=${timeRange}`;
+  const url = `${conf.host()}/bff/v2/departures/departures?ids=${quayIdParams}&numberOfDepartures=${limit}&startTime=${startDate}T03:00:00.000Z&timeRange=${timeRange}`;
 
   const res = http.post(url, '{}', {
     tags: {name: requestName},
@@ -78,7 +78,7 @@ export function stopDepartures(
   limit: number = 10,
 ) {
   const requestName = 'v2_stopDepartures';
-  const url = `${conf.host()}/bff/v2/departures/stop-departures?id=${stopId}&numberOfDepartures=${limit}&startTime=${startDate}T00:00:00.000Z&timeRange=${timeRange}`;
+  const url = `${conf.host()}/bff/v2/departures/stop-departures?id=${stopId}&numberOfDepartures=${limit}&startTime=${startDate}T03:00:00.000Z&timeRange=${timeRange}`;
 
   const res = http.post(url, '{}', {
     tags: {name: requestName},
@@ -141,7 +141,7 @@ export function stopDeparturesPOSTandGET(
   limit = 10,
 ) {
   const requestName = 'v2_stopDeparturesPOSTandGET';
-  const url = `${conf.host()}/bff/v2/departures/stop-departures?id=${stopId}&numberOfDepartures=${limit}&startTime=${startDate}T00:00:00.000Z&timeRange=${timeRange}`;
+  const url = `${conf.host()}/bff/v2/departures/stop-departures?id=${stopId}&numberOfDepartures=${limit}&startTime=${startDate}T03:00:00.000Z&timeRange=${timeRange}`;
 
   const resGET = http.get(url, {
     tags: {name: requestName},
@@ -191,7 +191,7 @@ export function quayDeparturesVsStopDepartures(
   startDate: string,
 ) {
   const requestName = 'v2_quayDeparturesVsStopDepartures';
-  const urlSD = `${conf.host()}/bff/v2/departures/stop-departures?id=${stopId}&numberOfDepartures=10&startTime=${startDate}T00:00:00.000Z&timeRange=86400`;
+  const urlSD = `${conf.host()}/bff/v2/departures/stop-departures?id=${stopId}&numberOfDepartures=10&startTime=${startDate}T03:00:00.000Z&timeRange=86400`;
 
   const resSD = http.post(urlSD, '{}', {
     tags: {name: requestName},
@@ -204,7 +204,7 @@ export function quayDeparturesVsStopDepartures(
     // Check equality on each quay
     const quays = jsonSD.stopPlace!.quays!.map((el) => el.id);
     for (let quay of quays) {
-      const urlQD = `${conf.host()}/bff/v2/departures/quay-departures?id=${quay}&numberOfDepartures=10&startTime=${startDate}T00:00:00.000Z&timeRange=86400`;
+      const urlQD = `${conf.host()}/bff/v2/departures/quay-departures?id=${quay}&numberOfDepartures=10&startTime=${startDate}T03:00:00.000Z&timeRange=86400`;
       const resQD = http.post(urlQD, '{}', {
         tags: {name: requestName},
         headers: bffHeadersPost,
@@ -253,7 +253,7 @@ export function quayDepartures(
   limit: number = 1000,
 ) {
   const requestName = 'v2_quayDepartures';
-  const url = `${conf.host()}/bff/v2/departures/quay-departures?id=${quayId}&numberOfDepartures=${limit}&startTime=${startDate}T00:00:00.000Z&timeRange=${timeRange}`;
+  const url = `${conf.host()}/bff/v2/departures/quay-departures?id=${quayId}&numberOfDepartures=${limit}&startTime=${startDate}T03:00:00.000Z&timeRange=${timeRange}`;
 
   const res = http.post(url, '{}', {
     tags: {name: requestName},
@@ -308,7 +308,7 @@ export function quayDeparturesPOSTandGET(
   limit: number = 1000,
 ) {
   const requestName = 'v2_quayDeparturesPOSTandGET';
-  const url = `${conf.host()}/bff/v2/departures/quay-departures?id=${quayId}&numberOfDepartures=${limit}&startTime=${startDate}T00:00:00.000Z&timeRange=${timeRange}`;
+  const url = `${conf.host()}/bff/v2/departures/quay-departures?id=${quayId}&numberOfDepartures=${limit}&startTime=${startDate}T03:00:00.000Z&timeRange=${timeRange}`;
 
   const resGET = http.get(url, {
     tags: {name: requestName},

--- a/test/src/v2/departures/favorites.ts
+++ b/test/src/v2/departures/favorites.ts
@@ -17,7 +17,7 @@ export function departureFavorites(
     const requestName = `v2_departureFavorites_${testData.scenarios.indexOf(
       test,
     )}`;
-    const url = `${conf.host()}/bff/v2/departure-favorites?startTime=${startDate}T00:00:00.000Z&limitPerLine=${limitPerLine}`;
+    const url = `${conf.host()}/bff/v2/departure-favorites?startTime=${startDate}T03:00:00.000Z&limitPerLine=${limitPerLine}`;
 
     let res = http.post(url, JSON.stringify(test), {
       tags: {name: requestName},


### PR DESCRIPTION
When doing travel searches and departure searches, the tests sometimes asks for a day that has weekend schedules. Added a simple solution where the search date is increased if such a date is picked.

Also changed search times from `00:00` to `03:00` to avoid getting departures from the previous day.