### PR TITLE
chore: remove geocoder v3 dev endpoint override

### DIFF
--- a/src/service/impl/geocoder_v3.ts
+++ b/src/service/impl/geocoder_v3.ts
@@ -28,8 +28,6 @@ interface ReverseV3Params {
   layers?: GeocoderV3Layer[];
 }
 
-const GEOCODER_V3_BASEURL = 'https://api.dev.entur.io';
-
 const FOCUS_WEIGHT = parseFloat(process.env.GEOCODER_V3_FOCUS_WEIGHT || '0.7');
 const RADIUS = parseInt(process.env.GEOCODER_V3_RADIUS || '60');
 
@@ -63,8 +61,6 @@ export default (): IGeocoderService_v3 => {
         const result = await get<FeatureCollection<Point, LocationV3>>(
           `/geocoder/v3/autocomplete?${queryString}`,
           request,
-          {},
-          GEOCODER_V3_BASEURL,
         );
         return Result.ok(result.features);
       } catch (error) {
@@ -89,8 +85,6 @@ export default (): IGeocoderService_v3 => {
         const result = await get<FeatureCollection<Point, LocationV3>>(
           `/geocoder/v3/reverse?${queryString}`,
           request,
-          {},
-          GEOCODER_V3_BASEURL,
         );
         return Result.ok(result.features);
       } catch (error) {


### PR DESCRIPTION
Entur has now released v3 in prod

### Acceptance criteria
- [ ] Geocoder v3 still works in app when toggled on