### PR TITLE
feat: expose cancellation status for estimatedcalls

### DIFF
--- a/src/service/impl/fragments/journey-gql/trips.graphql
+++ b/src/service/impl/fragments/journey-gql/trips.graphql
@@ -45,12 +45,14 @@ fragment tripPattern on TripPattern {
                 ...notice
             }
             stopPositionInPattern
+            cancellation
         }
         toEstimatedCall {
             notices {
                 ...notice
             }
             stopPositionInPattern
+            cancellation
         }
         situations {
             ...situation
@@ -148,6 +150,7 @@ fragment tripPattern on TripPattern {
                 name
             }
             predictionInaccurate
+            cancellation
         }
         bookingArrangements {
             ...bookingArrangement

--- a/src/service/impl/fragments/journey-gql/trips.graphql-gen.ts
+++ b/src/service/impl/fragments/journey-gql/trips.graphql-gen.ts
@@ -19,7 +19,7 @@ export type TripFragment = { nextPageCursor?: string, previousPageCursor?: strin
 export type TripPatternFragment = { expectedStartTime: any, expectedEndTime: any, duration?: any, walkDistance?: number, legs: Array<{ id?: string, mode: Types.Mode, distance: number, duration: any, aimedStartTime: any, aimedEndTime: any, expectedEndTime: any, expectedStartTime: any, realtime: boolean, transportSubmode?: Types.TransportSubmode, rentedBike?: boolean, line?: (
       { name?: string }
       & LineFragment
-    ), fromEstimatedCall?: { aimedDepartureTime: any, expectedDepartureTime: any, stopPositionInPattern: number, destinationDisplay?: { frontText?: string, via?: Array<string> }, quay: { publicCode?: string, name: string }, notices: Array<NoticeFragment> }, toEstimatedCall?: { stopPositionInPattern: number, notices: Array<NoticeFragment> }, situations: Array<SituationFragment>, fromPlace: { name?: string, longitude: number, latitude: number, quay?: { id: string, publicCode?: string, name: string, longitude?: number, latitude?: number, description?: string, stopPlace?: { id: string, longitude?: number, latitude?: number, name: string }, situations: Array<SituationFragment>, tariffZones: Array<TariffZoneFragment> } }, toPlace: { name?: string, longitude: number, latitude: number, quay?: { id: string, publicCode?: string, name: string, longitude?: number, latitude?: number, description?: string, stopPlace?: { id: string, longitude?: number, latitude?: number, name: string }, situations: Array<SituationFragment>, tariffZones: Array<TariffZoneFragment> } }, serviceJourney?: { id: string, notices: Array<NoticeFragment>, journeyPattern?: { notices: Array<NoticeFragment> } }, interchangeTo?: { guaranteed?: boolean, maximumWaitTime?: number, staySeated?: boolean, toServiceJourney?: { id: string } }, pointsOnLink?: { points?: string, length?: number }, intermediateEstimatedCalls: Array<{ date: any, quay: { name: string, id: string } }>, authority?: AuthorityFragment, serviceJourneyEstimatedCalls: Array<{ actualDepartureTime?: any, realtime: boolean, aimedDepartureTime: any, expectedDepartureTime: any, predictionInaccurate: boolean, quay: { name: string } }>, bookingArrangements?: BookingArrangementFragment, datedServiceJourney?: { id: string, estimatedCalls: Array<{ actualDepartureTime?: any, predictionInaccurate: boolean, quay: { name: string } }> } }> };
+    ), fromEstimatedCall?: { aimedDepartureTime: any, expectedDepartureTime: any, stopPositionInPattern: number, cancellation: boolean, destinationDisplay?: { frontText?: string, via?: Array<string> }, quay: { publicCode?: string, name: string }, notices: Array<NoticeFragment> }, toEstimatedCall?: { stopPositionInPattern: number, cancellation: boolean, notices: Array<NoticeFragment> }, situations: Array<SituationFragment>, fromPlace: { name?: string, longitude: number, latitude: number, quay?: { id: string, publicCode?: string, name: string, longitude?: number, latitude?: number, description?: string, stopPlace?: { id: string, longitude?: number, latitude?: number, name: string }, situations: Array<SituationFragment>, tariffZones: Array<TariffZoneFragment> } }, toPlace: { name?: string, longitude: number, latitude: number, quay?: { id: string, publicCode?: string, name: string, longitude?: number, latitude?: number, description?: string, stopPlace?: { id: string, longitude?: number, latitude?: number, name: string }, situations: Array<SituationFragment>, tariffZones: Array<TariffZoneFragment> } }, serviceJourney?: { id: string, notices: Array<NoticeFragment>, journeyPattern?: { notices: Array<NoticeFragment> } }, interchangeTo?: { guaranteed?: boolean, maximumWaitTime?: number, staySeated?: boolean, toServiceJourney?: { id: string } }, pointsOnLink?: { points?: string, length?: number }, intermediateEstimatedCalls: Array<{ date: any, quay: { name: string, id: string } }>, authority?: AuthorityFragment, serviceJourneyEstimatedCalls: Array<{ actualDepartureTime?: any, realtime: boolean, aimedDepartureTime: any, expectedDepartureTime: any, predictionInaccurate: boolean, cancellation: boolean, quay: { name: string } }>, bookingArrangements?: BookingArrangementFragment, datedServiceJourney?: { id: string, estimatedCalls: Array<{ actualDepartureTime?: any, predictionInaccurate: boolean, quay: { name: string } }> } }> };
 
 export const TripPatternFragmentDoc = gql`
     fragment tripPattern on TripPattern {
@@ -56,12 +56,14 @@ export const TripPatternFragmentDoc = gql`
         ...notice
       }
       stopPositionInPattern
+      cancellation
     }
     toEstimatedCall {
       notices {
         ...notice
       }
       stopPositionInPattern
+      cancellation
     }
     situations {
       ...situation
@@ -159,6 +161,7 @@ export const TripPatternFragmentDoc = gql`
         name
       }
       predictionInaccurate
+      cancellation
     }
     bookingArrangements {
       ...bookingArrangement


### PR DESCRIPTION
related to https://github.com/AtB-AS/kundevendt/issues/22806

expose `cancellation` param, also used in TPW here: https://github.com/AtB-AS/planner-web/blob/main/src/page-modules/assistant/journey-gql/trip-with-details.gql