### PR TITLE
feat: use `cursor` instead of `when` if it is defined

### DIFF
--- a/src/service/impl/trips/utils.ts
+++ b/src/service/impl/trips/utils.ts
@@ -31,6 +31,7 @@ export function generateSingleTripQueryString(
   const {
     from,
     to,
+    cursor,
     transferPenalty,
     waitReluctance,
     walkReluctance,
@@ -39,7 +40,7 @@ export function generateSingleTripQueryString(
   } = queryVariables;
   const arriveBy = false;
   const singleTripQuery: TripsQueryVariables = {
-    when,
+    ...(cursor !== undefined ? {cursor} : {when}),
     from,
     to,
     transferPenalty,


### PR DESCRIPTION
Fixes https://github.com/AtB-AS/kundevendt/issues/19814

Reference discussion: https://mittatb.slack.com/archives/C02EEG7D8EL/p1746604283420249

The message on the issue appears because there are inconsistencies between the result returned by the trip search and get single trip.

When we search trip by entering the address from-to, we get a list of trips. The first page of the trips list result is fetched using `datetime` parameter on the query. While the subsequent page is fetched using the `pagecursor` parameter on the query. 

When we select a single trip to see the details, we fetch the details of this single trip using `datetime` parameter, therefore the result can be different. 

This happens if we select a specific trip on the second page of result (using `pagecursor`), then the trip details will be fetched using `datetime` instead. Causing different results when fetching some queries (see reference chat on slack).

So the solution to fix this is to make the queries consistent across screens. For queries with `pagecursor`, fetch the details using that `pagecursor`, if it is not defined, use the `datetime`. 

Feel free to let me know if you need more explanation!