### PR TITLE
fix: Added stringification of locations 

### DIFF
--- a/src/graphql/graphql-client.ts
+++ b/src/graphql/graphql-client.ts
@@ -69,7 +69,7 @@ function createClient(url: string) {
       let error = '';
       if (graphQLErrors) {
         graphQLErrors.forEach(({message, locations, path}) => {
-          error += `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}\n`;
+          error += `[GraphQL error]: Message: ${message}, Location: ${JSON.stringify(locations)}, Path: ${path}\n`;
         });
       }
       if (networkError) {


### PR DESCRIPTION
This is done to avoid `Location: [object Object]` on errors