### PR TITLE
feat: add actualDepartureTime to departures

### DIFF
--- a/src/graphql/journey/journeyplanner-types_v3.ts
+++ b/src/graphql/journey/journeyplanner-types_v3.ts
@@ -1461,6 +1461,8 @@ export type RoutingError = {
 export enum RoutingErrorCode {
   /** The specified location is not close to any streets or transit stops */
   LocationNotFound = 'locationNotFound',
+  /** No usable itineraries were found for the requested direct mode and no transit was included in the search */
+  NoDirectModeConnection = 'noDirectModeConnection',
   /** No stops are reachable from the location specified. You can try searching using a different access or egress mode */
   NoStopsInRange = 'noStopsInRange',
   /** No transit connection was found between the origin and destination withing the operating day or the next day */

--- a/src/service/impl/departures-grouped/journey-gql/departure-group.graphql
+++ b/src/service/impl/departures-grouped/journey-gql/departure-group.graphql
@@ -59,6 +59,7 @@ fragment group_times_estimatedCallFields on EstimatedCall {
   }
   date
   expectedDepartureTime
+  actualDepartureTime
   aimedDepartureTime
   predictionInaccurate
   realtime

--- a/src/service/impl/departures-grouped/journey-gql/departure-group.graphql-gen.ts
+++ b/src/service/impl/departures-grouped/journey-gql/departure-group.graphql-gen.ts
@@ -35,7 +35,7 @@ export type QuayIdInStopsQuery = { stopPlaces: Array<{ id: string, quays?: Array
 
 export type Group_EstimatedCallFieldsFragment = { stopPositionInPattern: number, destinationDisplay?: { frontText?: string, via?: Array<string> }, notices: Array<NoticeFragment>, serviceJourney: Group_ServiceJourneyFieldsFragment };
 
-export type Group_Times_EstimatedCallFieldsFragment = { date: any, expectedDepartureTime: any, aimedDepartureTime: any, predictionInaccurate: boolean, realtime: boolean, cancellation: boolean, stopPositionInPattern: number, destinationDisplay?: { frontText?: string, via?: Array<string> }, notices: Array<NoticeFragment>, situations: Array<SituationFragment>, serviceJourney: { id: string, line: { id: string } }, bookingArrangements?: BookingArrangementFragment };
+export type Group_Times_EstimatedCallFieldsFragment = { date: any, expectedDepartureTime: any, actualDepartureTime?: any, aimedDepartureTime: any, predictionInaccurate: boolean, realtime: boolean, cancellation: boolean, stopPositionInPattern: number, destinationDisplay?: { frontText?: string, via?: Array<string> }, notices: Array<NoticeFragment>, situations: Array<SituationFragment>, serviceJourney: { id: string, line: { id: string } }, bookingArrangements?: BookingArrangementFragment };
 
 export type Group_NoticeFieldsFragment = { text?: string };
 
@@ -98,6 +98,7 @@ export const Group_Times_EstimatedCallFieldsFragmentDoc = gql`
   }
   date
   expectedDepartureTime
+  actualDepartureTime
   aimedDepartureTime
   predictionInaccurate
   realtime

--- a/src/service/impl/departures-grouped/utils/__tests__/__snapshots__/grouping.test.ts.snap
+++ b/src/service/impl/departures-grouped/utils/__tests__/__snapshots__/grouping.test.ts.snap
@@ -30,6 +30,7 @@ exports[`service stops -> departure group utils snapshot - should group data fro
           {
             "departures": [
               {
+                "actualTime": undefined,
                 "aimedTime": undefined,
                 "bookingArrangements": undefined,
                 "cancellation": undefined,
@@ -43,6 +44,7 @@ exports[`service stops -> departure group utils snapshot - should group data fro
                 "time": undefined,
               },
               {
+                "actualTime": undefined,
                 "aimedTime": undefined,
                 "bookingArrangements": undefined,
                 "cancellation": undefined,
@@ -56,6 +58,7 @@ exports[`service stops -> departure group utils snapshot - should group data fro
                 "time": undefined,
               },
               {
+                "actualTime": undefined,
                 "aimedTime": undefined,
                 "bookingArrangements": undefined,
                 "cancellation": undefined,
@@ -69,6 +72,7 @@ exports[`service stops -> departure group utils snapshot - should group data fro
                 "time": undefined,
               },
               {
+                "actualTime": undefined,
                 "aimedTime": undefined,
                 "bookingArrangements": undefined,
                 "cancellation": undefined,
@@ -82,6 +86,7 @@ exports[`service stops -> departure group utils snapshot - should group data fro
                 "time": undefined,
               },
               {
+                "actualTime": undefined,
                 "aimedTime": undefined,
                 "bookingArrangements": undefined,
                 "cancellation": undefined,
@@ -172,6 +177,7 @@ exports[`service stops -> departure group utils snapshot - should group data fro
           {
             "departures": [
               {
+                "actualTime": undefined,
                 "aimedTime": undefined,
                 "bookingArrangements": undefined,
                 "cancellation": undefined,
@@ -185,6 +191,7 @@ exports[`service stops -> departure group utils snapshot - should group data fro
                 "time": undefined,
               },
               {
+                "actualTime": undefined,
                 "aimedTime": undefined,
                 "bookingArrangements": undefined,
                 "cancellation": undefined,
@@ -198,6 +205,7 @@ exports[`service stops -> departure group utils snapshot - should group data fro
                 "time": undefined,
               },
               {
+                "actualTime": undefined,
                 "aimedTime": undefined,
                 "bookingArrangements": undefined,
                 "cancellation": undefined,
@@ -211,6 +219,7 @@ exports[`service stops -> departure group utils snapshot - should group data fro
                 "time": undefined,
               },
               {
+                "actualTime": undefined,
                 "aimedTime": undefined,
                 "bookingArrangements": undefined,
                 "cancellation": undefined,
@@ -224,6 +233,7 @@ exports[`service stops -> departure group utils snapshot - should group data fro
                 "time": undefined,
               },
               {
+                "actualTime": undefined,
                 "aimedTime": undefined,
                 "bookingArrangements": undefined,
                 "cancellation": undefined,

--- a/src/service/impl/departures-grouped/utils/grouping.ts
+++ b/src/service/impl/departures-grouped/utils/grouping.ts
@@ -51,6 +51,7 @@ type DepartureLineInfo = {
 type DepartureTime = {
   time: string;
   aimedTime: string;
+  actualTime?: string;
   realtime?: boolean;
   predictionInaccurate?: boolean;
   situations: Situation[];
@@ -162,6 +163,7 @@ export default function mapQueryToGroups(
             return {
               time: time.expectedDepartureTime,
               aimedTime: time.aimedDepartureTime,
+              actualTime: time.actualDepartureTime,
               predictionInaccurate: time.predictionInaccurate,
               realtime: time.realtime,
               situations: time.situations,

--- a/src/service/impl/departures/journey-gql/departures.graphql
+++ b/src/service/impl/departures/journey-gql/departures.graphql
@@ -22,6 +22,7 @@ query departures(
       date
       expectedDepartureTime
       aimedDepartureTime
+      actualDepartureTime
       realtime
       predictionInaccurate
       cancellation

--- a/src/service/impl/departures/journey-gql/departures.graphql-gen.ts
+++ b/src/service/impl/departures/journey-gql/departures.graphql-gen.ts
@@ -20,7 +20,7 @@ export type DeparturesQueryVariables = Types.Exact<{
 }>;
 
 
-export type DeparturesQuery = { quays: Array<{ id: string, description?: string, publicCode?: string, name: string, estimatedCalls: Array<{ date: any, expectedDepartureTime: any, aimedDepartureTime: any, realtime: boolean, predictionInaccurate: boolean, cancellation: boolean, stopPositionInPattern: number, quay: { id: string }, destinationDisplay?: { frontText?: string, via?: Array<string> }, serviceJourney: { id: string, transportMode?: Types.TransportMode, transportSubmode?: Types.TransportSubmode, line: (
+export type DeparturesQuery = { quays: Array<{ id: string, description?: string, publicCode?: string, name: string, estimatedCalls: Array<{ date: any, expectedDepartureTime: any, aimedDepartureTime: any, actualDepartureTime?: any, realtime: boolean, predictionInaccurate: boolean, cancellation: boolean, stopPositionInPattern: number, quay: { id: string }, destinationDisplay?: { frontText?: string, via?: Array<string> }, serviceJourney: { id: string, transportMode?: Types.TransportMode, transportSubmode?: Types.TransportSubmode, line: (
           { description?: string }
           & LineFragment
         ), journeyPattern?: { notices: Array<NoticeFragment> }, notices: Array<NoticeFragment> }, situations: Array<SituationFragment>, notices: Array<NoticeFragment>, bookingArrangements?: BookingArrangementFragment }>, situations: Array<SituationFragment> }> };
@@ -44,6 +44,7 @@ export const DeparturesDocument = gql`
       date
       expectedDepartureTime
       aimedDepartureTime
+      actualDepartureTime
       realtime
       predictionInaccurate
       cancellation

--- a/src/service/impl/realtime/departure-time.ts
+++ b/src/service/impl/realtime/departure-time.ts
@@ -36,6 +36,7 @@ function mapDeparture(input: EstimatedCallFragment[]) {
         realtime: departure.realtime ?? false,
         expectedDepartureTime: departure.expectedDepartureTime,
         aimedDepartureTime: departure.aimedDepartureTime,
+        actualDepartureTime: departure.actualDepartureTime,
       },
     };
   }

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -125,6 +125,7 @@ export type RealtimeData = {
     realtime: boolean;
     expectedDepartureTime: string;
     aimedDepartureTime: string;
+    actualDepartureTime?: string;
   };
 };
 


### PR DESCRIPTION
Want to improve how we handle passed departures by removing any departures that has a actualDepartureTime. This adds that field for the departures, departure favorites and realtime endpoints.