### PR TITLE
fix: preserve interchangeTo for v3 refreshSingleTrip endpoint

### DIFF
--- a/src/service/impl/trips/index.ts
+++ b/src/service/impl/trips/index.ts
@@ -223,7 +223,14 @@ export default (): ITrips_v2 => {
 
             if (result.data.leg) {
               refreshed++;
-              return {...(result.data.leg as Leg), refreshedAt: now};
+              // Preserve interchangeTo from the original leg: it's a trip-level
+              // relationship that journey-planner does not populate when a leg
+              // is queried in isolation by id.
+              return {
+                ...(result.data.leg as Leg),
+                interchangeTo: leg.interchangeTo,
+                refreshedAt: now,
+              };
             }
           } catch {
             // Query failed — leg keeps its old refreshedAt


### PR DESCRIPTION
related to https://github.com/AtB-AS/mittatb-app/pull/6092

Correspondence/Interchange message has been weirdly missing once we switch to v3 refreshSingleTrip. This PR restores its functionality. 