### PR TITLE
feat: add interchangeFrom on trip pattern legs

### DIFF
--- a/src/service/impl/fragments/journey-gql/interchanges.graphql
+++ b/src/service/impl/fragments/journey-gql/interchanges.graphql
@@ -1,0 +1,19 @@
+fragment interchange on Interchange {
+    fromServiceJourney {
+        id
+        publicCode
+        line {
+            publicCode
+        }
+    }
+    toServiceJourney {
+        id
+        publicCode
+        line {
+            publicCode
+        }
+    }
+    guaranteed
+    maximumWaitTime
+    staySeated
+}

--- a/src/service/impl/fragments/journey-gql/interchanges.graphql-gen.ts
+++ b/src/service/impl/fragments/journey-gql/interchanges.graphql-gen.ts
@@ -1,0 +1,34 @@
+import * as Types from '../../../../graphql/journey/journeyplanner-types_v3';
+
+import { DocumentNode } from 'graphql';
+import gql from 'graphql-tag';
+export type InterchangeFragment = { guaranteed?: boolean, maximumWaitTime?: number, staySeated?: boolean, fromServiceJourney?: { id: string, publicCode?: string, line: { publicCode?: string } }, toServiceJourney?: { id: string, publicCode?: string, line: { publicCode?: string } } };
+
+export const InterchangeFragmentDoc = gql`
+    fragment interchange on Interchange {
+  fromServiceJourney {
+    id
+    publicCode
+    line {
+      publicCode
+    }
+  }
+  toServiceJourney {
+    id
+    publicCode
+    line {
+      publicCode
+    }
+  }
+  guaranteed
+  maximumWaitTime
+  staySeated
+}
+    `;
+export type Requester<C = {}> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R> | AsyncIterable<R>
+export function getSdk<C>(requester: Requester<C>) {
+  return {
+
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/src/service/impl/fragments/journey-gql/legs.graphql
+++ b/src/service/impl/fragments/journey-gql/legs.graphql
@@ -103,12 +103,10 @@ fragment leg on Leg {
         }
     }
     interchangeTo {
-        toServiceJourney {
-            id
-        }
-        guaranteed
-        maximumWaitTime
-        staySeated
+        ...interchange
+    }
+    interchangeFrom {
+        ...interchange
     }
     pointsOnLink {
         points

--- a/src/service/impl/fragments/journey-gql/legs.graphql-gen.ts
+++ b/src/service/impl/fragments/journey-gql/legs.graphql-gen.ts
@@ -6,6 +6,7 @@ import { NoticeFragment } from './notices.graphql-gen';
 import { SituationFragment } from './situations.graphql-gen';
 import { StopPlaceFragment } from './stop-places.graphql-gen';
 import { TariffZoneFragment } from './tariff-zones.graphql-gen';
+import { InterchangeFragment } from './interchanges.graphql-gen';
 import { BookingArrangementFragment } from './booking-arrangements.graphql-gen';
 import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
@@ -15,11 +16,12 @@ import { NoticeFragmentDoc } from './notices.graphql-gen';
 import { SituationFragmentDoc } from './situations.graphql-gen';
 import { StopPlaceFragmentDoc } from './stop-places.graphql-gen';
 import { TariffZoneFragmentDoc } from './tariff-zones.graphql-gen';
+import { InterchangeFragmentDoc } from './interchanges.graphql-gen';
 import { BookingArrangementFragmentDoc } from './booking-arrangements.graphql-gen';
 export type LegFragment = { id?: string, mode: Types.Mode, distance: number, duration: any, aimedStartTime: any, aimedEndTime: any, expectedEndTime: any, expectedStartTime: any, realtime: boolean, transportSubmode?: Types.TransportSubmode, rentedBike?: boolean, line?: (
     { name?: string }
     & LineFragment
-  ), fromEstimatedCall?: { actualDepartureTime?: any, aimedDepartureTime: any, expectedDepartureTime: any, stopPositionInPattern: number, cancellation: boolean, destinationDisplay?: { frontText?: string, via?: Array<string> }, quay: { publicCode?: string, name: string }, notices: Array<NoticeFragment>, situations: Array<SituationFragment> }, toEstimatedCall?: { actualArrivalTime?: any, stopPositionInPattern: number, cancellation: boolean, notices: Array<NoticeFragment>, situations: Array<SituationFragment> }, situations: Array<SituationFragment>, fromPlace: { name?: string, longitude: number, latitude: number, quay?: { id: string, publicCode?: string, name: string, longitude?: number, latitude?: number, description?: string, stopPlace?: StopPlaceFragment, situations: Array<SituationFragment>, tariffZones: Array<TariffZoneFragment> } }, toPlace: { name?: string, longitude: number, latitude: number, quay?: { id: string, publicCode?: string, name: string, longitude?: number, latitude?: number, description?: string, stopPlace?: StopPlaceFragment, situations: Array<SituationFragment>, tariffZones: Array<TariffZoneFragment> } }, serviceJourney?: { id: string, notices: Array<NoticeFragment>, journeyPattern?: { notices: Array<NoticeFragment> } }, interchangeTo?: { guaranteed?: boolean, maximumWaitTime?: number, staySeated?: boolean, toServiceJourney?: { id: string } }, pointsOnLink?: { points?: string, length?: number }, intermediateEstimatedCalls: Array<{ date: any, stopPositionInPattern: number, aimedDepartureTime: any, expectedDepartureTime: any, realtime: boolean, quay: { name: string, id: string, stopPlace?: StopPlaceFragment } }>, authority?: AuthorityFragment, serviceJourneyEstimatedCalls: Array<{ actualDepartureTime?: any, realtime: boolean, aimedDepartureTime: any, expectedDepartureTime: any, predictionInaccurate: boolean, cancellation: boolean, quay: { name: string } }>, bookingArrangements?: BookingArrangementFragment, datedServiceJourney?: { id: string, estimatedCalls: Array<{ actualDepartureTime?: any, predictionInaccurate: boolean, quay: { name: string } }> } };
+  ), fromEstimatedCall?: { actualDepartureTime?: any, aimedDepartureTime: any, expectedDepartureTime: any, stopPositionInPattern: number, cancellation: boolean, destinationDisplay?: { frontText?: string, via?: Array<string> }, quay: { publicCode?: string, name: string }, notices: Array<NoticeFragment>, situations: Array<SituationFragment> }, toEstimatedCall?: { actualArrivalTime?: any, stopPositionInPattern: number, cancellation: boolean, notices: Array<NoticeFragment>, situations: Array<SituationFragment> }, situations: Array<SituationFragment>, fromPlace: { name?: string, longitude: number, latitude: number, quay?: { id: string, publicCode?: string, name: string, longitude?: number, latitude?: number, description?: string, stopPlace?: StopPlaceFragment, situations: Array<SituationFragment>, tariffZones: Array<TariffZoneFragment> } }, toPlace: { name?: string, longitude: number, latitude: number, quay?: { id: string, publicCode?: string, name: string, longitude?: number, latitude?: number, description?: string, stopPlace?: StopPlaceFragment, situations: Array<SituationFragment>, tariffZones: Array<TariffZoneFragment> } }, serviceJourney?: { id: string, notices: Array<NoticeFragment>, journeyPattern?: { notices: Array<NoticeFragment> } }, interchangeTo?: InterchangeFragment, interchangeFrom?: InterchangeFragment, pointsOnLink?: { points?: string, length?: number }, intermediateEstimatedCalls: Array<{ date: any, stopPositionInPattern: number, aimedDepartureTime: any, expectedDepartureTime: any, realtime: boolean, quay: { name: string, id: string, stopPlace?: StopPlaceFragment } }>, authority?: AuthorityFragment, serviceJourneyEstimatedCalls: Array<{ actualDepartureTime?: any, realtime: boolean, aimedDepartureTime: any, expectedDepartureTime: any, predictionInaccurate: boolean, cancellation: boolean, quay: { name: string } }>, bookingArrangements?: BookingArrangementFragment, datedServiceJourney?: { id: string, estimatedCalls: Array<{ actualDepartureTime?: any, predictionInaccurate: boolean, quay: { name: string } }> } };
 
 export const LegFragmentDoc = gql`
     fragment leg on Leg {
@@ -127,12 +129,10 @@ export const LegFragmentDoc = gql`
     }
   }
   interchangeTo {
-    toServiceJourney {
-      id
-    }
-    guaranteed
-    maximumWaitTime
-    staySeated
+    ...interchange
+  }
+  interchangeFrom {
+    ...interchange
   }
   pointsOnLink {
     points
@@ -187,6 +187,7 @@ ${NoticeFragmentDoc}
 ${SituationFragmentDoc}
 ${StopPlaceFragmentDoc}
 ${TariffZoneFragmentDoc}
+${InterchangeFragmentDoc}
 ${AuthorityFragmentDoc}
 ${BookingArrangementFragmentDoc}`;
 export type Requester<C = {}> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R> | AsyncIterable<R>

--- a/src/service/impl/trips/index.ts
+++ b/src/service/impl/trips/index.ts
@@ -223,12 +223,13 @@ export default (): ITrips_v2 => {
 
             if (result.data.leg) {
               refreshed++;
-              // Preserve interchangeTo from the original leg: it's a trip-level
-              // relationship that journey-planner does not populate when a leg
-              // is queried in isolation by id.
+              // Preserve interchangeTo/interchangeFrom from the original leg:
+              // they're trip-level relationships that journey-planner does not
+              // populate when a leg is queried in isolation by id.
               return {
                 ...(result.data.leg as Leg),
                 interchangeTo: leg.interchangeTo,
+                interchangeFrom: leg.interchangeFrom,
                 refreshedAt: now,
               };
             }


### PR DESCRIPTION
Also expand the existing `interchangeTo` and the new `interchangeFrom`
to include both service journeys with publicCode and line.publicCode,
via a shared `interchange` fragment. Preserve `interchangeFrom` on
single-trip refresh, same as `interchangeTo`.
