### PR TITLE
fix: Removes use of toMidnight

### DIFF
--- a/src/service/impl/trips/index.ts
+++ b/src/service/impl/trips/index.ts
@@ -15,7 +15,6 @@ import {
   TransportSubmode,
 } from '../../../graphql/journey/journeyplanner-types_v3';
 import {Result} from '@badrap/result';
-import {toMidnight} from './utils';
 import {getBookingInfo} from './booking-utils';
 
 export default (): ITrips_v2 => {
@@ -39,7 +38,7 @@ export default (): ITrips_v2 => {
         from: {place: query.fromStopPlaceId},
         to: {place: query.toStopPlaceId},
         arriveBy: false,
-        when: toMidnight(query.searchTime),
+        when: query.searchTime,
         searchWindow: 1440, // 24 hours
         modes: {
           transportModes: [

--- a/src/service/impl/trips/utils.ts
+++ b/src/service/impl/trips/utils.ts
@@ -61,11 +61,6 @@ function getPaddedStartTime(time: string): string {
   return addSeconds(startTime, -START_TIME_PADDING).toISOString();
 }
 
-export function toMidnight(time: string): string {
-  const date = formatDate(parseISO(time), 'yyyy-MM-dd');
-  return `${date}T00:00:00.000Z`;
-}
-
 /**
  * Maps a TripQueryString into QueryVariables and journeyIds
  * JourneyPlanner v3


### PR DESCRIPTION
Related to AtB-AS/kundevendt#20851

Because it was working with UTC-time, midnight was actually 22:00:00, so `toMidnight` set the day to the previous day which was not what we wanted. 