### PR TITLE
feat: Added situations to leg.from/toEstimatedCall

### DIFF
--- a/src/service/impl/fragments/journey-gql/trips.graphql
+++ b/src/service/impl/fragments/journey-gql/trips.graphql
@@ -44,12 +44,18 @@ fragment tripPattern on TripPattern {
             notices {
                 ...notice
             }
+            situations {
+                ...situation
+            }
             stopPositionInPattern
             cancellation
         }
         toEstimatedCall {
             notices {
                 ...notice
+            }
+            situations {
+                ...situation
             }
             stopPositionInPattern
             cancellation

--- a/src/service/impl/fragments/journey-gql/trips.graphql-gen.ts
+++ b/src/service/impl/fragments/journey-gql/trips.graphql-gen.ts
@@ -19,7 +19,7 @@ export type TripFragment = { nextPageCursor?: string, previousPageCursor?: strin
 export type TripPatternFragment = { expectedStartTime: any, expectedEndTime: any, duration?: any, walkDistance?: number, legs: Array<{ id?: string, mode: Types.Mode, distance: number, duration: any, aimedStartTime: any, aimedEndTime: any, expectedEndTime: any, expectedStartTime: any, realtime: boolean, transportSubmode?: Types.TransportSubmode, rentedBike?: boolean, line?: (
       { name?: string }
       & LineFragment
-    ), fromEstimatedCall?: { aimedDepartureTime: any, expectedDepartureTime: any, stopPositionInPattern: number, cancellation: boolean, destinationDisplay?: { frontText?: string, via?: Array<string> }, quay: { publicCode?: string, name: string }, notices: Array<NoticeFragment> }, toEstimatedCall?: { stopPositionInPattern: number, cancellation: boolean, notices: Array<NoticeFragment> }, situations: Array<SituationFragment>, fromPlace: { name?: string, longitude: number, latitude: number, quay?: { id: string, publicCode?: string, name: string, longitude?: number, latitude?: number, description?: string, stopPlace?: { id: string, longitude?: number, latitude?: number, name: string }, situations: Array<SituationFragment>, tariffZones: Array<TariffZoneFragment> } }, toPlace: { name?: string, longitude: number, latitude: number, quay?: { id: string, publicCode?: string, name: string, longitude?: number, latitude?: number, description?: string, stopPlace?: { id: string, longitude?: number, latitude?: number, name: string }, situations: Array<SituationFragment>, tariffZones: Array<TariffZoneFragment> } }, serviceJourney?: { id: string, notices: Array<NoticeFragment>, journeyPattern?: { notices: Array<NoticeFragment> } }, interchangeTo?: { guaranteed?: boolean, maximumWaitTime?: number, staySeated?: boolean, toServiceJourney?: { id: string } }, pointsOnLink?: { points?: string, length?: number }, intermediateEstimatedCalls: Array<{ date: any, quay: { name: string, id: string } }>, authority?: AuthorityFragment, serviceJourneyEstimatedCalls: Array<{ actualDepartureTime?: any, realtime: boolean, aimedDepartureTime: any, expectedDepartureTime: any, predictionInaccurate: boolean, cancellation: boolean, quay: { name: string } }>, bookingArrangements?: BookingArrangementFragment, datedServiceJourney?: { id: string, estimatedCalls: Array<{ actualDepartureTime?: any, predictionInaccurate: boolean, quay: { name: string } }> } }> };
+    ), fromEstimatedCall?: { aimedDepartureTime: any, expectedDepartureTime: any, stopPositionInPattern: number, cancellation: boolean, destinationDisplay?: { frontText?: string, via?: Array<string> }, quay: { publicCode?: string, name: string }, notices: Array<NoticeFragment>, situations: Array<SituationFragment> }, toEstimatedCall?: { stopPositionInPattern: number, cancellation: boolean, notices: Array<NoticeFragment>, situations: Array<SituationFragment> }, situations: Array<SituationFragment>, fromPlace: { name?: string, longitude: number, latitude: number, quay?: { id: string, publicCode?: string, name: string, longitude?: number, latitude?: number, description?: string, stopPlace?: { id: string, longitude?: number, latitude?: number, name: string }, situations: Array<SituationFragment>, tariffZones: Array<TariffZoneFragment> } }, toPlace: { name?: string, longitude: number, latitude: number, quay?: { id: string, publicCode?: string, name: string, longitude?: number, latitude?: number, description?: string, stopPlace?: { id: string, longitude?: number, latitude?: number, name: string }, situations: Array<SituationFragment>, tariffZones: Array<TariffZoneFragment> } }, serviceJourney?: { id: string, notices: Array<NoticeFragment>, journeyPattern?: { notices: Array<NoticeFragment> } }, interchangeTo?: { guaranteed?: boolean, maximumWaitTime?: number, staySeated?: boolean, toServiceJourney?: { id: string } }, pointsOnLink?: { points?: string, length?: number }, intermediateEstimatedCalls: Array<{ date: any, quay: { name: string, id: string } }>, authority?: AuthorityFragment, serviceJourneyEstimatedCalls: Array<{ actualDepartureTime?: any, realtime: boolean, aimedDepartureTime: any, expectedDepartureTime: any, predictionInaccurate: boolean, cancellation: boolean, quay: { name: string } }>, bookingArrangements?: BookingArrangementFragment, datedServiceJourney?: { id: string, estimatedCalls: Array<{ actualDepartureTime?: any, predictionInaccurate: boolean, quay: { name: string } }> } }> };
 
 export const TripPatternFragmentDoc = gql`
     fragment tripPattern on TripPattern {
@@ -55,12 +55,18 @@ export const TripPatternFragmentDoc = gql`
       notices {
         ...notice
       }
+      situations {
+        ...situation
+      }
       stopPositionInPattern
       cancellation
     }
     toEstimatedCall {
       notices {
         ...notice
+      }
+      situations {
+        ...situation
       }
       stopPositionInPattern
       cancellation


### PR DESCRIPTION
A step towards solving https://github.com/AtB-AS/kundevendt/issues/23714

Adds `.situations` to `fromEstimatedCall` and `toEstimatedCall`, since those are filtered to only surface relevant situations for a leg. This is similar to already existing `leg.situations`, and `from/toEstimatedCall.notices`. 

This means we can stop accessing `leg.from/toPlace.quay.situations`, which might not contain relevant information for a given trip/leg (especially when it has a `ValidityPeriod`). 