### PR TITLE
feat: add affected stop places to situations

### DIFF
--- a/src/service/impl/departures/utils/favorites.ts
+++ b/src/service/impl/departures/utils/favorites.ts
@@ -1,10 +1,10 @@
-import {
-  DestinationDisplay,
-  EstimatedCall,
-} from '../../../../graphql/journey/journeyplanner-types_v3';
+import {DestinationDisplay} from '../../../../graphql/journey/journeyplanner-types_v3';
 import {FavoriteDeparture} from '../../../types';
 import {DeparturesQuery} from '../journey-gql/departures.graphql-gen';
 import {ensureViaFormat, mapToLegacyLineName} from './converters';
+
+type DeparturesEstimatedCall =
+  DeparturesQuery['quays'][number]['estimatedCalls'][number];
 
 export function filterFavoriteDepartures(
   result?: DeparturesQuery,
@@ -18,7 +18,7 @@ export function filterFavoriteDepartures(
    * provided, returns true. Ignores the StopPlace ID in favorites, and requires
    * a Quay ID.
    */
-  const isFavorite = (ec: EstimatedCall) =>
+  const isFavorite = (ec: DeparturesEstimatedCall) =>
     !favorites ||
     favorites.some(
       (f) =>
@@ -31,9 +31,7 @@ export function filterFavoriteDepartures(
     quays: quays.map((quay) => {
       return {
         ...quay,
-        estimatedCalls: quay.estimatedCalls.filter((estimatedCall) =>
-          isFavorite(estimatedCall as EstimatedCall),
-        ),
+        estimatedCalls: quay.estimatedCalls.filter(isFavorite),
       };
     }),
   };
@@ -41,7 +39,7 @@ export function filterFavoriteDepartures(
 
 function favoriteDepartureMatchesEstimatedCall(
   favoriteDeparture: FavoriteDeparture,
-  estimatedCall: EstimatedCall,
+  estimatedCall: DeparturesEstimatedCall,
 ) {
   return (
     estimatedCall.serviceJourney?.line.id === favoriteDeparture.lineId &&

--- a/src/service/impl/fragments/journey-gql/situations.graphql
+++ b/src/service/impl/fragments/journey-gql/situations.graphql
@@ -17,4 +17,31 @@ fragment situation on PtSituationElement {
   validityPeriod {
     ...validityPeriod
   }
+  affects {
+    __typename
+    ... on AffectedStopPlace {
+      stopPlace {
+        name
+      }
+      quay {
+        name
+      }
+    }
+    ... on AffectedStopPlaceOnServiceJourney {
+      stopPlace {
+        name
+      }
+      quay {
+        name
+      }
+    }
+    ... on AffectedStopPlaceOnLine {
+      stopPlace {
+        name
+      }
+      quay {
+        name
+      }
+    }
+  }
 }

--- a/src/service/impl/fragments/journey-gql/situations.graphql
+++ b/src/service/impl/fragments/journey-gql/situations.graphql
@@ -18,30 +18,34 @@ fragment situation on PtSituationElement {
     ...validityPeriod
   }
   affects {
-    __typename
-    ... on AffectedStopPlace {
-      stopPlace {
-        name
-      }
-      quay {
-        name
-      }
+    ...affects
+  }
+}
+
+fragment affects on Affects {
+  __typename
+  ... on AffectedStopPlace {
+    stopPlace {
+      name
     }
-    ... on AffectedStopPlaceOnServiceJourney {
-      stopPlace {
-        name
-      }
-      quay {
-        name
-      }
+    quay {
+      name
     }
-    ... on AffectedStopPlaceOnLine {
-      stopPlace {
-        name
-      }
-      quay {
-        name
-      }
+  }
+  ... on AffectedStopPlaceOnServiceJourney {
+    stopPlace {
+      name
+    }
+    quay {
+      name
+    }
+  }
+  ... on AffectedStopPlaceOnLine {
+    stopPlace {
+      name
+    }
+    quay {
+      name
     }
   }
 }

--- a/src/service/impl/fragments/journey-gql/situations.graphql-gen.ts
+++ b/src/service/impl/fragments/journey-gql/situations.graphql-gen.ts
@@ -4,7 +4,7 @@ import { MultilingualStringFragment, InfoLinkFragment, ValidityPeriodFragment } 
 import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
 import { MultilingualStringFragmentDoc, InfoLinkFragmentDoc, ValidityPeriodFragmentDoc } from './shared.graphql-gen';
-export type SituationFragment = { id: string, situationNumber?: string, reportType?: Types.ReportType, summary: Array<MultilingualStringFragment>, description: Array<MultilingualStringFragment>, advice: Array<MultilingualStringFragment>, infoLinks?: Array<InfoLinkFragment>, validityPeriod?: ValidityPeriodFragment };
+export type SituationFragment = { id: string, situationNumber?: string, reportType?: Types.ReportType, summary: Array<MultilingualStringFragment>, description: Array<MultilingualStringFragment>, advice: Array<MultilingualStringFragment>, infoLinks?: Array<InfoLinkFragment>, validityPeriod?: ValidityPeriodFragment, affects: Array<{ __typename: 'AffectedLine' } | { __typename: 'AffectedServiceJourney' } | { __typename: 'AffectedStopPlace', stopPlace?: { name: string }, quay?: { name: string } } | { __typename: 'AffectedStopPlaceOnLine', stopPlace?: { name: string }, quay?: { name: string } } | { __typename: 'AffectedStopPlaceOnServiceJourney', stopPlace?: { name: string }, quay?: { name: string } } | { __typename: 'AffectedUnknown' }> };
 
 export const SituationFragmentDoc = gql`
     fragment situation on PtSituationElement {
@@ -25,6 +25,33 @@ export const SituationFragmentDoc = gql`
   }
   validityPeriod {
     ...validityPeriod
+  }
+  affects {
+    __typename
+    ... on AffectedStopPlace {
+      stopPlace {
+        name
+      }
+      quay {
+        name
+      }
+    }
+    ... on AffectedStopPlaceOnServiceJourney {
+      stopPlace {
+        name
+      }
+      quay {
+        name
+      }
+    }
+    ... on AffectedStopPlaceOnLine {
+      stopPlace {
+        name
+      }
+      quay {
+        name
+      }
+    }
   }
 }
     ${MultilingualStringFragmentDoc}

--- a/src/service/impl/fragments/journey-gql/situations.graphql-gen.ts
+++ b/src/service/impl/fragments/journey-gql/situations.graphql-gen.ts
@@ -4,8 +4,51 @@ import { MultilingualStringFragment, InfoLinkFragment, ValidityPeriodFragment } 
 import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
 import { MultilingualStringFragmentDoc, InfoLinkFragmentDoc, ValidityPeriodFragmentDoc } from './shared.graphql-gen';
-export type SituationFragment = { id: string, situationNumber?: string, reportType?: Types.ReportType, summary: Array<MultilingualStringFragment>, description: Array<MultilingualStringFragment>, advice: Array<MultilingualStringFragment>, infoLinks?: Array<InfoLinkFragment>, validityPeriod?: ValidityPeriodFragment, affects: Array<{ __typename: 'AffectedLine' } | { __typename: 'AffectedServiceJourney' } | { __typename: 'AffectedStopPlace', stopPlace?: { name: string }, quay?: { name: string } } | { __typename: 'AffectedStopPlaceOnLine', stopPlace?: { name: string }, quay?: { name: string } } | { __typename: 'AffectedStopPlaceOnServiceJourney', stopPlace?: { name: string }, quay?: { name: string } } | { __typename: 'AffectedUnknown' }> };
+export type SituationFragment = { id: string, situationNumber?: string, reportType?: Types.ReportType, summary: Array<MultilingualStringFragment>, description: Array<MultilingualStringFragment>, advice: Array<MultilingualStringFragment>, infoLinks?: Array<InfoLinkFragment>, validityPeriod?: ValidityPeriodFragment, affects: Array<Affects_AffectedLine_Fragment | Affects_AffectedServiceJourney_Fragment | Affects_AffectedStopPlace_Fragment | Affects_AffectedStopPlaceOnLine_Fragment | Affects_AffectedStopPlaceOnServiceJourney_Fragment | Affects_AffectedUnknown_Fragment> };
 
+export type Affects_AffectedLine_Fragment = { __typename: 'AffectedLine' };
+
+export type Affects_AffectedServiceJourney_Fragment = { __typename: 'AffectedServiceJourney' };
+
+export type Affects_AffectedStopPlace_Fragment = { __typename: 'AffectedStopPlace', stopPlace?: { name: string }, quay?: { name: string } };
+
+export type Affects_AffectedStopPlaceOnLine_Fragment = { __typename: 'AffectedStopPlaceOnLine', stopPlace?: { name: string }, quay?: { name: string } };
+
+export type Affects_AffectedStopPlaceOnServiceJourney_Fragment = { __typename: 'AffectedStopPlaceOnServiceJourney', stopPlace?: { name: string }, quay?: { name: string } };
+
+export type Affects_AffectedUnknown_Fragment = { __typename: 'AffectedUnknown' };
+
+export type AffectsFragment = Affects_AffectedLine_Fragment | Affects_AffectedServiceJourney_Fragment | Affects_AffectedStopPlace_Fragment | Affects_AffectedStopPlaceOnLine_Fragment | Affects_AffectedStopPlaceOnServiceJourney_Fragment | Affects_AffectedUnknown_Fragment;
+
+export const AffectsFragmentDoc = gql`
+    fragment affects on Affects {
+  __typename
+  ... on AffectedStopPlace {
+    stopPlace {
+      name
+    }
+    quay {
+      name
+    }
+  }
+  ... on AffectedStopPlaceOnServiceJourney {
+    stopPlace {
+      name
+    }
+    quay {
+      name
+    }
+  }
+  ... on AffectedStopPlaceOnLine {
+    stopPlace {
+      name
+    }
+    quay {
+      name
+    }
+  }
+}
+    `;
 export const SituationFragmentDoc = gql`
     fragment situation on PtSituationElement {
   id
@@ -27,36 +70,13 @@ export const SituationFragmentDoc = gql`
     ...validityPeriod
   }
   affects {
-    __typename
-    ... on AffectedStopPlace {
-      stopPlace {
-        name
-      }
-      quay {
-        name
-      }
-    }
-    ... on AffectedStopPlaceOnServiceJourney {
-      stopPlace {
-        name
-      }
-      quay {
-        name
-      }
-    }
-    ... on AffectedStopPlaceOnLine {
-      stopPlace {
-        name
-      }
-      quay {
-        name
-      }
-    }
+    ...affects
   }
 }
     ${MultilingualStringFragmentDoc}
 ${InfoLinkFragmentDoc}
-${ValidityPeriodFragmentDoc}`;
+${ValidityPeriodFragmentDoc}
+${AffectsFragmentDoc}`;
 export type Requester<C = {}> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R> | AsyncIterable<R>
 export function getSdk<C>(requester: Requester<C>) {
   return {


### PR DESCRIPTION
Extends the shared `situation` GraphQL fragment with `affects`, pulling
stopPlace/quay names so clients can list affected stops on situation
messages.

Also updates favorites.ts to type its helpers against the local
DeparturesQuery shape instead of casting to the upstream EstimatedCall,
since the new SituationFragment shape tipped the cast into a type error.
