### PR TITLE
feat: Add actual times for from/toEstimatedCall

### DIFF
--- a/src/service/impl/fragments/journey-gql/legs.graphql
+++ b/src/service/impl/fragments/journey-gql/legs.graphql
@@ -13,6 +13,7 @@ fragment leg on Leg {
         name
     }
     fromEstimatedCall {
+        actualDepartureTime
         aimedDepartureTime
         expectedDepartureTime
         destinationDisplay {
@@ -33,6 +34,7 @@ fragment leg on Leg {
         cancellation
     }
     toEstimatedCall {
+        actualArrivalTime
         notices {
             ...notice
         }

--- a/src/service/impl/fragments/journey-gql/legs.graphql-gen.ts
+++ b/src/service/impl/fragments/journey-gql/legs.graphql-gen.ts
@@ -17,7 +17,7 @@ import { BookingArrangementFragmentDoc } from './booking-arrangements.graphql-ge
 export type LegFragment = { id?: string, mode: Types.Mode, distance: number, duration: any, aimedStartTime: any, aimedEndTime: any, expectedEndTime: any, expectedStartTime: any, realtime: boolean, transportSubmode?: Types.TransportSubmode, rentedBike?: boolean, line?: (
     { name?: string }
     & LineFragment
-  ), fromEstimatedCall?: { aimedDepartureTime: any, expectedDepartureTime: any, stopPositionInPattern: number, cancellation: boolean, destinationDisplay?: { frontText?: string, via?: Array<string> }, quay: { publicCode?: string, name: string }, notices: Array<NoticeFragment>, situations: Array<SituationFragment> }, toEstimatedCall?: { stopPositionInPattern: number, cancellation: boolean, notices: Array<NoticeFragment>, situations: Array<SituationFragment> }, situations: Array<SituationFragment>, fromPlace: { name?: string, longitude: number, latitude: number, quay?: { id: string, publicCode?: string, name: string, longitude?: number, latitude?: number, description?: string, stopPlace?: { id: string, longitude?: number, latitude?: number, name: string }, situations: Array<SituationFragment>, tariffZones: Array<TariffZoneFragment> } }, toPlace: { name?: string, longitude: number, latitude: number, quay?: { id: string, publicCode?: string, name: string, longitude?: number, latitude?: number, description?: string, stopPlace?: { id: string, longitude?: number, latitude?: number, name: string }, situations: Array<SituationFragment>, tariffZones: Array<TariffZoneFragment> } }, serviceJourney?: { id: string, notices: Array<NoticeFragment>, journeyPattern?: { notices: Array<NoticeFragment> } }, interchangeTo?: { guaranteed?: boolean, maximumWaitTime?: number, staySeated?: boolean, toServiceJourney?: { id: string } }, pointsOnLink?: { points?: string, length?: number }, intermediateEstimatedCalls: Array<{ date: any, quay: { name: string, id: string } }>, authority?: AuthorityFragment, serviceJourneyEstimatedCalls: Array<{ actualDepartureTime?: any, realtime: boolean, aimedDepartureTime: any, expectedDepartureTime: any, predictionInaccurate: boolean, cancellation: boolean, quay: { name: string } }>, bookingArrangements?: BookingArrangementFragment, datedServiceJourney?: { id: string, estimatedCalls: Array<{ actualDepartureTime?: any, predictionInaccurate: boolean, quay: { name: string } }> } };
+  ), fromEstimatedCall?: { actualDepartureTime?: any, aimedDepartureTime: any, expectedDepartureTime: any, stopPositionInPattern: number, cancellation: boolean, destinationDisplay?: { frontText?: string, via?: Array<string> }, quay: { publicCode?: string, name: string }, notices: Array<NoticeFragment>, situations: Array<SituationFragment> }, toEstimatedCall?: { actualArrivalTime?: any, stopPositionInPattern: number, cancellation: boolean, notices: Array<NoticeFragment>, situations: Array<SituationFragment> }, situations: Array<SituationFragment>, fromPlace: { name?: string, longitude: number, latitude: number, quay?: { id: string, publicCode?: string, name: string, longitude?: number, latitude?: number, description?: string, stopPlace?: { id: string, longitude?: number, latitude?: number, name: string }, situations: Array<SituationFragment>, tariffZones: Array<TariffZoneFragment> } }, toPlace: { name?: string, longitude: number, latitude: number, quay?: { id: string, publicCode?: string, name: string, longitude?: number, latitude?: number, description?: string, stopPlace?: { id: string, longitude?: number, latitude?: number, name: string }, situations: Array<SituationFragment>, tariffZones: Array<TariffZoneFragment> } }, serviceJourney?: { id: string, notices: Array<NoticeFragment>, journeyPattern?: { notices: Array<NoticeFragment> } }, interchangeTo?: { guaranteed?: boolean, maximumWaitTime?: number, staySeated?: boolean, toServiceJourney?: { id: string } }, pointsOnLink?: { points?: string, length?: number }, intermediateEstimatedCalls: Array<{ date: any, quay: { name: string, id: string } }>, authority?: AuthorityFragment, serviceJourneyEstimatedCalls: Array<{ actualDepartureTime?: any, realtime: boolean, aimedDepartureTime: any, expectedDepartureTime: any, predictionInaccurate: boolean, cancellation: boolean, quay: { name: string } }>, bookingArrangements?: BookingArrangementFragment, datedServiceJourney?: { id: string, estimatedCalls: Array<{ actualDepartureTime?: any, predictionInaccurate: boolean, quay: { name: string } }> } };
 
 export const LegFragmentDoc = gql`
     fragment leg on Leg {
@@ -35,6 +35,7 @@ export const LegFragmentDoc = gql`
     name
   }
   fromEstimatedCall {
+    actualDepartureTime
     aimedDepartureTime
     expectedDepartureTime
     destinationDisplay {
@@ -55,6 +56,7 @@ export const LegFragmentDoc = gql`
     cancellation
   }
   toEstimatedCall {
+    actualArrivalTime
     notices {
       ...notice
     }


### PR DESCRIPTION
Related to https://github.com/AtB-AS/kundevendt/issues/23634

Needed to improve the `started` and `ended` status displays for trips. 