### PR TITLE
fix: Narrow non-transit queries for bike rentals to city bikes

### DIFF
--- a/src/service/impl/trips/journey-gql/trip.graphql
+++ b/src/service/impl/trips/journey-gql/trip.graphql
@@ -42,6 +42,7 @@ query TripsNonTransit($from: Location!, $to: Location!, $arriveBy: Boolean!, $wh
       directMode: bike_rental,
       transportModes: []
     }
+    whiteListed: {rentalNetworks: ["trondheimbysykkel", "bergenbysykkel", "oslobysykkel", "kolumbusbysykkel", "fartebysykkel"] }
   ) @include(if:$includeBikeRental) {
     ...trip
   }

--- a/src/service/impl/trips/journey-gql/trip.graphql-gen.ts
+++ b/src/service/impl/trips/journey-gql/trip.graphql-gen.ts
@@ -78,7 +78,7 @@ export const TripsNonTransitDocument = gql`
     arriveBy: $arriveBy
     walkSpeed: $walkSpeed
     modes: {directMode: bike_rental, transportModes: []}
-    whiteListed: {rentalNetworks: ["trondheimbysykkel","bergenbysykkel","oslobysykkel","kolumbusbysykkel","fartebysykkel"] }
+    whiteListed: {rentalNetworks: ["trondheimbysykkel", "bergenbysykkel", "oslobysykkel", "kolumbusbysykkel", "fartebysykkel"]}
   ) @include(if: $includeBikeRental) {
     ...trip
   }


### PR DESCRIPTION
Fixes https://github.com/AtB-AS/kundevendt/issues/21622

## Changes
As per @tormoseng's suggestion, added whitelisting of all city bike rental networks that are available under https://api.entur.io/mobility/v2/gbfs/v3/manifest.json

## Possible followups
- Rename `bikeRentalTrip` in query to reflect that it is just city bikes, `cityBikeRentalTrip` perhaps?
- Use `useBikeRentalAvailabilityInformation: true` for queries that are close in time, possibly sent in by app?

## Testing

Tested locally, and seems to work fine.
| Before | After |
|--------|--------|
| <img width="521" height="990" alt="image" src="https://github.com/user-attachments/assets/20c6887d-4444-4f2d-b6b6-85012674591b" /> | <img width="521" height="990" alt="image" src="https://github.com/user-attachments/assets/f2edca97-b943-41b6-b369-347faeb2a804" /> |