### PR TITLE
test: line name change

### DIFF
--- a/test/src/v2/testData/testData.ts
+++ b/test/src/v2/testData/testData.ts
@@ -111,7 +111,7 @@ export const departureFavoritesTestData: departureFavoritesTestDataType = {
       favorites: [
         {
           lineId: 'ATB:Line:2_82',
-          lineName: 'Hesttrøa',
+          lineName: 'Hesttrøa via Melhus skysstasjon',
           quayId: 'NSR:Quay:73576',
           quayName: 'Loddgårdstrøa',
           stopId: 'NSR:StopPlace:42912',
@@ -125,7 +125,7 @@ export const departureFavoritesTestData: departureFavoritesTestDataType = {
       favorites: [
         {
           lineId: 'ATB:Line:2_82',
-          lineName: 'Hesttrøa',
+          lineName: 'Hesttrøa via Melhus skysstasjon',
           quayId: 'NSR:Quay:73576',
           quayName: 'Loddgårdstrøa',
           stopId: 'NSR:StopPlace:42912',
@@ -136,7 +136,7 @@ export const departureFavoritesTestData: departureFavoritesTestDataType = {
         },
         {
           lineId: 'ATB:Line:2_82',
-          lineName: 'Hesttrøa',
+          lineName: 'Hesttrøa via Melhus skysstasjon',
           quayId: 'NSR:Quay:71785',
           quayName: 'Uglevegen',
           stopId: 'NSR:StopPlace:41942',


### PR DESCRIPTION
Line 82 changed from `Hesttrøa` to `Hesttrøa via Melhus skysstasjon`, which is kind of strange since this line has already passed Melhus skysstasjon at these quays.