### PR TITLE
fix: Added formatISO for correct handling of timezone

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Oslo';
+
 module.exports = {
   roots: ['<rootDir>/src'],
   testMatch: [

--- a/src/service/impl/trips/__tests__/utils.test.ts
+++ b/src/service/impl/trips/__tests__/utils.test.ts
@@ -135,25 +135,25 @@ describe('computeTripAimedStartEnd', () => {
   it('derives aimed start from first transit leg when first leg is foot', () => {
     const footLeg = makeFootLeg({duration: 300});
     const transitLeg = makeTransitLeg({
-      aimedStartTime: '2024-01-01T10:00:00.000Z',
-      aimedEndTime: '2024-01-01T10:10:00.000Z',
+      aimedStartTime: '2024-01-01T11:00:00+01:00',
+      aimedEndTime: '2024-01-01T11:10:00+01:00',
     });
     const result = computeTripAimedStartEnd([footLeg, transitLeg]);
-    // 10:00 - 300 seconds = 09:55
-    expect(result.aimedStartTime).toBe('2024-01-01T09:55:00.000Z');
-    expect(result.aimedEndTime).toBe('2024-01-01T10:10:00.000Z');
+    // 11:00+01:00 - 300 seconds = 10:55+01:00
+    expect(result.aimedStartTime).toBe('2024-01-01T10:55:00+01:00');
+    expect(result.aimedEndTime).toBe('2024-01-01T11:10:00+01:00');
   });
 
   it('derives aimed end from last transit leg when last leg is foot', () => {
     const transitLeg = makeTransitLeg({
-      aimedStartTime: '2024-01-01T10:00:00.000Z',
-      aimedEndTime: '2024-01-01T10:10:00.000Z',
+      aimedStartTime: '2024-01-01T11:00:00+01:00',
+      aimedEndTime: '2024-01-01T11:10:00+01:00',
     });
     const footLeg = makeFootLeg({duration: 300});
     const result = computeTripAimedStartEnd([transitLeg, footLeg]);
-    expect(result.aimedStartTime).toBe('2024-01-01T10:00:00.000Z');
-    // 10:10 + 300 seconds = 10:15
-    expect(result.aimedEndTime).toBe('2024-01-01T10:15:00.000Z');
+    expect(result.aimedStartTime).toBe('2024-01-01T11:00:00+01:00');
+    // 11:10+01:00 + 300 seconds = 11:15+01:00
+    expect(result.aimedEndTime).toBe('2024-01-01T11:15:00+01:00');
   });
 
   it('returns empty strings when legs array is empty', () => {

--- a/src/service/impl/trips/utils.ts
+++ b/src/service/impl/trips/utils.ts
@@ -9,7 +9,7 @@ import {
   compressToEncodedURIComponent,
   decompressFromEncodedURIComponent,
 } from 'lz-string';
-import {addSeconds, parseISO} from 'date-fns';
+import {addSeconds, formatISO, parseISO} from 'date-fns';
 
 const START_TIME_PADDING = 60; // time in seconds
 
@@ -151,10 +151,9 @@ export function computeTripAimedStartEnd(legs: Leg[]): {
         const durationBefore = legs
           .slice(0, firstTransitIndex)
           .reduce((acc, leg) => acc + leg.duration, 0);
-        aimedStartTime = addSeconds(
-          parseISO(firstTransit.aimedStartTime),
-          -durationBefore,
-        ).toISOString();
+        aimedStartTime = formatISO(
+          addSeconds(parseISO(firstTransit.aimedStartTime), -durationBefore),
+        );
       }
     }
 
@@ -166,10 +165,9 @@ export function computeTripAimedStartEnd(legs: Leg[]): {
         const durationAfter = reversedLegs
           .slice(0, lastTransitIndex)
           .reduce((acc, leg) => acc + leg.duration, 0);
-        aimedEndTime = addSeconds(
-          parseISO(lastTransit.aimedEndTime),
-          durationAfter,
-        ).toISOString();
+        aimedEndTime = formatISO(
+          addSeconds(parseISO(lastTransit.aimedEndTime), durationAfter),
+        );
       }
     }
   }


### PR DESCRIPTION
Depends on this PR in [gcp-infra](https://github.com/AtB-AS/gcp-infra/pull/1200) before merge. UPDATE: is now merged

Fixes issue found by @tormoseng in https://github.com/AtB-AS/atb-bff/pull/449#issuecomment-4388141754

The previous calculateAimedTImes use `.toISOString()`, which produces UTC time, while timestamps from Entur are with TZ. This uses `formatISO` to include the timezone in the output string instead and keep a consistent format. 