### PR TITLE
feat: increase distance limit polyline

### DIFF
--- a/src/service/impl/service-journey/utils.ts
+++ b/src/service/impl/service-journey/utils.ts
@@ -69,7 +69,7 @@ function findIndex(
       const distance = haversineDistance(t, quayCoords);
       return distance < closest.distance ? {index, distance} : closest;
     },
-    {index: -1, distance: 100},
+    {index: -1, distance: 250},
   ).index;
 }
 


### PR DESCRIPTION
refer to this slack discussion: https://mittatb.slack.com/archives/C0116FMPX4Y/p1748107469811009

The issue here is that the `buss for tog`/`rail replacement bus` from Trondheim Lufthavn departs from a quay which is located a bit further from the polyline, so it fails to detect the departure point, and cannot generate a polyline to send in to the client.

I have increased the detection distance a bit higher to 250 metres away, it should still be within reasonable distance used normally, and works with the Trondheim Lufthavn case we have (the specific distance is 221 metres).

This will indirectly fix this bugsnag issue: https://app.bugsnag.com/atb-as/mittatb/errors/6788c603c88e184232652ed0?filters[event.since]=all&filters[app.release_stage]=store