### PR TITLE
fix: select http/https agent for fetchWithTimeout / graphQL calls

### DIFF
--- a/src/utils/fetch-client.ts
+++ b/src/utils/fetch-client.ts
@@ -16,16 +16,20 @@ const httpAgent = new HttpAgent({
   keepAlive: true,
 });
 
+const selectAgent = (parsedURL: URL) =>
+  parsedURL.protocol === 'http:' ? httpAgent : httpsAgent;
+
 export function fetchWithTimeout(
   input: URL | RequestInfo,
   init: RequestInit | undefined,
 ): Promise<Response> {
+  const initWithAgent: RequestInit = {agent: selectAgent, ...init};
   return new Promise((resolve, reject) => {
     const timer = setTimeout(
       () => reject(new Error('TIMEOUT')),
       REQUEST_TIMEOUT,
     );
-    fetch(input, init)
+    fetch(input, initWithAgent)
       .then(
         (response) => resolve(response),
         (error) => reject(error),


### PR DESCRIPTION
The BFF in staging gives the error 

> "Invalid response body while trying to fetch https://api.staging.entur.io/journey-planner/v3/graphql: Premature close", 

which could point to this oversight in the fetchWithTimeout util.

It still seems weird that this issue appeared now (after I merged the pnpm migration), so I don't quite understand the actual cause here. But this should be an improvement non the less.