### PR TITLE
fix: adjust v3 singletrip duration to match the old v2 duration

### DIFF
--- a/src/service/impl/trips/index.ts
+++ b/src/service/impl/trips/index.ts
@@ -260,7 +260,10 @@ export default (): ITrips_v2 => {
       const expectedEndTime =
         adjustedLegs[adjustedLegs.length - 1].expectedEndTime;
 
-      const duration = adjustedLegs.reduce((acc, leg) => acc + leg.duration, 0);
+      const duration =
+        (new Date(expectedEndTime).getTime() -
+          new Date(expectedStartTime).getTime()) /
+        1000;
       const walkDistance = adjustedLegs
         .filter((leg) => leg.mode === Mode.Foot)
         .reduce((acc, leg) => acc + leg.distance, 0);


### PR DESCRIPTION
ref: https://github.com/AtB-AS/kundevendt/issues/22871#issuecomment-4554441548

The trip duration currently doesn't match the trip start-end time, so this should fix it to make it work as the v2 endpoint.

Current state:
14:24 - 15:04 is 40 minute, not 36 minute

<img width="1179" height="2556" alt="Image" src="https://github.com/user-attachments/assets/b70a4b69-09da-45d6-8444-8d5d17ea6db6" />