### PR TITLE
feat: fetch realtime updates for departures slightly in the past

### DIFF
--- a/src/service/impl/realtime/__tests__/sanitize-realtime-query.test.ts
+++ b/src/service/impl/realtime/__tests__/sanitize-realtime-query.test.ts
@@ -9,37 +9,40 @@ const createQuery = (startTime: Date): DepartureRealtimeQuery => ({
 });
 
 describe('sanitizeRealtimeQuery', () => {
-  it('When start time is now the sanitized start time should be unchanged and time range should be 30 minutes', () => {
+  it('When start time is now the sanitized start time should be 3 minutes in the past and time range should be 30+3 minutes', () => {
     const startTime = new Date();
     const sanitized = sanitizeRealtimeQuery(createQuery(startTime));
 
     expect(sanitized?.timeRange).toBeDefined();
     expect(
-      diff(sanitized!.startTime.getTime(), startTime.getTime()),
+      diff(sanitized!.startTime.getTime(), addMinutes(startTime, -3).getTime()),
     ).toBeLessThan(5);
-    expect(diff(sanitized!.timeRange, 1800)).toBeLessThanOrEqual(1);
+    expect(diff(sanitized!.timeRange, 33 * 60)).toBeLessThanOrEqual(1);
   });
 
-  it('When start time is in the past the sanitized start time should be now and time range should be 30 minutes', () => {
+  it('When start time is in the past the sanitized start time should be 3 minutes in the past and time range should be 30+3 minutes', () => {
     const startTime = addHours(new Date(), -2);
     const sanitized = sanitizeRealtimeQuery(createQuery(startTime));
 
     expect(sanitized?.timeRange).toBeDefined();
     expect(
-      diff(sanitized!.startTime.getTime(), new Date().getTime()),
+      diff(
+        sanitized!.startTime.getTime(),
+        addMinutes(new Date(), -3).getTime(),
+      ),
     ).toBeLessThan(5);
-    expect(diff(sanitized!.timeRange, 1800)).toBeLessThanOrEqual(1);
+    expect(diff(sanitized!.timeRange, 33 * 60)).toBeLessThanOrEqual(1);
   });
 
-  it('When start time is 15 minutes in the future the sanitized start time should be unchanged and time range should be 15 minutes', () => {
+  it('When start time is 15 minutes in the future the sanitized start time should be 15-3 minutes in the future and time range should be 15+3 minutes', () => {
     const startTime = addMinutes(new Date(), 15);
     const sanitized = sanitizeRealtimeQuery(createQuery(startTime));
 
     expect(sanitized?.timeRange).toBeDefined();
     expect(
-      diff(sanitized!.startTime.getTime(), startTime.getTime()),
+      diff(sanitized!.startTime.getTime(), addMinutes(startTime, -3).getTime()),
     ).toBeLessThan(5);
-    expect(diff(sanitized!.timeRange, 900)).toBeLessThanOrEqual(1);
+    expect(diff(sanitized!.timeRange, 18 * 60)).toBeLessThanOrEqual(1);
   });
 
   it('When start time is 45 minutes in the future the sanitized query should be undefined', () => {

--- a/src/service/impl/realtime/sanitize-realtime-query.ts
+++ b/src/service/impl/realtime/sanitize-realtime-query.ts
@@ -1,29 +1,32 @@
 import type {DepartureRealtimeQuery} from '../../types';
 import type {GetDepartureRealtimeQueryVariables} from './journey-gql/departure-time.graphql-gen';
-import {addMinutes, differenceInSeconds, isAfter} from 'date-fns';
+import {addSeconds, differenceInSeconds, isAfter} from 'date-fns';
 
-const REALTIME_MINUTES = 30;
+const END_PADDING_SECONDS = 30 * 60;
+const START_PADDING_SECONDS = 3 * 60;
 
 /**
  * Sanitize the input query to get the correct time range for the realtime
- * updates, since we should only fetch updates which are between now and 30
- * minutes in the feature.
+ * updates, since we should only fetch updates which are max END_PADDING_SECONDS
+ * in the future and have just passed (max START_PADDING_SECONDS in the past)
  *
- * Undefined is returned if the input start time is more than 30 minutes in the
- * future, which signals that no realtime updates should be fetched.
+ * Undefined is returned if the input start time is far in the future, which
+ * signals that no realtime updates should be fetched.
  */
 export const sanitizeRealtimeQuery = (
   query: DepartureRealtimeQuery,
 ): GetDepartureRealtimeQueryVariables | undefined => {
   const now = new Date();
   const startTime = isAfter(query.startTime, now) ? query.startTime : now;
-  const realtimeWindowEnd = addMinutes(now, REALTIME_MINUTES);
-  const timeRange = differenceInSeconds(realtimeWindowEnd, startTime);
 
+  const realtimeWindowEnd = addSeconds(now, END_PADDING_SECONDS);
+  const realtimeWindowStart = addSeconds(startTime, -START_PADDING_SECONDS);
+
+  const timeRange = differenceInSeconds(realtimeWindowEnd, realtimeWindowStart);
   if (timeRange <= 0) return undefined;
 
   const {lineIds, ...rest} = query;
   const filters = lineIds?.length ? [{select: [{lines: lineIds}]}] : undefined;
 
-  return {...rest, startTime, timeRange, filters};
+  return {...rest, startTime: realtimeWindowStart, timeRange, filters};
 };


### PR DESCRIPTION
To be able to filter out departures that have an actualDepartureTime, we need to include departures that have just passed their stop. This is achieved by always including realtime departures 3 minutes before the requested start time.

Related to https://github.com/AtB-AS/mittatb-app/pull/5986