### PR TITLE
docs: remove node requirements from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,6 @@ docker run --rm -it -e PORT=8080 -p 8080:8080 -v $PWD:/app atb-bff:dev
 
 ### Starting locally
 
-#### Requirements
-
-- Node.js >=18
-
 Install node packages
 
 `npm install`


### PR DESCRIPTION
Noticed this just after I merged https://github.com/AtB-AS/atb-bff/pull/450 🙈 The required node version is in package.json, so won't try to keep the README updated.