### PR TITLE
fix: support http calls though HttpAgent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@hapi/inert": "^7.1.0",
         "@hapi/vision": "^7.0.3",
         "@mapbox/polyline": "^1.2.1",
-        "agentkeepalive": "^4.5.0",
+        "agentkeepalive": "^4.6.0",
         "date-fns": "^3.3.1",
         "dotenv": "^16.4.1",
         "graphql": "^16.8.1",
@@ -5608,9 +5608,9 @@
       }
     },
     "node_modules/agentkeepalive": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
-      "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
       "dependencies": {
         "humanize-ms": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@hapi/inert": "^7.1.0",
     "@hapi/vision": "^7.0.3",
     "@mapbox/polyline": "^1.2.1",
-    "agentkeepalive": "^4.5.0",
+    "agentkeepalive": "^4.6.0",
     "date-fns": "^3.3.1",
     "dotenv": "^16.4.1",
     "graphql": "^16.8.1",

--- a/src/utils/fetch-client.ts
+++ b/src/utils/fetch-client.ts
@@ -1,7 +1,7 @@
 import fetch, {RequestInit, RequestInfo, Response} from 'node-fetch';
 import {ENTUR_BASEURL, ET_CLIENT_NAME} from '../config/env';
 import {logResponse} from './log-response';
-import {HttpsAgent as Agent} from 'agentkeepalive';
+import {HttpsAgent, HttpAgent} from 'agentkeepalive';
 import {ReqRefDefaults, Request} from '@hapi/hapi';
 import {Timer} from './timer';
 
@@ -9,7 +9,10 @@ const enturBaseUrl = ENTUR_BASEURL || 'https://api.entur.io';
 
 const REQUEST_TIMEOUT = 20_000;
 
-const agent = new Agent({
+const httpsAgent = new HttpsAgent({
+  keepAlive: true,
+});
+const httpAgent = new HttpAgent({
   keepAlive: true,
 });
 
@@ -72,7 +75,7 @@ export const get = async <T>(
     {
       ...options,
       method: 'GET',
-      agent: agent,
+      agent: baseUrl?.startsWith('http:') ? httpAgent : httpsAgent,
     },
     baseUrl,
   );
@@ -97,7 +100,7 @@ export const post = async (
       },
       method: 'POST',
       body: JSON.stringify(body),
-      agent: agent,
+      agent: baseUrl?.startsWith('http:') ? httpAgent : httpsAgent,
     },
     baseUrl,
   );


### PR DESCRIPTION
Fixes an issue with https://github.com/AtB-AS/kundevendt/issues/20794 where the internal call to sales didn't work because we the [agentkeepalive](https://www.npmjs.com/package/agentkeepalive) agent was set up only for https. 