### PR TITLE
feat: Add geocoder v3 endpoints

### DIFF
--- a/src/api/geocoder_v3/index.ts
+++ b/src/api/geocoder_v3/index.ts
@@ -1,0 +1,65 @@
+import Hapi, {ReqRefDefaults, Request} from '@hapi/hapi';
+import qs from 'querystring';
+
+import {IGeocoderService_v3} from '../../service/interface';
+import {getFeaturesV3Request, getFeaturesReverseV3Request} from './schema';
+import {FeaturesV3Query, ReverseFeaturesV3Query} from '../../service/types';
+import {
+  CACHE_TTL_MS_CLIENT,
+  CACHE_TTL_MS_SERVER_GEOCODER_FEATURES,
+  CACHE_TTL_MS_SERVER_GEOCODER_REVERSE,
+} from '../../config/env';
+import {getClientCache, getServerCache} from '../../utils/cache';
+
+export default (server: Hapi.Server) => (service: IGeocoderService_v3) => {
+  const getFeatures = async (q: FeaturesV3Query, h: Request<ReqRefDefaults>) =>
+    (await service.getFeatures(q, h)).unwrap();
+  const getFeaturesReverse = async (
+    q: ReverseFeaturesV3Query,
+    h: Request<ReqRefDefaults>,
+  ) => (await service.getFeaturesReverse(q, h)).unwrap();
+
+  server.method('feature_v3', getFeatures, {
+    generateKey: (q: FeaturesV3Query) => qs.stringify(q as any),
+    cache: getServerCache(CACHE_TTL_MS_SERVER_GEOCODER_FEATURES),
+  });
+  server.method('reverse_v3', getFeaturesReverse, {
+    generateKey: (q: ReverseFeaturesV3Query) => qs.stringify(q as any),
+    cache: getServerCache(CACHE_TTL_MS_SERVER_GEOCODER_REVERSE),
+  });
+
+  server.route({
+    method: 'GET',
+    path: '/bff/v2/geocoder/features',
+    options: {
+      description: 'Find features matching query',
+      tags: ['api', 'geocoder'],
+      validate: {
+        query: getFeaturesV3Request,
+      },
+      cache: getClientCache(CACHE_TTL_MS_CLIENT),
+    },
+    handler: async (request, h) => {
+      const query = request.query as unknown as FeaturesV3Query;
+      return server.methods.feature_v3(query, h.request);
+    },
+  });
+
+  server.route({
+    method: 'GET',
+    path: '/bff/v2/geocoder/reverse',
+    options: {
+      description:
+        'Find addresses, POIs and stop places near the given coordinates',
+      tags: ['api', 'geocoder'],
+      validate: {
+        query: getFeaturesReverseV3Request,
+      },
+      cache: getClientCache(CACHE_TTL_MS_CLIENT),
+    },
+    handler: async (request, h) => {
+      const query = request.query as unknown as ReverseFeaturesV3Query;
+      return server.methods.reverse_v3(query, h.request);
+    },
+  });
+};

--- a/src/api/geocoder_v3/schema.ts
+++ b/src/api/geocoder_v3/schema.ts
@@ -1,0 +1,35 @@
+import Joi from 'joi';
+import {FeaturesV3Query, ReverseFeaturesV3Query} from '../../service/types';
+
+const v3Layers = [
+  'stopPlace',
+  'address',
+  'street',
+  'groupOfStopPlaces',
+  'poi',
+  'place',
+] as const;
+
+export const getFeaturesV3Request = Joi.object<FeaturesV3Query>({
+  query: Joi.string().required(),
+  lon: Joi.number(),
+  lat: Joi.number(),
+  lang: Joi.string(),
+  layers: Joi.array()
+    .items(Joi.string().valid(...v3Layers))
+    .single(),
+  multimodal: Joi.string().valid('parent', 'child', 'all').default('child'),
+  fareZoneAuthorities: Joi.array().items(Joi.string()).single(),
+  limit: Joi.number(),
+}).and('lat', 'lon');
+
+export const getFeaturesReverseV3Request = Joi.object<ReverseFeaturesV3Query>({
+  lat: Joi.number().required(),
+  lon: Joi.number().required(),
+  radius: Joi.number(),
+  lang: Joi.string(),
+  layers: Joi.array()
+    .items(Joi.string().valid(...v3Layers))
+    .single(),
+  limit: Joi.number(),
+});

--- a/src/api/geocoder_v3/schema.ts
+++ b/src/api/geocoder_v3/schema.ts
@@ -1,14 +1,9 @@
 import Joi from 'joi';
