### PR TITLE
feat: add GEOCODER_SCALE env variable

### DIFF
--- a/src/service/impl/geocoder.ts
+++ b/src/service/impl/geocoder.ts
@@ -11,6 +11,7 @@ import {get} from '../../utils/fetch-client';
 import {IGeocoderService} from '../interface';
 
 const FOCUS_WEIGHT = parseInt(process.env.GEOCODER_FOCUS_WEIGHT || '18');
+const SCALE = parseInt(process.env.GEOCODER_SCALE || '200');
 
 export default (): IGeocoderService => {
   return {
@@ -29,7 +30,7 @@ export default (): IGeocoderService => {
               lon: params.lon,
             },
             weight: FOCUS_WEIGHT,
-            scale: '200km',
+            scale: `${SCALE}km`,
             function: 'exp',
           },
         };


### PR DESCRIPTION
In case we want to configure geocoder scale as an env variable, this should do it. E.g `GEOCODER_SCALE=300`.