### PR TITLE
feat: add geocoder hack to prioritize world cup features

### DIFF
--- a/src/service/impl/geocoder.ts
+++ b/src/service/impl/geocoder.ts
@@ -9,6 +9,7 @@ import {
 import {APIError} from '../../utils/api-error';
 import {get} from '../../utils/fetch-client';
 import {IGeocoderService} from '../interface';
+import {temporarilyPrioritizeWorldCupFeatures} from '../../utils/temporarily-prioritize-world-cup-features';
 
 const FOCUS_WEIGHT = parseInt(process.env.GEOCODER_FOCUS_WEIGHT || '18');
 
@@ -41,7 +42,10 @@ export default (): IGeocoderService => {
           `/geocoder/v1/autocomplete?${queryString}`,
           headers,
         );
-        return Result.ok(result.features);
+        const prioritizedFeatures = temporarilyPrioritizeWorldCupFeatures(
+          result.features,
+        );
+        return Result.ok(prioritizedFeatures);
       } catch (error) {
         return Result.err(new APIError(error));
       }

--- a/src/utils/temporarily-prioritize-world-cup-features.ts
+++ b/src/utils/temporarily-prioritize-world-cup-features.ts
@@ -1,0 +1,28 @@
+import {Feature, Point} from 'geojson';
+import {Location} from '../types/geocoder';
+
+export function temporarilyPrioritizeWorldCupFeatures(
+  features: Feature<Point, Location>[],
+) {
+  const granaasenIdrettsparkId = 'NSR:StopPlace:44095';
+  const featuresWithIdrettsparkFirst = moveFeatureToFront(
+    features,
+    granaasenIdrettsparkId,
+  );
+
+  const granaasenSkistadionId = 'OSM:TopographicPlace:8588322';
+  const featuresWithSkistadionFirst = moveFeatureToFront(
+    featuresWithIdrettsparkFirst,
+    granaasenSkistadionId,
+  );
+  return featuresWithSkistadionFirst;
+}
+
+function moveFeatureToFront(
+  features: Feature<Point, Location>[],
+  featureId: string,
+): Feature<Point, Location>[] {
+  const feature = features.find((f) => f.properties.id === featureId);
+  if (!feature) return features;
+  return [feature, ...features.filter((f) => f.properties.id !== featureId)];
+}


### PR DESCRIPTION
If the "Granåsen Idrettspark" stop place  or "Granåsen Skistadion" POI appears in a geocoder autocomplete search, this moves them to the top of the list of results. Hopefully this will make it appear often enough, and prevent some confusion among Ski VM visitors.

ref. https://mittatb.slack.com/archives/CHLDG8C30/p1737474070199799

### Acceptance criteria

- [ ] For any search that has "Granåsen Idrettspark" stop place as a result, it appears first in the list
- [ ] For any search that has "Granåsen Skistadion" location as a result, it appears first in the list (and before Granåsen Idrettspark if both appear)
