### PR TITLE
fix: allow filter to be undefined

### DIFF
--- a/src/service/impl/departures-grouped/departure-favorites.ts
+++ b/src/service/impl/departures-grouped/departure-favorites.ts
@@ -21,13 +21,16 @@ export async function getDepartureFavorites(
 ): Promise<Result<DepartureFavoritesMetadata, APIError>> {
   const quayIds = favorites?.map((f) => f.quayId).filter(onlyUniques);
 
+  const lineIds = favorites.map((f) => f.lineId);
+  const filters = lineIds.length ? [{select: [{lines: lineIds}]}] : undefined;
+
   const variables: GroupsByIdQueryVariables = {
     ids: quayIds,
     timeRange: 86400 * 2, // Two days
     startTime: options.startTime,
     limitPerLine: options.limitPerLine,
     totalLimit: options.limitPerLine * 10,
-    filterByLineIds: favorites.map((f) => f.lineId),
+    filters,
     includeCancelledTrips: options.includeCancelledTrips,
   };
 

--- a/src/service/impl/departures-grouped/journey-gql/departure-group.graphql
+++ b/src/service/impl/departures-grouped/journey-gql/departure-group.graphql
@@ -1,4 +1,4 @@
-query GroupsById($ids: [String]!, $startTime: DateTime!, $timeRange: Int!, $limitPerLine: Int!, $totalLimit: Int!, $filterByLineIds: [ID!], $includeCancelledTrips: Boolean) {
+query GroupsById($ids: [String]!, $startTime: DateTime!, $timeRange: Int!, $limitPerLine: Int!, $totalLimit: Int!, $filters: [EstimatedCallFilterInput!], $includeCancelledTrips: Boolean) {
   quays(ids: $ids) {
     ...group_quayFields
     stopPlace {
@@ -11,7 +11,7 @@ query GroupsById($ids: [String]!, $startTime: DateTime!, $timeRange: Int!, $limi
       numberOfDepartures: $totalLimit
       arrivalDeparture: departures
       includeCancelledTrips: $includeCancelledTrips
-      filters: [{select: [{lines: $filterByLineIds}]}]
+      filters: $filters
     ) {
       ...group_times_estimatedCallFields
     }
@@ -22,7 +22,7 @@ query GroupsById($ids: [String]!, $startTime: DateTime!, $timeRange: Int!, $limi
       numberOfDeparturesPerLineAndDestinationDisplay: 1
       arrivalDeparture: departures
       includeCancelledTrips: $includeCancelledTrips
-      filters: [{select: [{lines: $filterByLineIds}]}]
+      filters: $filters
     ) {
       ...group_estimatedCallFields
     }

--- a/src/service/impl/departures-grouped/journey-gql/departure-group.graphql-gen.ts
+++ b/src/service/impl/departures-grouped/journey-gql/departure-group.graphql-gen.ts
@@ -16,7 +16,7 @@ export type GroupsByIdQueryVariables = Types.Exact<{
   timeRange: Types.Scalars['Int']['input'];
   limitPerLine: Types.Scalars['Int']['input'];
   totalLimit: Types.Scalars['Int']['input'];
-  filterByLineIds?: Types.InputMaybe<Array<Types.Scalars['ID']['input']> | Types.Scalars['ID']['input']>;
+  filters?: Types.InputMaybe<Array<Types.EstimatedCallFilterInput> | Types.EstimatedCallFilterInput>;
   includeCancelledTrips?: Types.InputMaybe<Types.Scalars['Boolean']['input']>;
 }>;
 
@@ -150,7 +150,7 @@ export const Group_StopPlaceFieldsFragmentDoc = gql`
 }
     `;
 export const GroupsByIdDocument = gql`
-    query GroupsById($ids: [String]!, $startTime: DateTime!, $timeRange: Int!, $limitPerLine: Int!, $totalLimit: Int!, $filterByLineIds: [ID!], $includeCancelledTrips: Boolean) {
+    query GroupsById($ids: [String]!, $startTime: DateTime!, $timeRange: Int!, $limitPerLine: Int!, $totalLimit: Int!, $filters: [EstimatedCallFilterInput!], $includeCancelledTrips: Boolean) {
   quays(ids: $ids) {
     ...group_quayFields
     stopPlace {
@@ -163,7 +163,7 @@ export const GroupsByIdDocument = gql`
       numberOfDepartures: $totalLimit
       arrivalDeparture: departures
       includeCancelledTrips: $includeCancelledTrips
-      filters: [{select: [{lines: $filterByLineIds}]}]
+      filters: $filters
     ) {
       ...group_times_estimatedCallFields
     }
@@ -174,7 +174,7 @@ export const GroupsByIdDocument = gql`
       numberOfDeparturesPerLineAndDestinationDisplay: 1
       arrivalDeparture: departures
       includeCancelledTrips: $includeCancelledTrips
-      filters: [{select: [{lines: $filterByLineIds}]}]
+      filters: $filters
     ) {
       ...group_estimatedCallFields
     }

--- a/src/service/impl/departures/index.ts
+++ b/src/service/impl/departures/index.ts
@@ -55,6 +55,10 @@ export default (): IDeparturesService => {
               numberOfDepartures,
             };
 
+        const filters = lineIds?.length
+          ? [{select: [{lines: lineIds}]}]
+          : undefined;
+
         const result = await journeyPlannerClient(request).query<
           DeparturesQuery,
           DeparturesQueryVariables
@@ -64,7 +68,7 @@ export default (): IDeparturesService => {
             ids: quayIds,
             startTime,
             timeRange,
-            filterByLineIds: lineIds,
+            filters,
             ...limit,
           },
         });

--- a/src/service/impl/departures/journey-gql/departures.graphql
+++ b/src/service/impl/departures/journey-gql/departures.graphql
@@ -3,7 +3,7 @@ query departures(
   $numberOfDepartures: Int,
   $startTime: DateTime,
   $timeRange: Int,
-  $filterByLineIds: [ID!],
+  $filters: [EstimatedCallFilterInput!],
   $limitPerLine: Int
 ) {
   quays(ids: $ids) {
@@ -16,7 +16,7 @@ query departures(
       startTime: $startTime
       timeRange: $timeRange
       includeCancelledTrips: true
-      filters: [{select: [{lines: $filterByLineIds}]}]
+      filters: $filters
       numberOfDeparturesPerLineAndDestinationDisplay: $limitPerLine
     ) {
       date

--- a/src/service/impl/departures/journey-gql/departures.graphql-gen.ts
+++ b/src/service/impl/departures/journey-gql/departures.graphql-gen.ts
@@ -15,7 +15,7 @@ export type DeparturesQueryVariables = Types.Exact<{
   numberOfDepartures?: Types.InputMaybe<Types.Scalars['Int']['input']>;
   startTime?: Types.InputMaybe<Types.Scalars['DateTime']['input']>;
   timeRange?: Types.InputMaybe<Types.Scalars['Int']['input']>;
-  filterByLineIds?: Types.InputMaybe<Array<Types.Scalars['ID']['input']> | Types.Scalars['ID']['input']>;
+  filters?: Types.InputMaybe<Array<Types.EstimatedCallFilterInput> | Types.EstimatedCallFilterInput>;
   limitPerLine?: Types.InputMaybe<Types.Scalars['Int']['input']>;
 }>;
 
@@ -27,7 +27,7 @@ export type DeparturesQuery = { quays: Array<{ id: string, description?: string,
 
 
 export const DeparturesDocument = gql`
-    query departures($ids: [String]!, $numberOfDepartures: Int, $startTime: DateTime, $timeRange: Int, $filterByLineIds: [ID!], $limitPerLine: Int) {
+    query departures($ids: [String]!, $numberOfDepartures: Int, $startTime: DateTime, $timeRange: Int, $filters: [EstimatedCallFilterInput!], $limitPerLine: Int) {
   quays(ids: $ids) {
     id
     description
@@ -38,7 +38,7 @@ export const DeparturesDocument = gql`
       startTime: $startTime
       timeRange: $timeRange
       includeCancelledTrips: true
-      filters: [{select: [{lines: $filterByLineIds}]}]
+      filters: $filters
       numberOfDeparturesPerLineAndDestinationDisplay: $limitPerLine
     ) {
       date

--- a/src/service/impl/realtime/journey-gql/departure-time.graphql
+++ b/src/service/impl/realtime/journey-gql/departure-time.graphql
@@ -4,7 +4,7 @@ query GetDepartureRealtime(
   $timeRange: Int!
   $limit: Int!
   $limitPerLine: Int
-  $lineIds: [ID!]
+  $filters: [EstimatedCallFilterInput!]
 ) {
   quays(ids: $quayIds) {
     id
@@ -15,7 +15,7 @@ query GetDepartureRealtime(
       timeRange: $timeRange
       arrivalDeparture: departures
       includeCancelledTrips: false
-      filters: [{select: [{lines: $lineIds}]}]
+      filters: $filters
     ) {
       ...estimatedCall
     }

--- a/src/service/impl/realtime/journey-gql/departure-time.graphql-gen.ts
+++ b/src/service/impl/realtime/journey-gql/departure-time.graphql-gen.ts
@@ -8,7 +8,7 @@ export type GetDepartureRealtimeQueryVariables = Types.Exact<{
   timeRange: Types.Scalars['Int']['input'];
   limit: Types.Scalars['Int']['input'];
   limitPerLine?: Types.InputMaybe<Types.Scalars['Int']['input']>;
-  lineIds?: Types.InputMaybe<Array<Types.Scalars['ID']['input']> | Types.Scalars['ID']['input']>;
+  filters?: Types.InputMaybe<Array<Types.EstimatedCallFilterInput> | Types.EstimatedCallFilterInput>;
 }>;
 
 
@@ -31,7 +31,7 @@ export const EstimatedCallFragmentDoc = gql`
 }
     `;
 export const GetDepartureRealtimeDocument = gql`
-    query GetDepartureRealtime($quayIds: [String]!, $startTime: DateTime!, $timeRange: Int!, $limit: Int!, $limitPerLine: Int, $lineIds: [ID!]) {
+    query GetDepartureRealtime($quayIds: [String]!, $startTime: DateTime!, $timeRange: Int!, $limit: Int!, $limitPerLine: Int, $filters: [EstimatedCallFilterInput!]) {
   quays(ids: $quayIds) {
     id
     estimatedCalls(
@@ -41,7 +41,7 @@ export const GetDepartureRealtimeDocument = gql`
       timeRange: $timeRange
       arrivalDeparture: departures
       includeCancelledTrips: false
-      filters: [{select: [{lines: $lineIds}]}]
+      filters: $filters
     ) {
       ...estimatedCall
     }

--- a/src/service/impl/realtime/sanitize-realtime-query.ts
+++ b/src/service/impl/realtime/sanitize-realtime-query.ts
@@ -20,5 +20,10 @@ export const sanitizeRealtimeQuery = (
   const realtimeWindowEnd = addMinutes(now, REALTIME_MINUTES);
   const timeRange = differenceInSeconds(realtimeWindowEnd, startTime);
 
-  return timeRange > 0 ? {...query, startTime, timeRange} : undefined;
+  if (timeRange <= 0) return undefined;
+
+  const {lineIds, ...rest} = query;
+  const filters = lineIds?.length ? [{select: [{lines: lineIds}]}] : undefined;
+
+  return {...rest, startTime, timeRange, filters};
 };


### PR DESCRIPTION
Fixes issue in BFF: 
>  Exception while fetching data (/quays[1]/estimatedCalls) : A selector cannot be empty,


From the "select" documentation:

> A list of selectors for what estimated calls should be included. A call is included if it matches at least one selector. Omit the field to include all calls. An empty list is not allowed.

We still process empty list even when we don't specify the seleced line Ids due to this structure: `filters: [{select: [{lines: $filterByLineIds}]}]`

Therefore I changed it to use the type `EstimatedCallFilterInput` and create the `select` argument when the lineIds are not empty.