-import {FeaturesV3Query, ReverseFeaturesV3Query} from '../../service/types';
-
-const v3Layers = [
-  'stopPlace',
-  'address',
-  'street',
-  'groupOfStopPlaces',
-  'poi',
-  'place',
-] as const;
+import {
+  FeaturesV3Query,
+  geocoderV3Layers,
+  ReverseFeaturesV3Query,
+} from '../../service/types';
 
 export const getFeaturesV3Request = Joi.object<FeaturesV3Query>({
   query: Joi.string().required(),
@@ -16,7 +11,7 @@ export const getFeaturesV3Request = Joi.object<FeaturesV3Query>({
   lat: Joi.number(),
   lang: Joi.string(),
   layers: Joi.array()
-    .items(Joi.string().valid(...v3Layers))
+    .items(Joi.string().valid(...geocoderV3Layers))
     .single(),
   multimodal: Joi.string().valid('parent', 'child', 'all').default('child'),
   fareZoneAuthorities: Joi.array().items(Joi.string()).single(),
@@ -29,7 +24,7 @@ export const getFeaturesReverseV3Request = Joi.object<ReverseFeaturesV3Query>({
   radius: Joi.number(),
   lang: Joi.string(),
   layers: Joi.array()
-    .items(Joi.string().valid(...v3Layers))
+    .items(Joi.string().valid(...geocoderV3Layers))
     .single(),
   limit: Joi.number(),
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import {Boom} from '@hapi/boom';
 import {createServer, initializePlugins} from './server';
 
 import geocoderService from './service/impl/geocoder';
+import geocoderV3Service from './service/impl/geocoder_v3';
 import departuresGroupedService from './service/impl/departures-grouped';
 import departuresService from './service/impl/departures';
 import realtimeService from './service/impl/realtime';
@@ -14,6 +15,7 @@ import vehiclesService from './service/impl/vehicles';
 import stopPlacesService from './service/impl/stop-places';
 
 import geocoderRoutes from './api/geocoder';
+import geocoderV3Routes from './api/geocoder_v3';
 import departuresGroupedRoutes from './api/departures-grouped';
 import realtimeRoutes from './api/realtime';
 import healthRoutes from './api/health';
@@ -52,6 +54,7 @@ process.on('unhandledRejection', (err) => {
     healthRoutes(server);
     departuresGroupedRoutes(server)(departuresGroupedService());
     geocoderRoutes(server)(geocoderService());
+    geocoderV3Routes(server)(geocoderV3Service());
     enrollmentRoutes(server)(enrollmentService());
     quayRoutes(server)(quayService());
     mobilityRoutes(server)(mobilityService());

--- a/src/service/impl/geocoder_v3.ts
+++ b/src/service/impl/geocoder_v3.ts
@@ -1,0 +1,101 @@
+import {Result} from '@badrap/result';
+import {FeatureCollection, Point} from 'geojson';
+import qs from 'qs';
+import {GeocoderV3Layer, LocationV3} from '../types';
+import {APIError} from '../../utils/api-error';
+import {get} from '../../utils/fetch-client';
+import {IGeocoderService_v3} from '../interface';
+
+interface AutocompleteV3Params {
+  q: string;
+  lang?: string;
+  limit?: number;
+  lat?: number;
+  lon?: number;
+  radius?: number;
+  weight?: number;
+  layers?: GeocoderV3Layer[];
+  multimodal?: 'parent' | 'child' | 'all';
+  fareZoneAuthorities?: string[];
+}
+
+interface ReverseV3Params {
+  lat: number;
+  lon: number;
+  radius?: number;
+  lang?: string;
+  limit?: number;
+  layers?: GeocoderV3Layer[];
+}
+
+const GEOCODER_V3_BASEURL = 'https://api.dev.entur.io';
+
+const FOCUS_WEIGHT = parseFloat(process.env.GEOCODER_V3_FOCUS_WEIGHT || '0.5');
+const RADIUS = parseInt(process.env.GEOCODER_V3_RADIUS || '50');
+
+export default (): IGeocoderService_v3 => {
+  return {
+    async getFeatures(params, request) {
+      try {
+        const focusParams =
+          params.lat !== undefined && params.lon !== undefined
+            ? {
+                lat: params.lat,
+                lon: params.lon,
+                radius: RADIUS,
+                weight: FOCUS_WEIGHT,
+              }
+            : {};
+        const autocompleteParams: AutocompleteV3Params = {
+          q: params.query,
+          lang: params.lang,
+          limit: params.limit,
+          layers: params.layers,
+          multimodal: params.multimodal,
+          fareZoneAuthorities: params.fareZoneAuthorities,
+          ...focusParams,
+        };
+        const queryString = qs.stringify(autocompleteParams, {
+          allowDots: true,
+          arrayFormat: 'comma',
+          skipNulls: true,
+        });
+        const result = await get<FeatureCollection<Point, LocationV3>>(
+          `/geocoder/v3/autocomplete?${queryString}`,
+          request,
+          {},
+          GEOCODER_V3_BASEURL,
+        );
+        return Result.ok(result.features);
+      } catch (error) {
+        return Result.err(new APIError(error));
+      }
+    },
+    async getFeaturesReverse({lat, lon, ...params}, request) {
+      try {
+        const reverseParams: ReverseV3Params = {
+          lat,
+          lon,
+          radius: params.radius,
+          lang: params.lang,
+          limit: params.limit,
+          layers: params.layers,
+        };
+        const queryString = qs.stringify(reverseParams, {
+          allowDots: true,
+          arrayFormat: 'comma',
+          skipNulls: true,
+        });
+        const result = await get<FeatureCollection<Point, LocationV3>>(
+          `/geocoder/v3/reverse?${queryString}`,
+          request,
+          {},
+          GEOCODER_V3_BASEURL,
+        );
+        return Result.ok(result.features);
+      } catch (error) {
+        return Result.err(new APIError(error));
+      }
+    },
+  };
+};

--- a/src/service/interface.ts
+++ b/src/service/interface.ts
@@ -43,6 +43,9 @@ import {
   DeparturesRealtimeData,
   DeparturesWithLineName,
   FeaturesQuery,
+  FeaturesV3Query,
+  LocationV3,
+  ReverseFeaturesV3Query,
   QuaysCoordinatesPayload,
   ReverseFeaturesQuery,
   ServiceJourneyMapInfoData,
@@ -88,6 +91,18 @@ export interface IGeocoderService {
     query: ReverseFeaturesQuery,
     request: Request<ReqRefDefaults>,
   ): Promise<Result<Feature<Point, Location>[], APIError>>;
+}
+
+export interface IGeocoderService_v3 {
+  getFeatures(
+    query: FeaturesV3Query,
+    request: Request<ReqRefDefaults>,
+  ): Promise<Result<Feature<Point, LocationV3>[], APIError>>;
+
+  getFeaturesReverse(
+    query: ReverseFeaturesV3Query,
+    request: Request<ReqRefDefaults>,
+  ): Promise<Result<Feature<Point, LocationV3>[], APIError>>;
 }
 
 export interface IServiceJourneyService_v2 {

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -79,6 +79,62 @@ export type ReverseFeaturesQuery = {
   layers?: Array<'address' | 'venue'>;
 };
 
+export type GeocoderV3Layer =
+  | 'stopPlace'
+  | 'address'
+  | 'street'
+  | 'groupOfStopPlaces'
+  | 'poi'
+  | 'place';
+
+export type FeaturesV3Query = {
+  query: string;
+  lat?: number;
+  lon?: number;
+  lang?: string;
+  layers?: GeocoderV3Layer[];
+  fareZoneAuthorities?: string[];
+  limit?: number;
+  multimodal?: 'parent' | 'child' | 'all';
+};
+
+export type ReverseFeaturesV3Query = {
+  lat: number;
+  lon: number;
+  radius?: number;
+  limit?: number;
+  lang?: string;
+  layers?: GeocoderV3Layer[];
+};
+
+export interface LocationV3 {
+  id: string;
+  name: {
+    default: string;
+    display: string;
+  };
+  layer: GeocoderV3Layer;
+  address?: {
+    street?: string;
+    housenumber?: string;
+    postalCode?: string;
+    locality?: string;
+    localityId?: string;
+    county?: string;
+    countyId?: string;
+    countryCode?: string;
+  };
+  transportModes?: Array<{
+    mode: string;
+    subMode?: string;
+  }>;
+  stopPlaceTypes?: string[];
+  categories?: string[];
+  fareZones?: string[];
+  source?: string;
+  distance?: number;
+}
+
 export type DepartureFavoritesPayload = {
   favorites: FavoriteDeparture[];
 };

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -79,13 +79,16 @@ export type ReverseFeaturesQuery = {
   layers?: Array<'address' | 'venue'>;
 };
 
-export type GeocoderV3Layer =
-  | 'stopPlace'
-  | 'address'
-  | 'street'
-  | 'groupOfStopPlaces'
-  | 'poi'
-  | 'place';
+export const geocoderV3Layers = [
+  'stopPlace',
+  'address',
+  'street',
+  'groupOfStopPlaces',
+  'poi',
+  'place',
+] as const;
+
+export type GeocoderV3Layer = (typeof geocoderV3Layers)[number];
 
 export type FeaturesV3Query = {
   query: string;


### PR DESCRIPTION
- Uses v2 endpoints in BFF even if Entur endpoints is v3, since that was the pattern when using JP3.
- The new geocoder endpoints are now hardcoded to Entur dev environment as they are not available in prod yet.

Doc for the new Entur geocoder v3 endpoint:
https://github.com/entur/geocoder/blob/main/proxy/docs/v3.md