### PR TITLE
feat: return enrollment id from endpoint

### DIFF
--- a/src/api/enrollment/index.ts
+++ b/src/api/enrollment/index.ts
@@ -73,7 +73,11 @@ export default (server: Hapi.Server) => (service: IEnrollmentService) => {
       const payload = response.unwrap();
       const analyticsGroups = [];
       analyticsGroups.push(payload.analytics_group);
-      return {status: 'ok',enrollmentId: enrollmentId, groups: analyticsGroups};
+      return {
+        status: 'ok',
+        enrollmentId: enrollmentId,
+        groups: analyticsGroups,
+      };
     },
   });
 };


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/20660

adds enrollmentId to be returned from enrollment endpoint

ALSO removes `"ticketing_group"` from always being returned as analytics group