### PR TITLE
test: edit test data after route changes

### DIFF
--- a/test/src/v2/departures/favorites.ts
+++ b/test/src/v2/departures/favorites.ts
@@ -31,6 +31,7 @@ export function departureFavorites(
       const resStopPlaceIds = json.data.map((fav) => fav.stopPlace.id).sort();
       const expQuayIds = test.favorites.map((e) => e.quayId).sort();
       const expLineIds = test.favorites.map((e) => e.lineId).sort();
+      const expLineNames = test.favorites.map((e) => e.lineName).sort();
       const resQuayIds = json.data
         .map((fav) => fav.quays.map((quay) => quay.quay.id))
         .flat();
@@ -60,23 +61,25 @@ export function departureFavorites(
               expect: quay.group.length > 0,
             });
             for (let line of quay.group) {
-              expects.push(
-                {
-                  check: `should have correct line from quay '${quay.quay.id}'`,
-                  expect: expLineIds.includes(line.lineInfo.lineId),
-                },
-                {
-                  check: `should have correct date for departures from quay '${quay.quay.id}'`,
-                  expect:
-                    line.departures.filter(
-                      (dep) => dep.serviceDate !== startDate,
-                    ).length === 0,
-                },
-                {
-                  check: `should have correct number of departures from quay '${quay.quay.id}'`,
-                  expect: line.departures.length === limitPerLine,
-                },
-              );
+              if (expLineNames.includes(line.lineInfo.lineName)) {
+                expects.push(
+                  {
+                    check: `should have correct line from quay '${quay.quay.id}'`,
+                    expect: expLineIds.includes(line.lineInfo.lineId),
+                  },
+                  {
+                    check: `should have correct date for departures from quay '${quay.quay.id}'`,
+                    expect:
+                      line.departures.filter(
+                        (dep) => dep.serviceDate !== startDate,
+                      ).length === 0,
+                  },
+                  {
+                    check: `should have correct number of departures from quay '${quay.quay.id}'`,
+                    expect: line.departures.length === limitPerLine,
+                  },
+                );
+              }
             }
           } else {
             expects.push({

--- a/test/src/v2/testData/testData.ts
+++ b/test/src/v2/testData/testData.ts
@@ -117,6 +117,7 @@ export const departureFavoritesTestData: departureFavoritesTestDataType = {
       favorites: [
         {
           lineId: 'ATB:Line:2_82',
+          lineName: 'Hesttrøa via Melhus skysstasjon',
           quayId: 'NSR:Quay:73576',
           quayName: 'Loddgårdstrøa',
           stopId: 'NSR:StopPlace:42912',
@@ -130,6 +131,7 @@ export const departureFavoritesTestData: departureFavoritesTestDataType = {
       favorites: [
         {
           lineId: 'ATB:Line:2_82',
+          lineName: 'Hesttrøa via Melhus skysstasjon',
           quayId: 'NSR:Quay:73576',
           quayName: 'Loddgårdstrøa',
           stopId: 'NSR:StopPlace:42912',
@@ -140,6 +142,7 @@ export const departureFavoritesTestData: departureFavoritesTestDataType = {
         },
         {
           lineId: 'ATB:Line:2_82',
+          lineName: 'Hesttrøa via Melhus skysstasjon',
           quayId: 'NSR:Quay:71785',
           quayName: 'Uglevegen',
           stopId: 'NSR:StopPlace:41942',

--- a/test/src/v2/types/testData.ts
+++ b/test/src/v2/types/testData.ts
@@ -4,6 +4,7 @@ export type departureFavoritesTestDataType = {
   scenarios: Array<{
     favorites: Array<{
       lineId: string;
+      lineName: string;
       quayId: string;
       quayName: string;
       stopId: string;


### PR DESCRIPTION
Line 82 has now become `Hesttrøa via Melhus skysstasjon` and `Hesttrøa`. Not only `Hesttrøa`, which now gives more list items in the favourite response that the tests have to handle.

### Acceptance criteria
- [x] Tests run OK ✅ 
    https://github.com/AtB-AS/atb-bff/actions/runs/13026227256 