### PR TITLE
fix: filter out unknown quays in departure favorites

### DIFF
--- a/src/service/impl/departures-grouped/departure-favorites.ts
+++ b/src/service/impl/departures-grouped/departure-favorites.ts
@@ -10,7 +10,7 @@ import {
 } from './journey-gql/departure-group.graphql-gen';
 import mapQueryToGroups, {StopPlaceGroup} from './utils/grouping';
 import {ReqRefDefaults, Request} from '@hapi/hapi';
-import {onlyUniques} from '../stop-places/utils';
+import {isDefined, onlyUniques} from '../stop-places/utils';
 
 export type DepartureFavoritesMetadata = CursoredData<StopPlaceGroup[]>;
 
@@ -43,8 +43,11 @@ export async function getDepartureFavorites(
     return Result.err(new APIError(result.errors));
   }
 
+  // Quays that have been removed from NSR, will be `null` in the response.
+  const quays = result.data.quays.filter(isDefined);
+
   try {
-    const data = mapQueryToGroups(result.data.quays, favorites);
+    const data = mapQueryToGroups(quays, favorites);
     return Result.ok(generateCursorData(data, {hasNextPage: false}, options));
   } catch (error) {
     return Result.err(new APIError(error));


### PR DESCRIPTION
Quays that has been removed from NSR will be returned as `null` by journey planner. This caused the mapping function to throw, which caused a 500 response. We should instead filter these out, and return data for the quays that were found.

ref. discussion in slack: https://mittatb.slack.com/archives/C02EEG7D8EL/p1740388593702519

## Acceptance criteria

- [ ] Favorites sent to `/bff/v2/departure-favorites` with invalid/outdated data will be discarded by the bff instead of causing a 500. 
	- Can be tested by editing e.g. `lineId` for a request.