### PR TITLE
feat: Added calculation of aimedTimes for trips endpoint

### DIFF
--- a/src/service/impl/trips/index.ts
+++ b/src/service/impl/trips/index.ts
@@ -262,11 +262,20 @@ function mapTripsData(
     ...results,
     trip: {
       ...results.trip,
-      tripPatterns: results.trip.tripPatterns.map((pattern) => ({
-        ...pattern,
-        compressedQuery: generateSingleTripQueryString(pattern, queryVariables),
-        legs: pattern.legs.map((leg) => ({...leg, refreshedAt: now})),
-      })),
+      tripPatterns: results.trip.tripPatterns.map((pattern) => {
+        const legs = pattern.legs.map((leg) => ({...leg, refreshedAt: now}));
+        const {aimedStartTime, aimedEndTime} = computeTripAimedStartEnd(legs);
+        return {
+          ...pattern,
+          aimedStartTime,
+          aimedEndTime,
+          compressedQuery: generateSingleTripQueryString(
+            pattern,
+            queryVariables,
+          ),
+          legs,
+        };
+      }),
     },
   };
 }


### PR DESCRIPTION
Entur does not return `aimedStart/EndTime` for a trip-pattern, only for transport legs (bus, boat etc). That means that if the first or last leg is a walk leg (where `aimed` is always equal to `expected`) we basicly have no way of implementing this view, which shows both `aimed` and `expected` times: 
<img width="755" height="234" alt="Skjermbilde 2026-05-05 kl  13 01 07" src="https://github.com/user-attachments/assets/0e144390-d2d3-4023-8579-46c7773afedd" />

This PR calculates `aimedStart/EndTime` for a whole trip-pattern by looking at the first / last transportLeg, and subtracting/Adding the duration of walk legs, where applicable. 

This is backwards compatible for older app versions, and re-uses the logic already implemented in [singleTrip v3](https://github.com/AtB-AS/atb-bff/pull/447/changes#diff-193ca0a3f13cd3c46854d6ff53a97fa5975feb1bee5f98c2e02ca643587fb4d8R227)



## Test input
- Check that the trips endpoint still works for older versions of the app
- Check that `aimedStart/EndTime` is calculated correctly