### PR TITLE
build: pin docker image to node 22.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,20 @@
-FROM node:22-slim AS proddeps
+FROM node:22.22-slim AS proddeps
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci --omit dev
 
-FROM node:22-slim AS build
+FROM node:22.22-slim AS build
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 COPY . .
 RUN npm run build
 
-FROM node:22-slim as dev
+FROM node:22.22-slim as dev
 WORKDIR /app
 CMD ["npm", "run", "start:watch"]
 
-FROM node:22-slim as prod
+FROM node:22.22-slim as prod
 WORKDIR /app
 COPY package.json .
 COPY --from=proddeps /app/node_modules ./node_modules


### PR DESCRIPTION
GraphQL requests were failing after the latest changes, most likely due to the [node 22.23](https://nodejs.org/en/blog/release/v22.23.0) release interfering with Apollo. Pinning to 22.22 should fix it.

https://mittatb.slack.com/archives/C02EEG7D8EL/p1782115527946159