### PR TITLE
fix: make sales service non-required

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -79,11 +79,7 @@ export const ENROLLMENT_BASEURL: string = getServiceUrl(
   'ENROLLMENT',
   getEnv() === 'prod',
 );
-export const SALES_BASEURL: string | undefined = getServiceUrl(
-  'http://',
-  'SALES',
-  getEnv() === 'prod',
-);
+export const SALES_BASEURL: string = getServiceUrl('http://', 'SALES', false);
 export const REDIS_HOST: string = getServiceHost('REDIS');
 export const REDIS_PORT: string = getServicePort('REDIS');
 


### PR DESCRIPTION
With setting up the BFF for VKT/Farte, we noticed that the sales service is required for the BFF to run. Since it only affects the new booking endpoint we can set it to not be required.