### PR TITLE
fix: Fixes missing transitive stopplaces

### DIFF
--- a/src/api/stop-places/index.ts
+++ b/src/api/stop-places/index.ts
@@ -10,6 +10,8 @@ import {
   StopPlaceParentQuery,
   StopPlacesByModeQuery,
 } from '../../service/types';
+import {getClientCache, getServerCache} from "../../utils/cache";
+import {CACHE_TTL_MS_CLIENT, CACHE_TTL_MS_SERVER_SERVICE_JOURNEY_MAP_INFO} from "../../config/env";
 
 export default (server: Hapi.Server) => (service: IStopPlacesService) => {
   server.route({
@@ -35,7 +37,7 @@ export default (server: Hapi.Server) => (service: IStopPlacesService) => {
     },
     handler: async (request, h) => {
       const query = request.query as unknown as StopPlaceConnectionsQuery;
-      return (await service.getStopPlaceConnections(query, h.request)).unwrap();
+      return (await service.getStopPlaceConnections(query, h.request, 1)).unwrap();
     },
   });
   server.route({

--- a/src/api/stop-places/index.ts
+++ b/src/api/stop-places/index.ts
@@ -10,8 +10,6 @@ import {
   StopPlaceParentQuery,
   StopPlacesByModeQuery,
 } from '../../service/types';
-import {getClientCache, getServerCache} from "../../utils/cache";
-import {CACHE_TTL_MS_CLIENT, CACHE_TTL_MS_SERVER_SERVICE_JOURNEY_MAP_INFO} from "../../config/env";
 
 export default (server: Hapi.Server) => (service: IStopPlacesService) => {
   server.route({
@@ -37,7 +35,9 @@ export default (server: Hapi.Server) => (service: IStopPlacesService) => {
     },
     handler: async (request, h) => {
       const query = request.query as unknown as StopPlaceConnectionsQuery;
-      return (await service.getStopPlaceConnections(query, h.request, 1)).unwrap();
+      return (
+        await service.getStopPlaceConnections(query, h.request, 1)
+      ).unwrap();
     },
   });
   server.route({

--- a/src/service/interface.ts
+++ b/src/service/interface.ts
@@ -187,7 +187,7 @@ export interface IStopPlacesService {
   getStopPlaceConnections(
     query: StopPlaceConnectionsQuery,
     request: Request<ReqRefDefaults>,
-    recursiveDepth: number
+    recursiveDepth: number,
   ): Promise<Result<StopPlaces, APIError>>;
 
   getStopPlaceParent(

--- a/src/service/interface.ts
+++ b/src/service/interface.ts
@@ -187,6 +187,7 @@ export interface IStopPlacesService {
   getStopPlaceConnections(
     query: StopPlaceConnectionsQuery,
     request: Request<ReqRefDefaults>,
+    recursiveDepth: number
   ): Promise<Result<StopPlaces, APIError>>;
 
   getStopPlaceParent(


### PR DESCRIPTION
We have an issue (in both staging and prod!) where stop places which are on a multileg journey (i.e. you need to change between different express boat lines to arrive there) did not appear in the list of possible **to** stopplaces when buying an express boat ticket. This means no customers can currently buy periodic tickets on journeys with more than one stop - if there is no overrides in `firestore-configuration`. 

I.e. only stop places a single leg away appears when pressing this 
<img width="400"  src="https://github.com/user-attachments/assets/4f099f5e-369d-45de-bd1f-15f6363b0680" />

This is mainly an issue for Nordland, which do not have any overrides in `firestore-configuration`, and adding them would be _very_ resource intensive since there are a lot of stop places. 

This PR is a draft with a suggestion of solving that by recursively finding journey patterns from stop places - of course with heavy caching. This is just an extension of how it is done today. 

I intend to bring this up at the next CODEv, but feel free to have a look now. 